### PR TITLE
iphonesimulator support

### DIFF
--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -92,7 +92,7 @@ module Xcodeproj
         # @return [Symbol] the name of the platform of the target.
         #
         def platform_name
-          if    sdk.include? 'iphoneos' then :ios
+          if    sdk.include? 'iphone' then :ios
           elsif sdk.include? 'macosx'   then :osx
           end
         end


### PR DESCRIPTION
Fixed an issue when attempting to add a framework to a target whos sdk is 'iphonesimulator'. This would throw 'Unknown platform for target'  now only checks for 'iphone' in determining platform_name
