### PR TITLE
Add attribute :name for PBXReferenceProxy

### DIFF
--- a/lib/xcodeproj/project/object/reference_proxy.rb
+++ b/lib/xcodeproj/project/object/reference_proxy.rb
@@ -9,6 +9,10 @@ module Xcodeproj
       class PBXReferenceProxy < AbstractObject
         # @!group Attributes
 
+        # @return [String] the name of the reference.
+        #
+        attribute :name, String
+
         # @return [String] the path of the referenced filed.
         #
         attribute :path, String


### PR DESCRIPTION
This seems to be required at least for Xcode 6 under certain circumstances.
