### PR TITLE
Change 'LastUpgradeCheck' for Xcode 4.5

### DIFF
--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -45,7 +45,7 @@ module Xcodeproj
         }
         main_group = groups.new
         self.root_object = objects.add(PBXProject, {
-          'attributes' => { 'LastUpgradeCheck' => '0420' },
+          'attributes' => { 'LastUpgradeCheck' => '0450' },
           'compatibilityVersion' => 'Xcode 3.2',
           'developmentRegion' => 'English',
           'hasScannedForEncodings' => '0',


### PR DESCRIPTION
Changes 'LastUpgradeCheck' from '0420' to '0450'. This suppresses the
upgrade warning in Xcode 4.5.
