### PR TITLE
Add support for universal-darwin10.0 via st.h check.

### DIFF
--- a/ext/xcodeproj/extconf.rb
+++ b/ext/xcodeproj/extconf.rb
@@ -37,7 +37,7 @@ end
 have_header 'CoreFoundation/CoreFoundation.h'
 have_header 'CoreFoundation/CFStream.h'
 have_header 'CoreFoundation/CFPropertyList.h'
-have_header 'ruby/st.h'
+have_header 'ruby/st.h' or have_header 'st.h' or abort 'xcodeproj currently requires the (ruby/)st.h header'
 
 create_header
 create_makefile 'xcodeproj_ext'

--- a/ext/xcodeproj/xcodeproj_ext.c
+++ b/ext/xcodeproj/xcodeproj_ext.c
@@ -6,6 +6,8 @@
 #include "ruby.h"
 #if HAVE_RUBY_ST_H
 #include "ruby/st.h"
+#elif HAVE_ST_H
+#include "st.h"
 #endif
 
 #include "CoreFoundation/CoreFoundation.h"


### PR DESCRIPTION
As mentioned and demo'ed in a couple of reports, this is an issue installing cocoapods on older systems (CocoaPods/CocoaPods#257). The fallback to HAVE_ST_H is from the postgres ruby driver, the syck gem also has a similar check. There does seem to be some division over `#include <st.h>` and `#include "st.h"`, I went for the latter to prefer the ruby-specific version of the header.
