### PR TITLE
Refactor XCScheme API to enable multiple targets

### DIFF
--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -13,152 +13,149 @@ module Xcodeproj
     #
     attr_reader :doc
 
-    # @return [String] the name of the container (the project name file without
-    #         the extension) that have the targets used by the scheme.
-    #
-    attr_reader :container
-
-    # @return [Xcodeproj::Project::Object::AbstractTarget] the target used by
-    #         scheme in the build step.
-    #
-    attr_reader :build_target
-
-    # @return [Xcodeproj::Project::Object::AbstractTarget] the target used by
-    #         scheme in the test step.
-    #
-    attr_reader :test_target
-
     # Create a new XCScheme instance
     #
-    # @param [String] container
-    #        The name of the container (the project name file without the extension) that have the targets used by the
-    #        scheme.
-    #
-    # @param [Xcodeproj::Project::Object::AbstractTarget] build_target
-    #        The target used by scheme in the build step.
-    #
-    # @param [Xcodeproj::Project::Object::AbstractTarget] test_target
-    #        The target used by scheme in the test step.
-    #
-    # @example
-    #   Xcodeproj::XCScheme.new 'Cocoa Application', project.targets[0], project.targets[1]
-    #
-    def initialize(container, build_target, test_target = nil)
-      @container = container
-      @build_target = build_target
-      @test_target = test_target
-
+    def initialize
       @doc = REXML::Document.new
       @doc << REXML::XMLDecl.new(REXML::XMLDecl::DEFAULT_VERSION, 'UTF-8')
       @doc.context[:attribute_quote] = :quote
 
-      scheme = @doc.add_element 'Scheme'
-      scheme.attributes['LastUpgradeVersion'] = Constants::LAST_UPGRADE_CHECK
-      scheme.attributes['version'] = '1.3'
+      @scheme = @doc.add_element 'Scheme'
+      @scheme.attributes['LastUpgradeVersion'] = Constants::LAST_UPGRADE_CHECK
+      @scheme.attributes['version'] = '1.3'
 
-      build_action = scheme.add_element 'BuildAction'
-      build_action.attributes['parallelizeBuildables'] = 'YES'
-      build_action.attributes['buildImplicitDependencies'] = 'YES'
+      @build_action = @scheme.add_element 'BuildAction'
+      @build_action.attributes['parallelizeBuildables'] = 'YES'
+      @build_action.attributes['buildImplicitDependencies'] = 'YES'
+      @build_action_entries = nil
 
-      if (build_target.product_type == 'com.apple.product-type.application') then
-        build_action_entries = build_action.add_element 'BuildActionEntries'
+      @test_action = @scheme.add_element 'TestAction'
+      @test_action.attributes['selectedDebuggerIdentifier'] = 'Xcode.DebuggerFoundation.Debugger.LLDB'
+      @test_action.attributes['selectedLauncherIdentifier'] = 'Xcode.DebuggerFoundation.Launcher.LLDB'
+      @test_action.attributes['shouldUseLaunchSchemeArgsEnv'] = 'YES'
+      @test_action.attributes['buildConfiguration'] = 'Debug'
 
-        build_action_entry = build_action_entries.add_element 'BuildActionEntry'
-        build_action_entry.attributes['buildForTesting'] = 'YES'
-        build_action_entry.attributes['buildForRunning'] = 'YES'
-        build_action_entry.attributes['buildForProfiling'] = 'YES'
-        build_action_entry.attributes['buildForArchiving'] = 'YES'
-        build_action_entry.attributes['buildForAnalyzing'] = 'YES'
+      @testables = @test_action.add_element 'Testables'
 
-        buildable_reference = build_action_entry.add_element 'BuildableReference'
-        buildable_reference.attributes['BuildableIdentifier'] = 'primary'
-        buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
-        buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
-        buildable_reference.attributes['BlueprintName'] = build_target.name
-        buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
-      end
+      @launch_action = @scheme.add_element 'LaunchAction'
+      @launch_action.attributes['selectedDebuggerIdentifier'] = 'Xcode.DebuggerFoundation.Debugger.LLDB'
+      @launch_action.attributes['selectedLauncherIdentifier'] = 'Xcode.DebuggerFoundation.Launcher.LLDB'
+      @launch_action.attributes['launchStyle'] = '0'
+      @launch_action.attributes['useCustomWorkingDirectory'] = 'NO'
+      @launch_action.attributes['buildConfiguration'] = 'Debug'
+      @launch_action.attributes['ignoresPersistentStateOnLaunch'] = 'NO'
+      @launch_action.attributes['debugDocumentVersioning'] = 'YES'
+      @launch_action.attributes['allowLocationSimulation'] = 'YES'
+      additional_options = @launch_action.add_element 'AdditionalOptions'
 
