### PR TITLE
Remove empty OTHER_LDFLAGS setting

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -119,7 +119,6 @@ module Xcodeproj
         'ALWAYS_SEARCH_USER_PATHS'          => 'NO',
         'GCC_C_LANGUAGE_STANDARD'           => 'gnu99',
         'INSTALL_PATH'                      => "$(BUILT_PRODUCTS_DIR)",
-        'OTHER_LDFLAGS'                     => '',
         'COPY_PHASE_STRIP'                  => 'YES',
       }.freeze,
       :debug => {


### PR DESCRIPTION
Setting this to a blank value doesn't match Xcode's behavior, which is to not
set it at all.

This came up as a part of thoughtbot/liftoff#111
