### PR TITLE
Added missing rake runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ###### Bug Fixes
 
+* [Gem] Ensure rake is installed.
+  [Johannes Würbach](https://github.com/johanneswuerbach)
+  [#110](https://github.com/CocoaPods/Xcodeproj/pull/110)
+
 * [bin] Ensure the version file is loaded before trying to print it.
   [Eloy Durán](https://github.com/alloy)
   [#107](https://github.com/CocoaPods/Xcodeproj/issues/107)

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.executables   = %w{ xcodeproj }
   s.require_paths = %w{ ext lib }
 
+  s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'activesupport', '~> 3.0'
   s.add_runtime_dependency 'colored',       '~> 1.2'
 


### PR DESCRIPTION
This solves to following error we had on Travis:

```
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.
        rake RUBYARCHDIR=/Users/travis/build/XXX/vendor/bundle/ruby/1.9.1/gems/xcodeproj-0.14.0/ext RUBYLIBDIR=/Users/travis/build/XXX/vendor/bundle/ruby/1.9.1/gems/xcodeproj-0.14.0/ext
/Users/travis/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/dependency.rb:247:in `to_specs': Could not find rake (>= 0) amongst [activesupport-3.2.15, claide-0.3.2, cocoapods-core-0.27.1, cocoapods-downloader-0.2.0, colored-1.2, escape-0.0.4, i18n-0.6.5, json_pure-1.8.1, multi_json-1.8.2, nap-0.5.1, open4-1.3.0] (Gem::LoadError)
    from /Users/travis/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems/dependency.rb:256:in `to_spec'
    from /Users/travis/.rvm/rubies/ruby-1.9.3-p392/lib/ruby/site_ruby/1.9.1/rubygems.rb:1231:in `gem'
    from /Users/travis/.rvm/gems/ruby-1.9.3-p392@global/bin/rake:18:in `<main>'
    from /Users/travis/.rvm/gems/ruby-1.9.3-p392/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/travis/.rvm/gems/ruby-1.9.3-p392/bin/ruby_noexec_wrapper:14:in `<main>'
Gem files will remain installed in /Users/travis/build/XXX/vendor/bundle/ruby/1.9.1/gems/xcodeproj-0.14.0 for inspection.
Results logged to /Users/travis/build/XXX/vendor/bundle/ruby/1.9.1/gems/xcodeproj-0.14.0/ext/xcodeproj/gem_make.out
```

We install cocoapods using bundler.
