### PR TITLE
group: find_subpath method behavior is incorrect. it does not use path for new_group init

### DIFF
--- a/lib/xcodeproj/project/object/group.rb
+++ b/lib/xcodeproj/project/object/group.rb
@@ -309,7 +309,7 @@ module Xcodeproj
           child = children.find{ |c| c.display_name == child_name }
           if child.nil?
             if should_create
-              child = new_group(child_name)
+              child = new_group(child_name,child_name)
             else
               return nil
             end


### PR DESCRIPTION
Hi! 
I have found that new_group method does not use parameter path.
If so, group will be created in top level.

suppose, that we want create subgroup.
parent/subgroup

if it happens in find_subpath with create all subpaths options, it will create subgroup directory with path equal to parent directory.

so, now, subgroup will have path as parent.
