### PR TITLE
Test to ensure Xcodeproj can save a project after removing a subproject

### DIFF
--- a/lib/xcodeproj/project/object_dictionary.rb
+++ b/lib/xcodeproj/project/object_dictionary.rb
@@ -110,7 +110,7 @@ module Xcodeproj
       #
       def to_hash
         result = {}
-        each { |key, obj| result[key] = obj.uuid }
+        each { |key, obj| result[key] = obj.uuid if obj }
         result
       end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -165,6 +165,40 @@ module ProjectSpecs
         new_instance.should == @project
       end
 
+      it "can save a project after removing a subproject" do
+        project = Xcodeproj::Project.open(fixture_path("Sample Project/Cocoa Application.xcodeproj"))
+
+        # UUID's related to ReferencedProject.xcodeproj (subproject)
+        # FIXME: these UUID's should all be deleted automatically when calling 
+        #        remove_from_project on the subproject PBXFileReference
+        #        See https://github.com/CocoaPods/Xcodeproj/issues/158
+        uuids_to_remove = [
+          "5138059B16499F4C001D82AD",
+          "5138059C16499F4C001D82AD",
+          "E5FBB3451635ED35009E96B0",
+          "E5FBB3461635ED35009E96B0",
+          "E5FBB34B1635ED36009E96B0",
+          "E5FBB34C1635ED36009E96B0",
+          "E5FBB34D1635ED36009E96B0",
+          "E5FBB34E1635ED36009E96B0",
+          "E5FBB34F1635ED36009E96B0",
+          "E5FBB3501635ED36009E96B0"
+        ]
+
+        objects_to_remove = project.objects.select { |o| uuids_to_remove.include?(o.uuid) }
+        
+        objects_to_remove.each do |object|
+          object.remove_from_project
+        end
+
+        project.save(@path)
+
+        new_instance = Xcodeproj::Project.open(@path)
+        new_instance.objects.count.should > 0 # make sure we still have a valid project
+        removed_objects = new_instance.objects.select { |o| uuids_to_remove.include?(o.uuid) }
+        removed_objects.count.should == 0
+      end
+
       it "can open a project and save it without altering any information" do
         project = Xcodeproj::Project.open(fixture_path("Sample Project/Cocoa Application.xcodeproj"))
         plist = Xcodeproj.read_plist(fixture_path("Sample Project/Cocoa Application.xcodeproj/project.pbxproj"))


### PR DESCRIPTION
This is a small step in fixing #158. For the time being, if you know all the UUID's relevant to a subproject you want to delete, this PR allows you to manually remove all those objects.

Of course, I'd rather all these UUID's be detected as the subproject's referrers, but I haven't found a way to do this comprehensively yet.
