### PR TITLE
Fix add_system_framework could not find the system framework

### DIFF
--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -289,7 +289,7 @@ module Xcodeproj
             when :ios
               group = project.frameworks_group['iOS'] || project.frameworks_group.new_group('iOS')
               path_sdk_name = 'iPhoneOS'
-              path_sdk_version = sdk_version || Constants::LAST_KNOWN_IOS_SDK
+              path_sdk_version = ''
             when :osx
               group = project.frameworks_group['OS X'] || project.frameworks_group.new_group('OS X')
               path_sdk_name = 'MacOSX'


### PR DESCRIPTION
when I’m trying to create project in command line,  the path is wrong
when add System framework into a target, in my environment (Xcode6.2
Mac OS X 10.10.2) the Constants::LAST_KNOWN_IOS_SDK is 7.1 but in Xcode
Folder， there are only iPhoneOS.sdk and iPhoneOS8.2.sdk, so, I think it's no need to add sdk_version in iPhoneOS