### PR TITLE
[WIP] Add Support for deterministic UUIDs

### DIFF
--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -55,7 +55,7 @@ module Xcodeproj
     #
     def initialize(path, skip_initialization = false)
       @path = Pathname.new(path).expand_path
-      @objects_by_uuid = {}
+      @objects = []
       @generated_uuids = []
       @available_uuids = []
       unless skip_initialization
@@ -105,10 +105,9 @@ module Xcodeproj
     #
     attr_reader :object_version
 
-    # @return [Hash{String => AbstractObject}] A hash containing all the
-    #         objects of the project by UUID.
+    # @return [Array<AbstractObject>] all the objects of the project.
     #
-    attr_reader :objects_by_uuid
+    attr_reader :objects
 
     # @return [PBXProject] the root object of the project.
     #
@@ -414,16 +413,25 @@ module Xcodeproj
     # @!group Convenience accessors
     #-------------------------------------------------------------------------#
 
-    # @return [Array<AbstractObject>] all the objects of the project.
-    #
-    def objects
-      objects_by_uuid.values
-    end
-
     # @return [Array<String>] all the UUIDs of the project.
     #
+    # @note   In Xcodeproj objects might not have an assigned UUID until the
+    #         project is saved.
+    #
     def uuids
-      objects_by_uuid.keys
+      objects.map(&:uuid).compact
+    end
+
+    # @return [AbstractObject] The object with the given UUID.
+    #
+    # @param  [String] uuid
+    #         The UUID to search for.
+    #
+    # @note   In Xcodeproj objects might not have an assigned UUID until the
+    #         project is saved.
+    #
+    def object_with_uuid(uuid)
+      objects.find { |object| object.uuid == uuid }
     end
 
     # @return [Array<AbstractObject>] all the objects of the project with a

--- a/lib/xcodeproj/project/object.rb
+++ b/lib/xcodeproj/project/object.rb
@@ -98,7 +98,7 @@ module Xcodeproj
         # @return [void]
         #
         def remove_from_project
-          project.objects_by_uuid.delete(uuid)
+          project.objects.delete(self)
 
           referrers.dup.each do |referrer|
             referrer.remove_reference(self)
@@ -200,7 +200,7 @@ module Xcodeproj
         #
         def add_referrer(referrer)
           @referrers << referrer
-          @project.objects_by_uuid[uuid] = self
+          @project.objects << self
         end
 
         # Informs the object that another object stopped referencing it. If the
@@ -214,7 +214,7 @@ module Xcodeproj
         def remove_referrer(referrer)
           @referrers.delete(referrer)
           if @referrers.count == 0
-            @project.objects_by_uuid.delete(uuid)
+            @project.objects.delete(self)
           end
         end
 
@@ -334,7 +334,9 @@ module Xcodeproj
         # @visibility private
         #
         def object_with_uuid(uuid, objects_by_uuid_plist, attribute)
-          unless object = project.objects_by_uuid[uuid] || project.new_from_plist(uuid, objects_by_uuid_plist)
+          object = project.objects.find { |object| object.uuid == uuid }
+          object ||= project.new_from_plist(uuid, objects_by_uuid_plist)
+          unless object
             UI.warn "`#{inspect}` attempted to initialize an object with " \
               "an unknown UUID. `#{uuid}` for attribute: " \
               "`#{attribute.name}`. This can be the result of a merge and  " \

--- a/lib/xcodeproj/project/object/container_item_proxy.rb
+++ b/lib/xcodeproj/project/object/container_item_proxy.rb
@@ -49,15 +49,16 @@ module Xcodeproj
         # @return [String] apparently the UUID of the represented
         #         object.
         #
-        # @note   If the object is in another project the UUID would not be
-        #         present in the {Project#objects_by_uuid} hash. For this
-        #         reason this is not an `has_one` attribute. It is assumes that
-        #         if the object belongs to the project at least another object
-        #         should be retaining it. This assumption is reasonable because
-        #         this is a proxy class.
+        # @note   If the object is in another project the UUID will not be
+        #         found in the project. For this reason this is not an
+        #         `has_one` attribute. It is assumes that if the object belongs
+        #         to the project at least another object should be retaining
+        #         it. This assumption is reasonable because this is a proxy
+        #         class.
         #
-        #         If this assumption is incorrect, there could be loss of
-        #         information opening and saving an existing project.
+        #         If this assumption is incorrect, however, there could be loss
+        #         of information just by opening and saving an existing
+        #         project.
         #
         attribute :remote_global_id_string, String
 

--- a/spec/project/object/file_reference_spec.rb
+++ b/spec/project/object/file_reference_spec.rb
@@ -120,11 +120,11 @@ module ProjectSpecs
 
       it 'removes the proxy related objects when removing the file reference' do
         @file.remove_from_project
-        @project.objects_by_uuid[@file_proxy.uuid].should.nil?
-        @project.objects_by_uuid[@file_container.uuid].should.nil?
-        @project.objects_by_uuid[@target_container.uuid].should.nil?
-        @project.objects_by_uuid[@target_dependency.uuid].should.nil?
-        @project.objects_by_uuid[@group.uuid].should.nil?
+        @project.object_with_uuid(@file_proxy.uuid).should.nil?
+        @project.object_with_uuid(@file_container.uuid).should.nil?
+        @project.object_with_uuid(@target_container.uuid).should.nil?
+        @project.object_with_uuid(@target_dependency.uuid).should.nil?
+        @project.object_with_uuid(@group.uuid).should.nil?
         @project.root_object.project_references.should.not.include @project_reference
         @target.dependencies.should.be.empty
       end

--- a/spec/project/object/group_spec.rb
+++ b/spec/project/object/group_spec.rb
@@ -147,10 +147,10 @@ module ProjectSpecs
       @group.remove_children_recursively
       @group.children.count.should == 0
 
