### PR TITLE
Close and release the CFWriteStream used to write projects when done

### DIFF
--- a/ext/xcodeproj/xcodeproj_ext.c
+++ b/ext/xcodeproj/xcodeproj_ext.c
@@ -256,10 +256,12 @@ write_plist(VALUE self, VALUE hash, VALUE path) {
     if (!success) {
       CFShow(errorString);
     }
+    CFWriteStreamClose(stream);
   } else {
     printf("Unable to open stream!\n");
   }
 
+  CFRelease(stream);
   CFRelease(dict);
   return success ? Qtrue : Qfalse;
 }


### PR DESCRIPTION
I was hitting a crash when generating thousands of projects at a time due to these file handles being leaked.