-      test_action = scheme.add_element 'TestAction'
-      test_action.attributes['selectedDebuggerIdentifier'] = 'Xcode.DebuggerFoundation.Debugger.LLDB'
-      test_action.attributes['selectedLauncherIdentifier'] = 'Xcode.DebuggerFoundation.Launcher.LLDB'
-      test_action.attributes['shouldUseLaunchSchemeArgsEnv'] = 'YES'
-      test_action.attributes['buildConfiguration'] = 'Debug'
+      @profile_action = @scheme.add_element 'ProfileAction'
+      @profile_action.attributes['shouldUseLaunchSchemeArgsEnv'] = 'YES'
+      @profile_action.attributes['savedToolIdentifier'] = ''
+      @profile_action.attributes['useCustomWorkingDirectory'] = 'NO'
+      @profile_action.attributes['buildConfiguration'] = 'Release'
+      @profile_action.attributes['debugDocumentVersioning'] = 'YES'
 
-      testables = test_action.add_element 'Testables'
-
-      if (test_target != nil) then
-        testable_reference = testables.add_element 'TestableReference'
-        testable_reference.attributes['skipped'] = 'NO'
-
-        buildable_reference = testable_reference.add_element 'BuildableReference'
-        buildable_reference.attributes['BuildableIdentifier'] = 'primary'
-        buildable_reference.attributes['BlueprintIdentifier'] = test_target.uuid
-        buildable_reference.attributes['BuildableName'] = "#{test_target.name}.octest"
-        buildable_reference.attributes['BlueprintName'] = test_target.name
-        buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
-
-        if (build_target.product_type == 'com.apple.product-type.application') then
-          macro_expansion = test_action.add_element 'MacroExpansion'
-
-          buildable_reference = macro_expansion.add_element 'BuildableReference'
-          buildable_reference.attributes['BuildableIdentifier'] = 'primary'
-          buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
-          buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
-          buildable_reference.attributes['BlueprintName'] = build_target.name
-          buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
-        end
-      end
-
-      launch_action = scheme.add_element 'LaunchAction'
-      launch_action.attributes['selectedDebuggerIdentifier'] = 'Xcode.DebuggerFoundation.Debugger.LLDB'
-      launch_action.attributes['selectedLauncherIdentifier'] = 'Xcode.DebuggerFoundation.Launcher.LLDB'
-      launch_action.attributes['launchStyle'] = '0'
-      launch_action.attributes['useCustomWorkingDirectory'] = 'NO'
-      launch_action.attributes['buildConfiguration'] = 'Debug'
-      launch_action.attributes['ignoresPersistentStateOnLaunch'] = 'NO'
-      launch_action.attributes['debugDocumentVersioning'] = 'YES'
-      launch_action.attributes['allowLocationSimulation'] = 'YES'
-
-      if (build_target.product_type == 'com.apple.product-type.application') then
-        buildable_product_runnable = launch_action.add_element 'BuildableProductRunnable'
-
-        buildable_reference = buildable_product_runnable.add_element 'BuildableReference'
-        buildable_reference.attributes['BuildableIdentifier'] = 'primary'
-        buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
-        buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
-        buildable_reference.attributes['BlueprintName'] = build_target.name
-        buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
-      end
-
-      additional_options = launch_action.add_element 'AdditionalOptions'
-
-      profile_action = scheme.add_element 'ProfileAction'
-      profile_action.attributes['shouldUseLaunchSchemeArgsEnv'] = 'YES'
-      profile_action.attributes['savedToolIdentifier'] = ''
-      profile_action.attributes['useCustomWorkingDirectory'] = 'NO'
-      profile_action.attributes['buildConfiguration'] = 'Release'
-      profile_action.attributes['debugDocumentVersioning'] = 'YES'
-
-      if (build_target.product_type == 'com.apple.product-type.application') then
-        buildable_product_runnable = profile_action.add_element 'BuildableProductRunnable'
-
-        buildable_reference = buildable_product_runnable.add_element 'BuildableReference'
-        buildable_reference.attributes['BuildableIdentifier'] = 'primary'
-        buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
-        buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
-        buildable_reference.attributes['BlueprintName'] = build_target.name
-        buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
-      end
-
-      analyze_action = scheme.add_element 'AnalyzeAction'
+      analyze_action = @scheme.add_element 'AnalyzeAction'
       analyze_action.attributes['buildConfiguration'] = 'Debug'
 
-      archive_action = scheme.add_element 'ArchiveAction'
+      archive_action = @scheme.add_element 'ArchiveAction'
       archive_action.attributes['buildConfiguration'] = 'Release'
       archive_action.attributes['revealArchiveInOrganizer'] = 'YES'
     end
 
     public