-      @project.objects_by_uuid[group1.uuid].should.nil?
-      @project.objects_by_uuid[group2.uuid].should.nil?
-      @project.objects_by_uuid[file1.uuid].should.nil?
-      @project.objects_by_uuid[file2.uuid].should.nil?
+      @project.object_with_uuid(group1.uuid).should.nil?
+      @project.object_with_uuid(group2.uuid).should.nil?
+      @project.object_with_uuid(file1.uuid).should.nil?
+      @project.object_with_uuid(file2.uuid).should.nil?
     end
 
     #----------------------------------------#

--- a/spec/project/object_spec.rb
+++ b/spec/project/object_spec.rb
@@ -34,7 +34,7 @@ module ProjectSpecs
       it 'can remove itself from the project' do
         @object.remove_from_project
         @object.referrers.count.should == 0
-        @project.objects_by_uuid[@object.uuid].should.be.nil
+        @project.object_with_uuid(@object.uuid).should.be.nil
       end
 
       it 'removes the itself from referred objects' do
@@ -43,7 +43,7 @@ module ProjectSpecs
 
         group.remove_from_project
         file.referrers.count.should == 0
-        @project.objects_by_uuid[file.uuid].should.be.nil
+        @project.object_with_uuid(file.uuid).should.be.nil
       end
 
       it 'maintains the list of referrers' do
@@ -69,17 +69,17 @@ module ProjectSpecs
         uuid = 'uuid'
         f = PBXFileReference.new(@project, uuid)
         f.referrers.count.should == 0
-        @project.objects_by_uuid[uuid].should.be.nil
+        @project.object_with_uuid(uuid).should.be.nil
         f.add_referrer(group)
         f.referrers.count.should == 1
-        @project.objects_by_uuid[uuid].should == f
+        @project.object_with_uuid(uuid).should == f
       end
 
       it 'removes itself from the project objects when it has no referrers' do
         group = @object.referrers.first
         @object.remove_referrer(group)
         @object.referrers.count.should == 0
-        @project.objects_by_uuid[@object.uuid].should.be.nil
+        @project.object_with_uuid(@object.uuid).should.be.nil
       end
 
       it 'can remove any reference to another object' do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -9,8 +9,8 @@ module ProjectSpecs
 
     describe 'In general' do
 
-      it 'return the objects by UUID hash' do
-        @project.objects_by_uuid.should.not.be.nil
+      it 'return the objects' do
+        @project.objects.should.not.be.empty?
       end
 
       it 'returns the root object' do
@@ -42,9 +42,8 @@ module ProjectSpecs
         @project.root_object.referrers.should == [@project]
       end
 
-      it 'includes the root object in the objects by UUID hash' do
-        uuid = @project.root_object.uuid
-        @project.objects_by_uuid[uuid].should.not.be.nil
+      it 'includes the root object in the objects list' do
+        @project.objects.should.include(@project.root_object)
       end
 
       it 'initializes the root object main group' do
@@ -195,7 +194,7 @@ module ProjectSpecs
           'E5FBB3501635ED36009E96B0', # PBXReferenceProxy links to E5FBB34F1635ED36009E96B0
         ]
 
-        subproject_file_reference = @project.objects_by_uuid['E5FBB3451635ED35009E96B0']
+        subproject_file_reference = @project.object_with_uuid('E5FBB3451635ED35009E96B0')
         subproject_file_reference.remove_from_project
         @project.save(@tmp_path)
 
@@ -259,13 +258,13 @@ module ProjectSpecs
       it "doesn't add an object to the objects tree until an object references it" do
         obj = @project.new(PBXFileReference)
         obj.path = 'some/file.m'
-        @project.objects_by_uuid[obj.uuid].should.nil?
+        @project.object_with_uuid(obj.uuid).should.nil?
       end
 
       it 'adds an object to the objects tree once an object references it' do
         obj = @project.new(PBXFileReference)
         @project.main_group << obj
-        @project.objects_by_uuid[obj.uuid].should == obj
+        @project.object_with_uuid(obj.uuid).should == obj
       end
 
       it 'initializes new objects (not created form a plist) with the default values' do
@@ -436,7 +435,7 @@ module ProjectSpecs
         group = @project.new_group('NewGroup')
         group.isa.should == 'PBXGroup'
         group.name.should == 'NewGroup'
-        @project.objects_by_uuid[group.uuid].should.not.be.nil
+        @project.object_with_uuid(group.uuid).should.not.be.nil
         @project.main_group.children.should.include group
       end
 
@@ -444,7 +443,7 @@ module ProjectSpecs
         file = @project.new_file('Classes/Test.h')
         file.isa.should == 'PBXFileReference'
         file.display_name.should == 'Test.h'
-        @project.objects_by_uuid[file.uuid].should.not.be.nil
+        @project.object_with_uuid(file.uuid).should.not.be.nil
         @project.main_group.children.should.include file
       end
 


### PR DESCRIPTION
This is the work in progress patch for https://github.com/CocoaPods/Xcodeproj/issues/175.


The difficult part of this patch are:

- Xcodeproj relies on the UUIDs (`objects_by_uuid`) for its internal reference counting.
- Proxies to avoid retain cycles and to allow to reference objects in another projects consider the UUIDs as strings (instead of using the Xcodeproj reference system) and objects, with this patch, might not have an UUID until saved.

There are alternative approaches like specifying an temporary UUID during the creation of the object and then update it during save according to the final attributes of the object. However, I feel that this approach would be slower and I would prefer to first explore any alternative with the approach proposed in this patch.

```
550 specifications (886 requirements), 3 failures, 0 errors
```

---

Closes https://github.com/CocoaPods/CocoaPods/issues/1118
