### PR TITLE
Add runpath search paths to default settings

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -123,6 +123,7 @@ module Xcodeproj
         'INSTALL_PATH'                      => '$(BUILT_PRODUCTS_DIR)',
         'OTHER_LDFLAGS'                     => '',
         'COPY_PHASE_STRIP'                  => 'YES',
+        'LD_RUNPATH_SEARCH_PATHS'           => ['$(inherited)', '@executable_path/Frameworks'],
       }.freeze,
       :debug => {
         'GCC_DYNAMIC_NO_PIC'                => 'NO',


### PR DESCRIPTION
This setting is required to run targets containing Swift code. Adding this
here keeps xcodeproj in sync with Xcode's default settings.
