### PR TITLE
add missing require

### DIFF
--- a/lib/xcodeproj/plist_helper.rb
+++ b/lib/xcodeproj/plist_helper.rb
@@ -1,4 +1,5 @@
 require 'fiddle'
+require 'pathname'
 
 module Xcodeproj
   # TODO: Delete me (compatibility with Ruby 1.8.7 C ext bundle)


### PR DESCRIPTION
PlistHelper was using Pathname but not requiring it.
Issue #243 