### PR TITLE
Added .tpp header extension support

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -274,6 +274,6 @@ module Xcodeproj
 
     # @return [Hash] The extensions which are associated with header files.
     #
-    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp).freeze
+    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .tpp).freeze
   end
 end


### PR DESCRIPTION
Xcodeproj should now recognize `.tpp` files as header files.