+
+    # @!group Target methods
+
+    # Add a target to the list of targets to build in the build action.
+    #
+    # @param [Xcodeproj::Project::Object::AbstractTarget] build_target
+    #        A target used by scheme in the build step.
+    #
+    # @param [String] container
+    #        The name of the container (the project name file without the extension) that has this target.
+    #
+    # @param [Bool] build_for_running
+    #        Whether to build this target in the launch action. Often false for test targets.
+    #
+    def add_build_target(build_target, container, build_for_running = true)
+      if !@build_action_entries then
+        @build_action_entries = @build_action.add_element 'BuildActionEntries'
+      end
+
+      build_action_entry = @build_action_entries.add_element 'BuildActionEntry'
+      build_action_entry.attributes['buildForTesting'] = 'YES'
+      build_action_entry.attributes['buildForRunning'] = build_for_running ? 'YES' : 'NO'
+      build_action_entry.attributes['buildForProfiling'] = 'YES'
+      build_action_entry.attributes['buildForArchiving'] = 'YES'
+      build_action_entry.attributes['buildForAnalyzing'] = 'YES'
+
+      buildable_reference = build_action_entry.add_element 'BuildableReference'
+      buildable_reference.attributes['BuildableIdentifier'] = 'primary'
+      buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
+      buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
+      buildable_reference.attributes['BlueprintName'] = build_target.name
+      buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
+    end
+
+    # Add a target to the list of targets to build in the build action.
+    #
+    # @param [Xcodeproj::Project::Object::AbstractTarget] test_target
+    #        A target used by scheme in the test step.
+    #
+    # @param [String] container
+    #        The name of the container (the project name file without the extension) that has this target.
+    #
+    def add_test_target(test_target, container)
+      testable_reference = @testables.add_element 'TestableReference'
+      testable_reference.attributes['skipped'] = 'NO'
+
+      buildable_reference = testable_reference.add_element 'BuildableReference'
+      buildable_reference.attributes['BuildableIdentifier'] = 'primary'
+      buildable_reference.attributes['BlueprintIdentifier'] = test_target.uuid
+      buildable_reference.attributes['BuildableName'] = "#{test_target.name}.octest"
+      buildable_reference.attributes['BlueprintName'] = test_target.name
+      buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
+    end
+
+    # Sets a runnable target target to be the target of the launch action of the scheme.
+    #
+    # @param [Xcodeproj::Project::Object::AbstractTarget] build_target
+    #        A target used by scheme in the launch step.
+    #
+    # @param [String] container
+    #        The name of the container (the project name file without the extension) that has this target.
+    #
+    def set_launch_target(build_target, container)
+      launch_product_runnable = @launch_action.add_element 'BuildableProductRunnable'
+
+      launch_buildable_reference = launch_product_runnable.add_element 'BuildableReference'
+      launch_buildable_reference.attributes['BuildableIdentifier'] = 'primary'
+      launch_buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
+      launch_buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
+      launch_buildable_reference.attributes['BlueprintName'] = build_target.name
+      launch_buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
+
+      profile_product_runnable = @profile_action.add_element 'BuildableProductRunnable'
+
+      profile_buildable_reference = profile_product_runnable.add_element 'BuildableReference'
+      profile_buildable_reference.attributes['BuildableIdentifier'] = 'primary'
+      profile_buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
+      profile_buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
+      profile_buildable_reference.attributes['BlueprintName'] = build_target.name
+      profile_buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
+
+      if build_target.product_type == 'com.apple.product-type.application' then
+        macro_expansion = @test_action.add_element 'MacroExpansion'
+
+        buildable_reference = macro_expansion.add_element 'BuildableReference'
+        buildable_reference.attributes['BuildableIdentifier'] = 'primary'
+        buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
+        buildable_reference.attributes['BuildableName'] = "#{build_target.name}.app"
+        buildable_reference.attributes['BlueprintName'] = build_target.name
+        buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
+      end
+    end
 
     # @!group Class methods
 
@@ -201,71 +198,6 @@ module Xcodeproj
 
     public
 
