### PR TITLE
fix in XML_Formatter + change: PBXScheme supports adding PBXLegacyTarget

### DIFF
--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -285,6 +285,8 @@ module Xcodeproj
         File.basename(build_target.product_reference.path)
       when 'PBXAggregateTarget'
         build_target.name
+      when 'PBXLegacyTarget'
+        build_target.name
       else
         raise ArgumentError, "Unsupported build target type #{build_target.isa}"
       end

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -130,12 +130,15 @@ module ProjectSpecs
           .attributes['BuildableName'].should == aggregate_target.name
       end
 
-      it 'Does not support adding legacy build targets' do
+      it 'Supports adding legacy build targets' do
         legacy_target = @project.new(PBXLegacyTarget)
-
-        should.raise ArgumentError do
-          @scheme.add_build_target(legacy_target)
-        end.message.should.match /Unsupported build target/
+        legacy_target.name = 'Legacy'
+        @scheme.add_build_target(legacy_target)
+        @scheme.doc.root.elements['BuildAction'] \
+          .elements['BuildActionEntries'] \
+          .elements['BuildActionEntry'] \
+          .elements['BuildableReference'] \
+          .attributes['BuildableName'].should == legacy_target.name
       end
 
       it 'Constructs ReferencedContainer attributes correctly' do


### PR DESCRIPTION
while the formatter had a bug, I am not sure if the change of PBXScheme should make it into the project: I need it in https://github.com/HBehrens/pebblex to declare a shell script as executable after building with an external tool. This works great in AppCode but causes an error in Xcode.

As this seems to be a rare case, I can live with [my monkey patch](https://github.com/HBehrens/pebblex/blob/master/lib/pebble_x/monkey_patches.rb) for the PBXScheme change.
