### PR TITLE
Bumping last known Xcode version to 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## master
+
+###### Enhancements
+
+* Bumping last known Xcode version to 5.1
+  [Romans Karpelcevs](https://github.com/coverback)
+  [#138](https://github.com/CocoaPods/Xcodeproj/pull/138)
+
 ## 0.14.1
 
 ###### Bug Fixes

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -22,7 +22,7 @@ module Xcodeproj
 
     # @return [String] The last known object version to Xcodeproj.
     #
-    LAST_UPGRADE_CHECK  = '0500'
+    LAST_UPGRADE_CHECK  = '0510'
 
     # @return [Hash] The all the known ISAs grouped by superclass.
     #

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/project.pbxproj
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/project.pbxproj
@@ -1718,7 +1718,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = CP;
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					806F6FC217EFAF47001051EE = {

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0500"
+   LastUpgradeVersion = "0510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -33,7 +33,7 @@ module ProjectSpecs
           @sut.to_s[0..190].should == <<-DOC.strip_heredoc
           <?xml version="1.0" encoding="UTF-8"?>
           <Scheme
-             LastUpgradeVersion = "0500"
+             LastUpgradeVersion = "0510"
              version = "1.3">
              <BuildAction
                 parallelizeBuildables = "YES"


### PR DESCRIPTION
Now that Xcode 5.1 is released, pods created with '0500' version show up with "Validate project settings" warning. Bumping version fixes that.
