### PR TITLE
Support .hh files as headers

### DIFF
--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -127,7 +127,7 @@ module Xcodeproj
 
             file = (files + new_files).find { |file| file.path == path.to_s } || @project.files.new('path' => path.to_s)
             build_file = file.build_files.new
-            if (path.extname == '.h' || path.extname == '.hpp')
+            if (path.extname == '.h' || path.extname == '.hpp' || path.extname == '.hh')
               build_file.settings = { 'ATTRIBUTES' => ["Public"] }
               # Working around a bug in Xcode 4.2 betas, remove this once the Xcode bug is fixed:
               # https://github.com/alloy/cocoapods/issues/13


### PR DESCRIPTION
We have a C++ library we are trying to use with CocoaPods, but it uses `.hh` for the header file extension instead of `.hpp` that Xcodeproj expects today. This simply adds the new header file extension to the conditional check.
