### PR TITLE
Explicitly call `close` on `PBXProject` instances.

### DIFF
--- a/lib/xcodeproj/plist_helper.rb
+++ b/lib/xcodeproj/plist_helper.rb
@@ -94,6 +94,7 @@ module Xcodeproj
 
           project = DevToolsCore::PBXProject.new(path)
           success &= project.writeToFileSystemProjectFile
+          project.close
         rescue Fiddle::DLError
           success = false
         end
@@ -671,6 +672,14 @@ module DevToolsCore
           CoreFoundation.NSSelectorFromString(CoreFoundation.RubyStringToCFString(selector)),
           CoreFoundation.RubyStringToCFString(path))
       end
+    end
+
+    def close
+      selector = 'close'
+      return unless NSObject.respondsToSelector(@project, selector)
+
+      close = PBXProject.objc_msgSend([], CoreFoundation::Void)
+      close.call(@project, CoreFoundation.NSSelectorFromString(CoreFoundation.RubyStringToCFString(selector)))
     end
 
     def writeToFileSystemProjectFile


### PR DESCRIPTION
Not doing this explicitly leads to incomplete saves under certain circumstances.