### PR TITLE
[Constants] Fix COPY_PHASE_STRIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Xcodeproj Changelog
 
+## Master
+
+#### Bug Fixes
+
+* Use the correct value for `COPY_PHASE_STRIP` when creating build
+  configurations.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [#3062](https://github.com/CocoaPods/CocoaPods/issues/3062)
+
+
 ## 0.21.2
 
 ##### Bug Fixes

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -233,13 +233,13 @@ module Xcodeproj
         'GCC_WARN_UNUSED_VARIABLE'           => 'YES',
       },
       :release => {
-        'COPY_PHASE_STRIP'                   => 'NO',
+        'COPY_PHASE_STRIP'                   => 'YES',
         'ENABLE_NS_ASSERTIONS'               => 'NO',
         'VALIDATE_PRODUCT'                   => 'YES',
       }.freeze,
       :debug => {
         'ONLY_ACTIVE_ARCH'                   => 'YES',
-        'COPY_PHASE_STRIP'                   => 'YES',
+        'COPY_PHASE_STRIP'                   => 'NO',
         'GCC_DYNAMIC_NO_PIC'                 => 'NO',
         'GCC_OPTIMIZATION_LEVEL'             => '0',
         'GCC_PREPROCESSOR_DEFINITIONS'       => ['DEBUG=1', '$(inherited)'],


### PR DESCRIPTION
As pointed out in CocoaPods/CocoaPods#3062, the value for the build setting `COPY_PHASE_STRIP` is swapped for debug and release configuration.