### PR TITLE
[Project] Create all configurations for new_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Xcodeproj Changelog
 
+## Master
+
+##### Bug Fixes
+
+* `Project` The `new_target` method now creates build configurations
+  corresponding to all configurations of the project, not just Debug
+  and Release.  
+  [Boris Bügling](https://github.com/neonichu)
+  [Xcodeproj#228](https://github.com/CocoaPods/Xcodeproj/issues/228)
+  [CocoaPods#3055](https://github.com/CocoaPods/CocoaPods/issues/3055)
+
+
 ## 0.21.0
 
 ##### Breaking

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -157,6 +157,15 @@ module Xcodeproj
 
         cl.build_configurations << release_conf
         cl.build_configurations << debug_conf
+
+        project.build_configurations.each do |configuration|
+          next if cl.build_configurations.map(&:name).include?(configuration.name)
+
+          new_config = project.new(XCBuildConfiguration)
+          new_config.name = configuration.name
+          cl.build_configurations << new_config
+        end
+
         cl
       end
 

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -15,6 +15,18 @@ module ProjectSpecs
 
     #----------------------------------------#
 
+    describe 'Creation' do
+      it 'inherits build configurations from the project similar to Xcode' do
+        @project.add_build_configuration('App Store', :release)
+        @target = @project.new_target(:static_library, 'Pods', :ios)
+
+        @project.build_configurations.map(&:name).sort.should == \
+          @target.build_configurations.map(&:name).sort
+      end
+    end
+
+    #----------------------------------------#
+
     describe 'Helpers' do
       before do
         @target = @project.new_target(:static_library, 'Pods', :ios)


### PR DESCRIPTION
The `new_target` method now creates build configurations corresponding to all configurations of the project, not just Debug and Release.

Fixes #228 