### PR TITLE
Add includes when writing the xcconfig file

### DIFF
--- a/lib/xcodeproj/config.rb
+++ b/lib/xcodeproj/config.rb
@@ -67,7 +67,8 @@ module Xcodeproj
     # @return [String] The serialized internal data.
     #
     def to_s
-      to_hash.sort_by(&:first).map { |k, v| "#{k} = #{v}" }.join("\n")
+      [includes.map { |i| "#include \"#{i}\""} +
+       to_hash.sort_by(&:first).map { |k, v| "#{k} = #{v}" }].join("\n")
     end
 
     # Writes the serialized representation of the internal data to the given


### PR DESCRIPTION
This supports hierarchies of xcconfig files for using per spec targets in CocoaPods/CocoaPods#1011.
