### PR TITLE
Add optional name to replace OTHER_LDFLAGS in xcconfig hash

### DIFF
--- a/lib/xcodeproj/config.rb
+++ b/lib/xcodeproj/config.rb
@@ -109,8 +109,6 @@ module Xcodeproj
       
       hash.delete('OTHER_LDFLAGS')
       hash[@ldflags_output_namespace] = flags.strip unless flags.strip.empty?
-      hash['OTHER_LDFLAGS'] = "${#{@ldflags_output_namespace}}" unless @ldflags_output_namespace == 'OTHER_LDFLAGS'
-      
       hash
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -61,7 +61,7 @@ describe "Xcodeproj::Config" do
   
   it "namespaces the output linker flags" do
     config = Xcodeproj::Config.new(@hash, 'MY_LDFLAGS')
-    config.should == { 'MY_LDFLAGS' => '-framework Foundation' , 'OTHER_LDFLAGS' => '${MY_LDFLAGS}'}
+    config.should == { 'MY_LDFLAGS' => '-framework Foundation' }
   end
   
   it "does not include OTHER_LDFLAGS in the output hash when there are no linker flags specified" do
@@ -107,19 +107,13 @@ describe "Xcodeproj::Config" do
   it "merges two namespaced configs" do
     config = Xcodeproj::Config.new({'OTHER_LDFLAGS' => '-framework CFNetwork'}, 'MY_LDFLAGS')
     config << Xcodeproj::Config.new({'OTHER_LDFLAGS' => '-framework Security'}, 'MY_LDFLAGS')
-    config.to_hash['MY_LDFLAGS'].should == '-framework CFNetwork -framework Security'
+    config.should == {'MY_LDFLAGS' => '-framework CFNetwork -framework Security'}
   end
   
   it "merges a non-namespaced linker hash into an existing namespaced config" do
     config = Xcodeproj::Config.new({'OTHER_LDFLAGS' => '-framework CFNetwork'}, 'MY_LDFLAGS')
     config << {'OTHER_LDFLAGS' => '-framework Security'}
-    config.to_hash['MY_LDFLAGS'].should == '-framework CFNetwork -framework Security'
-  end
-  
-  it "merges a namespaced linker hash into an existing namespaced config" do
-    config = Xcodeproj::Config.new({'OTHER_LDFLAGS' => '-framework CFNetwork'}, 'MY_LDFLAGS')
-    config << {'MY_LDFLAGS' => '-framework Security'}
-    config.to_hash['MY_LDFLAGS'].should == '-framework CFNetwork -framework Security'
+    config.should == {'MY_LDFLAGS' => '-framework CFNetwork -framework Security'}
   end
 
   it "appends a value for the same key when merging" do


### PR DESCRIPTION
I've been working on fully integrating cocoapods into my project set up. Since I also use xcconfig files to manage my build settings, I'm wanting to get to the point where all variables in the **Pods.xcconfig** are namespaced.

In working towards a solution (https://github.com/CocoaPods/CocoaPods/pull/1016), it seems easier to provide this flexibility inside **xcodeproj** here, and then use that new optional functionality in cocoapods.

Here, I've added the ability to specify what you want the output linker flags to be instead of `OTHER_LDFLAGS`. It defaults to the same value as before, so all existing behaviour should be unchanged.

On the input side (from a hash or xcconfig file), it still expects `OTHER_LDFLAGS`. Only on the output `to_hash` does it use the optional name.