-    # @!group
-
-    #-------------------------------------------------------------------------#
-
-    # Returns the current value if the build target must be runned during the
-    # build step.
-    #
-    # @return [Boolean]
-    #         true  => run during the build step
-    #         false => not run during the build step
-    #
-    def build_target_for_running?
-      build_target_for_running = ''
-
-      if build_action = @doc.root.elements['BuildAction']
-        if build_action_entries = build_action.elements['BuildActionEntries']
-          if build_action_entry = build_action_entries.elements['BuildActionEntry']
-            build_target_for_running = build_action_entry.attributes['buildForRunning']
-          end
-        end
-      end
-
-      build_target_for_running == 'YES'
-    end
-
-    # Set the build target to run or not run during the build step. Useful for
-    # cases where the build target is a unit test bundle.
-    #
-    # @param [Boolean] build_target_for_running
-    #        true  => run during the build step
-    #        false => not run during the build step
-    #
-    def build_target_for_running=(build_target_for_running)
-      build_action = @doc.root.elements['BuildAction']
-
-      if (build_action.elements['BuildActionEntries'] == nil) then
-        build_action_entries = build_action.add_element('BuildActionEntries')
-      else
-        build_action_entries = build_action.elements['BuildActionEntries']
-      end
-
-      if (build_action_entries.elements['BuildActionEntry'] == nil) then
-        build_action_entry = build_action_entries.add_element 'BuildActionEntry'
-        build_action_entry.attributes['buildForTesting'] = 'YES'
-        build_action_entry.attributes['buildForProfiling'] = 'NO'
-        build_action_entry.attributes['buildForArchiving'] = 'NO'
-        build_action_entry.attributes['buildForAnalyzing'] = 'NO'
-      else
-        build_action_entry = build_action_entries.elements['BuildActionEntry']
-      end
-
-      build_action_entry.attributes['buildForRunning'] = build_target_for_running ? 'YES' : 'NO'
-
-      if (build_action_entry.elements['BuildableReference'] == nil) then
-        buildable_reference = build_action_entry.add_element 'BuildableReference'
-        buildable_reference.attributes['BuildableIdentifier'] = 'primary'
-        buildable_reference.attributes['BlueprintIdentifier'] = build_target.uuid
-        buildable_reference.attributes['BuildableName'] = "#{build_target.name}.octest"
-        buildable_reference.attributes['BlueprintName'] = build_target.name
-        buildable_reference.attributes['ReferencedContainer'] = "container:#{container}.xcodeproj"
-      end
-    end
-
-    public
-
     # @!group Serialization
 
     #-------------------------------------------------------------------------#
@@ -287,6 +219,9 @@ module Xcodeproj
     # @param [String, Pathname] project_path
     #        The path where the ".xcscheme" file should be stored.
     #
+    # @param [String] name
+    #        The name of the scheme, to have ".xcscheme" appended.
+    #
     # @param [Boolean] shared
     #        true  => if the scheme must be a shared scheme (default value)
     #        false => if the scheme must be a user scheme
@@ -296,14 +231,14 @@ module Xcodeproj
     # @example Saving a scheme
     #   scheme.save_as('path/to/Project.xcodeproj') #=> true
     #
-    def save_as(project_path, shared = true)
+    def save_as(project_path, name, shared = true)
       if shared
         scheme_folder_path = self.class.shared_data_dir(project_path)
       else
         scheme_folder_path = self.class.user_data_dir(project_path)
       end
       scheme_folder_path.mkpath
-      scheme_path = scheme_folder_path + "#{build_target.name}.xcscheme"
+      scheme_path = scheme_folder_path + "#{name}.xcscheme"
       File.open(scheme_path, 'w') do |f|
         f.write(to_s)
       end

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/project.pbxproj
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/project.pbxproj
@@ -23,6 +23,15 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		806F6FB717EFAF46001051EE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		806F6FBC17EFAF46001051EE /* iOS_staticLibrary.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 806F6FBB17EFAF46001051EE /* iOS_staticLibrary.h */; };
+		806F6FBE17EFAF46001051EE /* iOS_staticLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = 806F6FBD17EFAF46001051EE /* iOS_staticLibrary.m */; };
+		806F6FC517EFAF47001051EE /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 806F6FC417EFAF47001051EE /* XCTest.framework */; };
+		806F6FC617EFAF47001051EE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		806F6FC717EFAF47001051EE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523F616245AB20012E2BA /* UIKit.framework */; };
+		806F6FCA17EFAF47001051EE /* libiOS staticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */; };
+		806F6FD017EFAF47001051EE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 806F6FCE17EFAF47001051EE /* InfoPlist.strings */; };
+		806F6FD217EFAF47001051EE /* iOS_staticLibraryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */; };
 		E525239116245A900012E2BA /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
 		E525239B16245A900012E2BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E525239916245A900012E2BA /* InfoPlist.strings */; };
 		E525239D16245A900012E2BA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E525239C16245A900012E2BA /* main.m */; };
@@ -162,6 +171,20 @@
 			remoteGlobalIDString = E5FBB2E41635ED34009E96B0;
 			remoteInfo = ReferencedProject;
 		};
+		806F6FC817EFAF47001051EE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 806F6FB517EFAF46001051EE;
+			remoteInfo = "iOS staticLibrary";
+		};
+		806F6FDB17EFB0E7001051EE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E52523F316245AB20012E2BA;
+			remoteInfo = "iOS application";
+		};
 		E52523B716245A910012E2BA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = E525238316245A900012E2BA /* Project object */;
