### PR TITLE
Set path attribute on XCVersionGroup when creating with #new_xcdatamodel_group

### DIFF
--- a/lib/xcodeproj/project/object/group.rb
+++ b/lib/xcodeproj/project/object/group.rb
@@ -105,9 +105,10 @@ module Xcodeproj
 
         attribute :version_group_type
         attribute :current_version
+        attribute :path
 
         def self.new_xcdatamodel_group(project, xcdatamodel_path)
-          group = new(project, nil, 'versionGroupType' => 'wrapper.xcdatamodel')
+          group = new(project, nil, 'path' => xcdatamodel_path, 'versionGroupType' => 'wrapper.xcdatamodel')
           file = group.files.new(
             'path' => xcdatamodel_path.sub(/xcdatamodeld$/, 'xcdatamodel'),
             'lastKnownFileType' => 'wrapper.xcdatamodel'

--- a/spec/project/object/group_spec.rb
+++ b/spec/project/object/group_spec.rb
@@ -121,6 +121,7 @@ module ProjectSpecs
       file = @project.files[version_group.current_version]
       version_group.files.should == [file]
       file.path.should == 'some/Model.xcdatamodel'
+      version_group.path.should == 'some/Model.xcdatamodeld'
     end
   end
 end


### PR DESCRIPTION
Messed up with path attribute in my last PR - XCVersionGroup should have path attribute itself too.

Related to issue #21.
