### PR TITLE
Double quotes on scheme generation

### DIFF
--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -250,7 +250,7 @@ module Xcodeproj
         node.attributes.each_attribute do |attr|
           output << "\n"
           output << ' ' * @level
-          output << attr.to_string.gsub(/=/, ' = ')
+          output << attr.to_string.gsub(/=/, ' = ').gsub('\'', '"')
         end unless node.attributes.empty?
 
         output << '>'


### PR DESCRIPTION
I'm doing some editing to scheme files and save them back using XMLFormatter.
While [this spec](https://github.com/CocoaPods/Xcodeproj/blob/master/spec/scheme_spec.rb#L29-L40) passes (don't know why), generated file uses single quotes, and Xcode uses (afaik) double quotes. There is diff after saving scheme generated by XMLFormatter against Xcode saved one:

```
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
-   version = "1.7">
+   LastUpgradeVersion = '0610'
+   version = '1.7'>
```

Also, since test is already passing, I don't know if it's my fault getting wrong result, or how to write specs for this.

And, formatter uses `to_string` method of `REXML::Attribute` which returns with single quote too:

```
irb(main):110:0> ref.attributes.each_attribute { |a| puts a.to_string}
BuildableIdentifier='primary'
BlueprintIdentifier='F720E3E6192770D6005A8754'
BuildableName='Testing RXML'
```