@@ -228,6 +251,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		806F6FB417EFAF46001051EE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				806F6FBC17EFAF46001051EE /* iOS_staticLibrary.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E525243E16245B1A0012E2BA /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -268,6 +301,15 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libiOS staticLibrary.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		806F6FBA17EFAF46001051EE /* iOS staticLibrary-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOS staticLibrary-Prefix.pch"; sourceTree = "<group>"; };
+		806F6FBB17EFAF46001051EE /* iOS_staticLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOS_staticLibrary.h; sourceTree = "<group>"; };
+		806F6FBD17EFAF46001051EE /* iOS_staticLibrary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOS_staticLibrary.m; sourceTree = "<group>"; };
+		806F6FC317EFAF47001051EE /* iOS staticLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS staticLibraryTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		806F6FC417EFAF47001051EE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		806F6FCD17EFAF47001051EE /* iOS staticLibraryTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "iOS staticLibraryTests-Info.plist"; sourceTree = "<group>"; };
+		806F6FCF17EFAF47001051EE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOS_staticLibraryTests.m; sourceTree = "<group>"; };
 		E525238C16245A900012E2BA /* Cocoa Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Cocoa Application.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E525239016245A900012E2BA /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		E525239316245A900012E2BA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
@@ -380,6 +422,25 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		806F6FB317EFAF46001051EE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FB717EFAF46001051EE /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		806F6FC017EFAF47001051EE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FCA17EFAF47001051EE /* libiOS staticLibrary.a in Frameworks */,
+				806F6FC517EFAF47001051EE /* XCTest.framework in Frameworks */,
+				806F6FC717EFAF47001051EE /* UIKit.framework in Frameworks */,
+				806F6FC617EFAF47001051EE /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E525238916245A900012E2BA /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -644,6 +705,42 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		806F6FB817EFAF46001051EE /* iOS staticLibrary */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FBB17EFAF46001051EE /* iOS_staticLibrary.h */,
+				806F6FBD17EFAF46001051EE /* iOS_staticLibrary.m */,
+				806F6FB917EFAF46001051EE /* Supporting Files */,
+			);
+			path = "iOS staticLibrary";
+			sourceTree = "<group>";
+		};
+		806F6FB917EFAF46001051EE /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FBA17EFAF46001051EE /* iOS staticLibrary-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		806F6FCB17EFAF47001051EE /* iOS staticLibraryTests */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */,
+				806F6FCC17EFAF47001051EE /* Supporting Files */,
+			);
+			path = "iOS staticLibraryTests";
+			sourceTree = "<group>";
+		};
+		806F6FCC17EFAF47001051EE /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FCD17EFAF47001051EE /* iOS staticLibraryTests-Info.plist */,
+				806F6FCE17EFAF47001051EE /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		E525238116245A900012E2BA = {
 			isa = PBXGroup;
 			children = (
@@ -668,6 +765,8 @@
 				E52523D216245A910012E2BA /* Cocoa ApplicationImporter */,
 				E52523FC16245AB20012E2BA /* iOS application */,
 				E525242616245AB20012E2BA /* iOS applicationTests */,
+				806F6FB817EFAF46001051EE /* iOS staticLibrary */,
+				806F6FCB17EFAF47001051EE /* iOS staticLibraryTests */,
 				E525238F16245A900012E2BA /* Frameworks */,
 				E525238D16245A900012E2BA /* Products */,
 				E525243B16245AE10012E2BA /* Linked Folder */,
@@ -708,6 +807,8 @@
 				E550D8A516371C0F00A003E9 /* CommandLineTool */,
 				E550D8B616371C1700A003E9 /* MacRubyApplication.app */,
 				E550D8D816371C1800A003E9 /* MacRubyApplicationImporter.mdimporter */,
+				806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */,
+				806F6FC317EFAF47001051EE /* iOS staticLibraryTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -734,6 +835,7 @@
 				E550D7F416371BA500A003E9 /* InstallerPlugins.framework */,
 				E550D81216371BAF00A003E9 /* Quartz.framework */,
 				E550D88816371C0600A003E9 /* AppleScriptObjC.framework */,
+				806F6FC417EFAF47001051EE /* XCTest.framework */,
 				E525239216245A900012E2BA /* Other Frameworks */,
 			);
 			name = Frameworks;
@@ -1031,6 +1133,42 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
+		806F6FB517EFAF46001051EE /* iOS staticLibrary */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 806F6FD917EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibrary" */;
+			buildPhases = (
+				806F6FB217EFAF46001051EE /* Sources */,
+				806F6FB317EFAF46001051EE /* Frameworks */,
+				806F6FB417EFAF46001051EE /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "iOS staticLibrary";
+			productName = "iOS staticLibrary";
+			productReference = 806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		806F6FC217EFAF47001051EE /* iOS staticLibraryTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 806F6FDA17EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibraryTests" */;
+			buildPhases = (
+				806F6FBF17EFAF47001051EE /* Sources */,
+				806F6FC017EFAF47001051EE /* Frameworks */,
+				806F6FC117EFAF47001051EE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				806F6FDC17EFB0E7001051EE /* PBXTargetDependency */,
+				806F6FC917EFAF47001051EE /* PBXTargetDependency */,
+			);
+			name = "iOS staticLibraryTests";
+			productName = "iOS staticLibraryTests";
+			productReference = 806F6FC317EFAF47001051EE /* iOS staticLibraryTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		E525238B16245A900012E2BA /* Cocoa Application */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = E52523E616245A910012E2BA /* Build configuration list for PBXNativeTarget "Cocoa Application" */;
@@ -1582,6 +1720,11 @@
 				CLASSPREFIX = CP;
 				LastUpgradeCheck = 0500;
 				ORGANIZATIONNAME = CocoaPods;
+				TargetAttributes = {
+					806F6FC217EFAF47001051EE = {
+						TestTargetID = E525238B16245A900012E2BA;
+					};
+				};
 			};
 			buildConfigurationList = E525238616245A900012E2BA /* Build configuration list for PBXProject "Cocoa Application" */;
 			compatibilityVersion = "Xcode 3.1";
@@ -1607,6 +1750,8 @@
 				E52523C516245A910012E2BA /* Cocoa ApplicationImporter */,
 				E52523F316245AB20012E2BA /* iOS application */,
 				E525241E16245AB20012E2BA /* iOS applicationTests */,
+				806F6FB517EFAF46001051EE /* iOS staticLibrary */,
+				806F6FC217EFAF47001051EE /* iOS staticLibraryTests */,
 				E550D6AA16371AF600A003E9 /* Aggregate */,
 				E550D6B016371B0600A003E9 /* External */,
 				E550D6B816371B1A00A003E9 /* UnitTestingBundle */,
@@ -1664,6 +1809,14 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
+		806F6FC117EFAF47001051EE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FD017EFAF47001051EE /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E525238A16245A900012E2BA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2027,6 +2180,22 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		806F6FB217EFAF46001051EE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FBE17EFAF46001051EE /* iOS_staticLibrary.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		806F6FBF17EFAF47001051EE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FD217EFAF47001051EE /* iOS_staticLibraryTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E525238816245A900012E2BA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2254,6 +2423,16 @@
 			name = ReferencedProject;
 			targetProxy = 5138059B16499F4C001D82AD /* PBXContainerItemProxy */;
 		};
