### PR TITLE
Constants for .swift and .xctest files

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -81,9 +81,11 @@ module Xcodeproj
       'xcdatamodel' => 'wrapper.xcdatamodel',
       'xib'         => 'file.xib',
       'sh'          => 'text.script.sh',
+      'swift'       => 'sourcecode.swift',
       'plist'       => 'text.plist.xml',
       'markdown'    => 'text',
-      'xcassets'    => 'folder.assetcatalog'
+      'xcassets'    => 'folder.assetcatalog',
+      'xctest'      => 'wrapper.cfbundle'
     }.freeze
 
     # @return [Hash] The uniform type identifier of various product types.


### PR DESCRIPTION
Set automatically on project modification the lastKnownFileType correctly for these file types.
