### PR TITLE
Fix for undefined method `display_name' for nil:NilClass

### DIFF
--- a/lib/xcodeproj/project/object/build_file.rb
+++ b/lib/xcodeproj/project/object/build_file.rb
@@ -43,7 +43,7 @@ module Xcodeproj
         #         user.
         #
         def display_name
-          file_ref.display_name
+          file_ref.display_name unless file_ref.nil?
         end
 
         # @return [Hash{String => Hash}, String] A hash suitable to display the


### PR DESCRIPTION
On one large Xcode project I get an `undefined method display_name for nil:NilClass` error when running `xcodeproj show`.   This change prevents the error and show runs to completion.