+		806F6FC917EFAF47001051EE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 806F6FB517EFAF46001051EE /* iOS staticLibrary */;
+			targetProxy = 806F6FC817EFAF47001051EE /* PBXContainerItemProxy */;
+		};
+		806F6FDC17EFB0E7001051EE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E52523F316245AB20012E2BA /* iOS application */;
+			targetProxy = 806F6FDB17EFB0E7001051EE /* PBXContainerItemProxy */;
+		};
 		E52523B816245A910012E2BA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = E525238B16245A900012E2BA /* Cocoa Application */;
@@ -2287,6 +2466,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		806F6FCE17EFAF47001051EE /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				806F6FCF17EFAF47001051EE /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		E525239916245A900012E2BA /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -2371,6 +2558,130 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		806F6FD317EFAF47001051EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				DSTROOT = /tmp/iOS_staticLibrary.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		806F6FD417EFAF47001051EE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				DSTROOT = /tmp/iOS_staticLibrary.dst;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		806F6FD517EFAF47001051EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/iOS application.app/iOS application";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "iOS staticLibraryTests/iOS staticLibraryTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		806F6FD617EFAF47001051EE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/iOS application.app/iOS application";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "iOS staticLibraryTests/iOS staticLibraryTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				VALIDATE_PRODUCT = YES;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
 		E52523E116245A910012E2BA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3307,6 +3618,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		806F6FD917EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibrary" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				806F6FD317EFAF47001051EE /* Debug */,
