### PR TITLE
Do not rewrite configs if content is identical.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [Eloy Durán](https://github.com/alloy)
   [Xcodeproj#206](https://github.com/CocoaPods/Xcodeproj/issues/206)
 
+* Stop re-writing config files if they have not changed.  
+  [Kyle Fuller](https://github.com/kylef)
+  [Boris Bügling](https://github.com/neonichu)
+
 
 ## 0.19.3
 

--- a/lib/xcodeproj/config.rb
+++ b/lib/xcodeproj/config.rb
@@ -76,7 +76,7 @@ module Xcodeproj
     #
     def save_as(pathname, prefix = nil)
       if File.exist?(pathname)
-        return unless Config.new(pathname).to_yaml != to_yaml
+        return unless Config.new(pathname) != self
       end
 
       pathname.open('w') { |file| file << to_s(prefix) }

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -123,13 +123,11 @@ describe Xcodeproj::Config do
     end
 
     it 'does not rewrite the config file if contents have not changed' do
-      fname = temporary_directory + 'Pods.xcconfig'
-      @config.save_as(fname)
-      mtime = File.mtime(fname)
-      sleep(1)
+      filename = temporary_directory + 'Pods.xcconfig'
+      @config.save_as(filename)
 
-      @config.save_as(fname)
-      File.mtime(fname).should == mtime
+      IO.expects(:open).never
+      @config.save_as(filename)
     end
 
     it 'contains file path refs to all included xcconfigs' do


### PR DESCRIPTION
This would first read old content of XCConfigs and compare it to the current one, to prevent unnecessary writing.

I kinda hate the spec for it, because it takes a second. Ideas for a better spec?
