### PR TITLE
Fix syntax of YARD documentation for #build_configurations

### DIFF
--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -180,8 +180,8 @@ module Xcodeproj
       end
     end
 
-    # @return [PBXObjectList<XCBuildConfiguration]  A list of project wide
-    #                                               build configurations.
+    # @return [PBXObjectList<XCBuildConfiguration>]  A list of project wide
+    #                                                build configurations.
     def build_configurations
       root_object.build_configuration_list.build_configurations
     end


### PR DESCRIPTION
Noticed the syntax typo while reading the docs on

http://rdoc.info/github/CocoaPods/Xcodeproj/Xcodeproj/Project
