### PR TITLE
Fixed issue in a Save test

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -159,10 +159,9 @@ module ProjectSpecs
       end
 
       it "saves the project to the given path" do
-        path = temporary_directory + 'Project.xcodeproj'
         save_path = temporary_directory + 'Project_2.xcodeproj'
-        @project.save
-        new_instance = Xcodeproj::Project.open(@path)
+        @project.save(save_path)
+        new_instance = Xcodeproj::Project.open(save_path)
         new_instance.should == @project
       end
 


### PR DESCRIPTION
This test wasn't testing what it said it was testing.

Now saves `@project` at a new location, opens the project from this new location and compares equality with the original.