+				806F6FD417EFAF47001051EE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		806F6FDA17EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibraryTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				806F6FD517EFAF47001051EE /* Debug */,
+				806F6FD617EFAF47001051EE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		E525238616245A900012E2BA /* Build configuration list for PBXProject "Cocoa Application" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E52523F316245AB20012E2BA"
+               BuildableName = "iOS application.app"
+               BlueprintName = "iOS application"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "806F6FB517EFAF46001051EE"
+               BuildableName = "libiOS staticLibrary.a"
+               BlueprintName = "iOS staticLibrary"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "806F6FC217EFAF47001051EE"
+               BuildableName = "iOS staticLibraryTests.xctest"
+               BlueprintName = "iOS staticLibraryTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E525241E16245AB20012E2BA"
+               BuildableName = "iOS applicationTests.octest"
+               BlueprintName = "iOS applicationTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "806F6FC217EFAF47001051EE"
+               BuildableName = "iOS staticLibraryTests.xctest"
+               BlueprintName = "iOS staticLibraryTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Sample Project/iOS staticLibrary/iOS staticLibrary-Prefix.pch
+++ b/spec/fixtures/Sample Project/iOS staticLibrary/iOS staticLibrary-Prefix.pch
@@ -1,0 +1,9 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#ifdef __OBJC__
+  #import <Foundation/Foundation.h>
+#endif

--- a/spec/fixtures/Sample Project/iOS staticLibrary/iOS_staticLibrary.h
+++ b/spec/fixtures/Sample Project/iOS staticLibrary/iOS_staticLibrary.h
@@ -1,0 +1,13 @@
+//
+//  iOS_staticLibrary.h
+//  iOS staticLibrary
+//
+//  Created by Jason Prado on 9/22/13.
+//  Copyright (c) 2013 CocoaPods. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface iOS_staticLibrary : NSObject
+
+@end

--- a/spec/fixtures/Sample Project/iOS staticLibrary/iOS_staticLibrary.m
+++ b/spec/fixtures/Sample Project/iOS staticLibrary/iOS_staticLibrary.m
@@ -1,0 +1,13 @@
+//
+//  iOS_staticLibrary.m
+//  iOS staticLibrary
+//
+//  Created by Jason Prado on 9/22/13.
+//  Copyright (c) 2013 CocoaPods. All rights reserved.
+//
+
+#import "iOS_staticLibrary.h"
+
+@implementation iOS_staticLibrary
+
+@end

--- a/spec/fixtures/Sample Project/iOS staticLibraryTests/en.lproj/InfoPlist.strings
+++ b/spec/fixtures/Sample Project/iOS staticLibraryTests/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/spec/fixtures/Sample Project/iOS staticLibraryTests/iOS staticLibraryTests-Info.plist
+++ b/spec/fixtures/Sample Project/iOS staticLibraryTests/iOS staticLibraryTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.cocoapods.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/spec/fixtures/Sample Project/iOS staticLibraryTests/iOS_staticLibraryTests.m
+++ b/spec/fixtures/Sample Project/iOS staticLibraryTests/iOS_staticLibraryTests.m
@@ -1,0 +1,34 @@
+//
+//  iOS_staticLibraryTests.m
+//  iOS staticLibraryTests
+//
+//  Created by Jason Prado on 9/22/13.
+//  Copyright (c) 2013 CocoaPods. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface iOS_staticLibraryTests : XCTestCase
+
+@end
+
+@implementation iOS_staticLibraryTests
+
+- (void)setUp
+{
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown
+{
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testExample
+{
+    XCTFail(@"No implementation for \"%s\"", __PRETTY_FUNCTION__);
+}
+
+@end

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -53,12 +53,21 @@ module Xcodeproj
         @ios_application_tests = Xcodeproj::Project::PBXNativeTarget.new(nil, 'E525241E16245AB20012E2BA')
         @ios_application_tests.name = "iOS applicationTests"
         @ios_application_tests.product_type = "com.apple.product-type.bundle"
+        @ios_static_library = Xcodeproj::Project::PBXNativeTarget.new(nil, '806F6FC217EFAF47001051EE')
+        @ios_static_library.name = "iOS staticLibrary"
+        @ios_static_library.product_type = "com.apple.product-type.library.static"
+        @ios_static_library_tests = Xcodeproj::Project::PBXNativeTarget.new(nil, '806F6FC217EFAF47001051EE')
+        @ios_static_library_tests.name = "iOS staticLibraryTests"
+        @ios_static_library_tests.product_type = "com.apple.product-type.bundle"
       end
 
       describe 'For iOS Application' do
 
         before do
-          @scheme = Xcodeproj::XCScheme.new('Cocoa Application', @ios_application, @ios_application_tests)
+          @scheme = Xcodeproj::XCScheme.new
+          @scheme.add_build_target(@ios_application, 'Cocoa Application')
+          @scheme.add_test_target(@ios_application_tests, 'Cocoa Application')
+          @scheme.set_launch_target(@ios_application, 'Cocoa Application')
           @xml = REXML::Document.new File.new fixture_path('Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme')
         end
 
@@ -219,7 +228,8 @@ module Xcodeproj
       describe 'For iOS Application Tests' do
 
         before do
-          @scheme = Xcodeproj::XCScheme.new 'Cocoa Application', @ios_application_tests, @ios_application_tests
+          @scheme = Xcodeproj::XCScheme.new
+          @scheme.add_test_target(@ios_application_tests, 'Cocoa Application')
           @xml = REXML::Document.new File.new fixture_path('Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme')
         end
 
@@ -302,10 +312,9 @@ module Xcodeproj
         extend SpecHelper::TemporaryDirectory
 
         before do
-          @scheme = Xcodeproj::XCScheme.new 'Cocoa Application', @ios_application_tests, @ios_application_tests
-          @scheme.build_target_for_running?.should.be.false
-          @scheme.build_target_for_running = true
-          @scheme.build_target_for_running?.should.be.true
+          @scheme = Xcodeproj::XCScheme.new
+          @scheme.add_build_target(@ios_application_tests, 'Cocoa Application')
+          @scheme.add_test_target(@ios_application_tests, 'Cocoa Application')
           @xml = REXML::Document.new File.new fixture_path('Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme')
         end
 
@@ -380,13 +389,113 @@ module Xcodeproj
         end
 
         it 'Save as Shared Scheme' do
-          result = @scheme.save_as(temporary_directory, true)
+          result = @scheme.save_as(temporary_directory, 'iOS applicationTests', true)
           (result > 0).should.be.true
           File.exists?(File.join temporary_directory, 'xcshareddata', 'xcschemes', 'iOS applicationTests.xcscheme').should.be.true
         end
 
         it 'Save as User Scheme' do
-          result = @scheme.save_as(temporary_directory, false)
+          result = @scheme.save_as(temporary_directory, 'iOS applicationTests', false)
+          (result > 0).should.be.true
+          File.exists?(File.join temporary_directory, 'xcuserdata', "#{ENV['USER']}.xcuserdatad", 'xcschemes', 'iOS applicationTests.xcscheme').should.be.true
+        end
+
+      end
+
+      #-------------------------------------------------------------------------#
+
+      describe 'For iOS Application And Static Library' do
+
+        extend SpecHelper::TemporaryDirectory
+
+        before do
+          @scheme = Xcodeproj::XCScheme.new
+          @scheme.add_build_target(@ios_application, 'Cocoa Application')
+          @scheme.add_build_target(@ios_static_library, 'Cocoa Application')
+          @scheme.add_test_target(@ios_application_tests, 'Cocoa Application')
+          @scheme.add_test_target(@ios_static_library_tests, 'Cocoa Application')
+          @scheme.set_launch_target(@ios_application, 'Cocoa Application')
+          @xml = REXML::Document.new File.new fixture_path('Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme')
+        end
+
+        it 'XML Decl' do
+          @xml.xml_decl.should.be.equal @scheme.doc.xml_decl
+        end
+
+        it 'Scheme' do
+          compare_elements @xml.root, @scheme.doc.root
+        end
+
+        it 'Scheme > BuildAction' do
+          compare_elements @xml.root.elements['BuildAction'], @scheme.doc.root.elements['BuildAction']
+        end
+
+        it 'Scheme > TestAction' do
+          compare_elements @xml.root.elements['TestAction'], @scheme.doc.root.elements['TestAction']
+        end
+
+        it 'Scheme > TestAction > Testables' do
+          compare_elements \
+            @xml.root.elements['TestAction'] \
+            .elements['Testables'], \
+            @scheme.doc.root.elements['TestAction'] \
+            .elements['Testables']
+        end
+
+        it 'Scheme > TestAction > Testables > TestableReference' do
+          compare_elements \
+            @xml.root.elements['TestAction'] \
+            .elements['Testables'] \
+            .elements['TestableReference'], \
+            @scheme.doc.root.elements['TestAction'] \
+            .elements['Testables'] \
+            .elements['TestableReference']
+        end
+
+        it 'Scheme > TestAction > Testables > TestableReference > BuildableReference' do
+          compare_elements \
+            @xml.root.elements['TestAction'] \
+            .elements['Testables'] \
+            .elements['TestableReference'] \
+            .elements['BuildableReference'], \
+            @scheme.doc.root.elements['TestAction'] \
+            .elements['Testables'] \
+            .elements['TestableReference'] \
+            .elements['BuildableReference']
+        end
+
+        it 'Scheme > LaunchAction' do
+          compare_elements @xml.root.elements['LaunchAction'], @scheme.doc.root.elements['LaunchAction']
+        end
+
+        it 'Scheme > LaunchAction > AdditionalOptions' do
+          compare_elements \
+            @xml.root.elements['LaunchAction'] \
+            .elements['AdditionalOptions'], \
+            @scheme.doc.root.elements['LaunchAction'] \
+            .elements['AdditionalOptions']
+        end
+
+        it 'Scheme > ProfileAction' do
+          compare_elements @xml.root.elements['ProfileAction'], @scheme.doc.root.elements['ProfileAction']
+        end
+
+        it 'Scheme > AnalyzeAction' do
+          compare_elements @xml.root.elements['AnalyzeAction'], @scheme.doc.root.elements['AnalyzeAction']
+        end
+
+        it 'Scheme > ArchiveAction' do
+          compare_elements @xml.root.elements['ArchiveAction'], @scheme.doc.root.elements['ArchiveAction']
+        end
+
+        it 'Save as Shared Scheme' do
+          result = @scheme.save_as(temporary_directory, 'iOS applicationTests', true)
+          (result > 0).should.be.true
+          File.exists?(File.join temporary_directory, 'xcshareddata', 'xcschemes', 'iOS applicationTests.xcscheme').should.be.true
+        end
+
+        it 'Save as User Scheme' do
+          result = @scheme.save_as(temporary_directory, 'iOS applicationTests', false)
           (result > 0).should.be.true
           File.exists?(File.join temporary_directory, 'xcuserdata', "#{ENV['USER']}.xcuserdatad", 'xcschemes', 'iOS applicationTests.xcscheme').should.be.true
         end


### PR DESCRIPTION
This is my first time writing Ruby, so please let me know if I've done anything that's not idiomatic. Also this is a breaking API change, let me know if there's a way to handle that.

With the changes to the API, all existing specs still pass. I added a spec for a project that explicitly builds and tests multiple targets.

Thanks!
