### PR TITLE
Remove GCC_VERSION and GCC_C_LANGUAGE_STANDARD default build settings

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -111,13 +111,11 @@ module Xcodeproj
     #
     COMMON_BUILD_SETTINGS = {
       :all => {
-        'GCC_VERSION'                       => 'com.apple.compilers.llvm.clang.1_0',
         'GCC_PRECOMPILE_PREFIX_HEADER'      => 'YES',
         'PRODUCT_NAME'                      => '$(TARGET_NAME)',
         'SKIP_INSTALL'                      => 'YES',
         'DSTROOT'                           => '/tmp/xcodeproj.dst',
         'ALWAYS_SEARCH_USER_PATHS'          => 'NO',
-        'GCC_C_LANGUAGE_STANDARD'           => 'gnu99',
         'INSTALL_PATH'                      => "$(BUILT_PRODUCTS_DIR)",
         'OTHER_LDFLAGS'                     => '',
         'COPY_PHASE_STRIP'                  => 'YES',


### PR DESCRIPTION
Creating new static libraries, frameworks and applications in both Xcode 5 and Xcode 6 do not add these. Instead the default version is used.
