### PR TITLE
Add `to_s` method to Targets

### DIFF
--- a/lib/xcodeproj/project/object.rb
+++ b/lib/xcodeproj/project/object.rb
@@ -117,6 +117,8 @@ module Xcodeproj
           result || isa.gsub(/^(PBX|XC)/, '')
         end
 
+        alias :to_s :display_name
+
         # @!group Reference counting
 
         # @return [Array<ObjectList>] The list of the objects that have a

--- a/spec/project/object_spec.rb
+++ b/spec/project/object_spec.rb
@@ -10,6 +10,10 @@ module ProjectSpecs
         @object.name = 'AnObject'
       end
 
+      it "returns its name when converting to a string" do
+        @object.to_s.should == 'AnObject'
+      end
+
       it "returns its isa" do
         @object.isa.should == 'PBXFileReference'
       end


### PR DESCRIPTION
I didn't see a specific reason for this to not be implemented.
