### PR TITLE
add .H to HEADER_FILES_EXTENSIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
   [Marius Rackwitz](https://github.com/mrackwitz)
   [#3062](https://github.com/CocoaPods/CocoaPods/issues/3062)
 
+* handle .H header files as headers and remove from the compile
+  sources build phase.  
+  [banjun](https://github.com/banjun)
+  [Xcodeproj#239](https://github.com/CocoaPods/Xcodeproj/pull/239)
 
 ## 0.21.2
 

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -272,6 +272,6 @@ module Xcodeproj
 
     # @return [Hash] The extensions which are associated with header files.
     #
-    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp).freeze
+    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .H).freeze
   end
 end

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -272,6 +272,6 @@ module Xcodeproj
 
     # @return [Hash] The extensions which are associated with header files.
     #
-    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .H).freeze
+    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp).freeze
   end
 end

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -412,7 +412,7 @@ module Xcodeproj
 
             extension = File.extname(file.path)
             header_extensions = Constants::HEADER_FILES_EXTENSIONS
-            if header_extensions.include?(extension)
+            if header_extensions.include?(extension.downcase)
               headers_build_phase.files << build_file
             else
               if compiler_flags && !compiler_flags.empty?

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -410,9 +410,9 @@ module Xcodeproj
             build_file = project.new(PBXBuildFile)
             build_file.file_ref = file
 
-            extension = File.extname(file.path)
+            extension = File.extname(file.path).downcase
             header_extensions = Constants::HEADER_FILES_EXTENSIONS
-            if header_extensions.include?(extension.downcase)
+            if header_extensions.include?(extension)
               headers_build_phase.files << build_file
             else
               if compiler_flags && !compiler_flags.empty?

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -508,6 +508,15 @@ module ProjectSpecs
         build_files.first.settings.should.be.nil
       end
 
+      it 'adds a list of header files with capitalized .H extension to the target header build phases' do
+        ref = @project.main_group.new_file('CLASS.H')
+        @target.add_file_references([ref], '-fobjc-arc')
+        build_files = @target.headers_build_phase.files
+        build_files.count.should == 1
+        build_files.first.file_ref.path.should == 'CLASS.H'
+        build_files.first.settings.should.be.nil
+      end
+
       it 'returns a list of header files to the target header build phases' do
         ref = @project.main_group.new_file('Class.h')
         new_build_files = @target.add_file_references([ref], '-fobjc-arc')


### PR DESCRIPTION
We have legacy header files named capitalized like `FOO.H`.
Currently `pod install` adds these headers to the Compile Sources build phase.
This PR handles `FOO.H` as a header file and does not add to the Compile Sources, same as manually drag & drop them to Xcode project. (.H files are treated as `C Header` in a project by default)