### PR TITLE
use sub instead of gsub

### DIFF
--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -250,7 +250,7 @@ module Xcodeproj
         node.attributes.each_attribute do |attr|
           output << "\n"
           output << ' ' * @level
-          output << attr.to_string.gsub(/=/, ' = ')
+          output << attr.to_string.sub(/=/, ' = ')
         end unless node.attributes.empty?
 
         output << '>'


### PR DESCRIPTION
Hello, 
Since we're printing one attribute at a line I wanted to propose change gsub with sub (hence name: sub('gsub', 'sub') 😄). The reason is I have pre-action scripts on my scheme like this:
![screen shot 2014-12-22 at 3 29 08 pm](https://cloud.githubusercontent.com/assets/1816725/5523220/b51abd86-89ef-11e4-9704-1595ced3063a.png)
Which saved on xml like this:
```
         <ExecutionAction
            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
            <ActionContent
               title = "Run Script"
               scriptText = "// getting json file name&#10;BUNDLE_ID=$(/usr/libexec/PlistBuddy -c &quot;Print :CFBundleIdentifier&quot; &quot;${INFOPLIST_FILE}&quot;)&#10;JSON_FILE_NAME=&quot;config.json&quot;&#10;&#10;// getting json remote url&#10;JSON_REMOTE_URL=&quot;http://website.com/v1/${BUNDLE_ID}/config&quot;&#10;&#10;// local json path&#10;JSON_PATH=&quot;${PROJECT_DIR}/app/${JSON_FILE_NAME}&quot;&#10;&#10;// loading&#10;curl ${JSON_REMOTE_URL} &gt; ${JSON_PATH}&#10;"
               shellToInvoke = "/bin/sh">
            </ActionContent>
         </ExecutionAction>
```
And after saving scheme with `XMLFormatter` it changes all '=' with ' = ', so my scripts no longer works.

I think we're ok with changing only first occurrence of '='.