### PR TITLE
Don't add Frameworks to project by default

### DIFF
--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -53,10 +53,6 @@ module Xcodeproj
         target.build_phases << project.new(PBXSourcesBuildPhase)
         target.build_phases << project.new(PBXFrameworksBuildPhase)
 
-        # Frameworks
-        framework_name = (platform == :ios) ? 'Foundation' : 'Cocoa'
-        framework_ref = target.add_system_framework(framework_name)
-
         target
       end
 

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -246,11 +246,7 @@ module ProjectSpecs
           end
 
           phase.should.be.instance_of klass
-          if phase.is_a? PBXFrameworksBuildPhase
-            phase.files.count.should == 1
-          else
-            phase.files.to_a.should == []
-          end
+          phase.files.to_a.should == []
         end
       end
 
@@ -377,7 +373,7 @@ module ProjectSpecs
         pretty_print = @sut.pretty_print
         pretty_print['Pods']['Build Phases'].should == [
           { "SourcesBuildPhase" => [] },
-          { "FrameworksBuildPhase" => ["Foundation.framework"] }
+          { "FrameworksBuildPhase" => [] }
         ]
         build_configurations = pretty_print['Pods']['Build Configurations']
         build_configurations.map { |bf| bf.keys.first } .should == ["Release", "Debug"]


### PR DESCRIPTION
There is another issue (#141) with the `#add_system_framework` method not
setting the path properly, but in all actuality, we could just skip adding the
default Cocoa and Foundation frameworks to new projects by default. We're
already turning Modules on by default, so these imports are superfluous
(especially since they don't actually work).
