### PR TITLE
Rename to_plist methods on AbstractObject and ObjectDictionary

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     xcodeproj (0.5.2)
-      activesupport (~> 3.2.6)
+      activesupport (~> 3.2.13)
       colored (~> 1.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.12)
-      i18n (~> 0.6)
+    activesupport (3.2.13)
+      i18n (= 0.6.1)
       multi_json (~> 1.0)
     bacon (1.2.0)
     colored (1.2)
@@ -21,7 +21,7 @@ GEM
       simplecov (>= 0.7)
       thor
     github-markup (0.7.5)
-    i18n (0.6.4)
+    i18n (0.6.1)
     kicker (2.6.1)
       listen
     listen (0.7.3)

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -186,12 +186,12 @@ module Xcodeproj
       end
     end
 
-    # @return [Hash] The plist representation of the project.
+    # @return [Hash] The hash representation of the project.
     #
     def to_hash
       plist = {}
       objects_dictionary = {}
-      objects.each { |obj| objects_dictionary[obj.uuid] = obj.to_plist }
+      objects.each { |obj| objects_dictionary[obj.uuid] = obj.to_hash }
       plist['objects']        =  objects_dictionary
       plist['archiveVersion'] =  archive_version.to_s
       plist['objectVersion']  =  object_version.to_s
@@ -199,8 +199,6 @@ module Xcodeproj
       plist['rootObject']     =  root_object.uuid
       plist
     end
-
-    alias :to_plist :to_hash
 
     # Converts the objects tree to a hash substituting the hash
     # of the referenced to their UUID reference. As a consequence the hash of
@@ -251,7 +249,7 @@ module Xcodeproj
     def save_as(projpath)
       projpath = projpath.to_s
       FileUtils.mkdir_p(projpath)
-      Xcodeproj.write_plist(to_plist, File.join(projpath, 'project.pbxproj'))
+      Xcodeproj.write_plist(to_hash, File.join(projpath, 'project.pbxproj'))
     end
 
     #-------------------------------------------------------------------------#

--- a/lib/xcodeproj/project/object.rb
+++ b/lib/xcodeproj/project/object.rb
@@ -286,11 +286,17 @@ module Xcodeproj
                 "Please file an issue: https://github.com/CocoaPods/Xcodeproj/issues/new"
         end
 
+        # Returns a cascade representation of the object with UUIDs.
+        #
+        # @return [Hash] a hash representation of the project.
+        #
+        # @visibility public
+        #
         # @note the key for simple and to_one attributes usually appears only
         #       if there is a value. To-many keys always appear with an empty
         #       array.
         #
-        def to_plist
+        def to_hash
           plist = {}
           plist['isa'] = isa
 
@@ -311,12 +317,11 @@ module Xcodeproj
 
           references_by_keys_attributes.each do |attrb|
             list = attrb.get_value(self)
-            plist[attrb.plist_name] = list.map { |dictionary| dictionary.to_plist }
+            plist[attrb.plist_name] = list.map { |dictionary| dictionary.to_hash }
           end
 
           plist
         end
-        alias :to_hash :to_plist
 
         # Returns a cascade representation of the object without UUIDs.
         #
@@ -378,7 +383,7 @@ module Xcodeproj
         # @!group Object methods
 
         def ==(other)
-          other.is_a?(AbstractObject) && self.to_plist == other.to_plist
+          other.is_a?(AbstractObject) && self.to_hash == other.to_hash
         end
 
         def <=>(other)

--- a/lib/xcodeproj/project/object_dictionary.rb
+++ b/lib/xcodeproj/project/object_dictionary.rb
@@ -108,7 +108,7 @@ module Xcodeproj
       #
       # @return [Hash<String => String>]
       #
-      def to_plist
+      def to_hash
         result = {}
         each { |key, obj| result[key] = obj.uuid }
         result

--- a/spec/project/object_dictionary_spec.rb
+++ b/spec/project/object_dictionary_spec.rb
@@ -21,7 +21,7 @@ module ProjectSpecs
     it "returns the plist representation of the dictionary" do
       project_ref_uuid = @dict['projectRef'].uuid
       product_group_uuid = @dict['productGroup'].uuid
-      @dict.to_plist.should == {
+      @dict.to_hash.should == {
         'projectRef' => project_ref_uuid,
         'productGroup' => product_group_uuid,
       }

--- a/spec/project/object_spec.rb
+++ b/spec/project/object_spec.rb
@@ -83,7 +83,7 @@ module ProjectSpecs
 
       it "merges the class name into the plist representation" do
         @object.isa.should == 'PBXFileReference'
-        @object.to_plist['isa'].should == 'PBXFileReference'
+        @object.to_hash['isa'].should == 'PBXFileReference'
       end
 
       it "sorts by UUID" do
@@ -173,7 +173,7 @@ module ProjectSpecs
       it "can serialize itself to a plist" do
         @object.name = 'AnObject'
         @object.source_tree = 'SOURCE_ROOT'
-        @object.to_plist.should == {
+        @object.to_hash.should == {
           "isa"            => "PBXFileReference",
           "name"           => "AnObject",
           "sourceTree"     => "SOURCE_ROOT",

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -107,7 +107,7 @@ module ProjectSpecs
       #
       it "can regenerate the EXACT plist that initialized it" do
         plist = Xcodeproj.read_plist(fixture_path("Sample Project/Cocoa Application.xcodeproj/project.pbxproj"))
-        generated = @project.to_plist
+        generated = @project.to_hash
         diff = Xcodeproj::Differ.diff(generated, plist)
         diff.should.be.nil
       end
@@ -120,7 +120,7 @@ module ProjectSpecs
         obj = @project.new_from_plist(uuid, objects_by_uuid_plist)
         attrb = PBXFileReference.simple_attributes.find { |a| a.name == :include_in_index }
         attrb.default_value.should == '1'
-        obj.to_plist.should == expected
+        obj.to_hash.should == expected
       end
 
       extend SpecHelper::TemporaryDirectory
@@ -156,7 +156,7 @@ module ProjectSpecs
           "sourceTree"     => "SOURCE_ROOT",
           "includeInIndex" => "1"
         }
-        obj.to_plist.should == expected
+        obj.to_hash.should == expected
       end
 
       it "generates new UUIDs" do


### PR DESCRIPTION
Since the to_plist methods don't actually create a plist you can write directly to a file, it should not be named as such. Fixes CocoaPods/cocoapods.github.com#11

**Note:** This breaks backwards compatibility with anyone using `to_plist` since the method has been removed all together. Not sure if there's a depreciation plan for this.
