### PR TITLE
Fix `fix_encoding` workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Xcodeproj Changelog
 
+## Master
+
+#### Bug Fixes
+
+* Do not apply `fix_encoding` workaround when writing ASCII plists. 
+  [CocoaPods#3298](https://github.com/CocoaPods/CocoaPods/issues/3298)
+  [Boris Bügling](https://github.com/neonichu)
+
+
 ## 0.23.0
 
 ##### Enhancements

--- a/lib/xcodeproj/plist_helper.rb
+++ b/lib/xcodeproj/plist_helper.rb
@@ -86,7 +86,7 @@ module Xcodeproj
         output = ''
         input = File.open(filename, 'rb') { |file| file.read }
         input.unpack('U*').each do |codepoint|
-          if codepoint > 127
+          if codepoint > 127 # ASCII is 7-bit, so 0-127 are valid characters
             output << "&##{codepoint};"
           else
             output << codepoint.chr

--- a/lib/xcodeproj/plist_helper.rb
+++ b/lib/xcodeproj/plist_helper.rb
@@ -41,6 +41,7 @@ module Xcodeproj
           ruby_hash_write_xcode(hash, path)
         else
           CoreFoundation.RubyHashPropertyListWrite(hash, path)
+          fix_encoding(path)
         end
       end
 
@@ -62,6 +63,37 @@ module Xcodeproj
       end
 
       private
+
+      # Simple workaround to escape characters which are outside of ASCII
+      # character-encoding. Relies on the fact that there are no XML characters
+      # which would need to be escaped.
+      #
+      # @note   This is necessary because Xcode (4.6 currently) uses the MacRoman
+      #         encoding unless the `// !$*UTF8*$!` magic comment is present. It
+      #         is not possible to serialize a plist using the NeXTSTEP format
+      #         without access to the private classes of Xcode and that comment
+      #         is not compatible with the XML format. For the complete
+      #         discussion see CocoaPods/CocoaPods#926.
+      #
+      #
+      # @note   Sadly this hack is not sufficient for supporting Emoji.
+      #
+      # @param  [String, Pathname] The path of the file which needs to be fixed.
+      #
+      # @return [void]
+      #
+      def fix_encoding(filename)
+        output = ''
+        input = File.open(filename, 'rb') { |file| file.read }
+        input.unpack('U*').each do |codepoint|
+          if codepoint > 127
+            output << "&##{codepoint};"
+          else
+            output << codepoint.chr
+          end
+        end
+        File.open(filename, 'wb') { |file| file.write(output) }
+      end
 
       # @return [Bool] Checks whether there are merge conflicts in the file.
       #

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -317,38 +317,6 @@ module Xcodeproj
       FileUtils.mkdir_p(save_path)
       file = File.join(save_path, 'project.pbxproj')
       Xcodeproj.write_plist(to_hash, file)
-      fix_encoding(file)
-    end
-
-    # Simple workaround to escape characters which are outside of ASCII
-    # character-encoding. Relies on the fact that there are no XML characters
-    # which would need to be escaped.
-    #
-    # @note   This is necessary because Xcode (4.6 currently) uses the MacRoman
-    #         encoding unless the `// !$*UTF8*$!` magic comment is present. It
-    #         is not possible to serialize a plist using the NeXTSTEP format
-    #         without access to the private classes of Xcode and that comment
-    #         is not compatible with the XML format. For the complete
-    #         discussion see CocoaPods/CocoaPods#926.
-    #
-    #
-    # @note   Sadly this hack is not sufficient for supporting Emoji.
-    #
-    # @param  [String, Pathname] The path of the file which needs to be fixed.
-    #
-    # @return [void]
-    #
-    def fix_encoding(filename)
-      output = ''
-      input = File.open(filename, 'rb') { |file| file.read }
-      input.unpack('U*').each do |codepoint|
-        if codepoint > 127
-          output << "&##{codepoint};"
-        else
-          output << codepoint.chr
-        end
-      end
-      File.open(filename, 'wb') { |file| file.write(output) }
     end
 
     public

--- a/spec/fixtures/Sample Project/Emoji.xcodeproj/project.pbxproj
+++ b/spec/fixtures/Sample Project/Emoji.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		806F6FCA17EFAF47001051EE /* libiOS staticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */; };
 		806F6FD017EFAF47001051EE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 806F6FCE17EFAF47001051EE /* InfoPlist.strings */; };
 		806F6FD217EFAF47001051EE /* iOS_staticLibraryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */; };
+		A167CE581AC1A60F00F867E6 /* ⾞⻋.swift in Sources */ = {isa = PBXBuildFile; fileRef = A167CE571AC1A60E00F867E6 /* ⾞⻋.swift */; };
 		A1CFC16619E48F59004D3230 /* 🍷.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CFC16519E48F59004D3230 /* 🍷.swift */; };
 		E525239116245A900012E2BA /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
 		E525239B16245A900012E2BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E525239916245A900012E2BA /* InfoPlist.strings */; };
@@ -311,6 +312,7 @@
 		806F6FCD17EFAF47001051EE /* iOS staticLibraryTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "iOS staticLibraryTests-Info.plist"; sourceTree = "<group>"; };
 		806F6FCF17EFAF47001051EE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOS_staticLibraryTests.m; sourceTree = "<group>"; };
+		A167CE571AC1A60E00F867E6 /* ⾞⻋.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "⾞⻋.swift"; sourceTree = "<group>"; };
 		A1CFC16519E48F59004D3230 /* 🍷.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "🍷.swift"; sourceTree = "<group>"; };
 		E525238C16245A900012E2BA /* Cocoa Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Cocoa Application.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E525239016245A900012E2BA /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
@@ -748,6 +750,7 @@
 			children = (
 				E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */,
 				A1CFC16519E48F59004D3230 /* 🍷.swift */,
+				A167CE571AC1A60E00F867E6 /* ⾞⻋.swift */,
 				E5FBB2D016357C16009E96B0 /* sample.xcconfig */,
 				E52523AB16245A910012E2BA /* CPDocument.xcdatamodeld */,
 				E5D464AB163578AC006A4730 /* Tools_version.xcdatamodeld */,
@@ -1721,7 +1724,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = CP;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0620;
 				ORGANIZATIONNAME = CocoaPods;
 				TargetAttributes = {
 					806F6FC217EFAF47001051EE = {
@@ -2207,6 +2210,7 @@
 				E52523A416245A900012E2BA /* CPDocument.m in Sources */,
 				E52523AD16245A910012E2BA /* CPDocument.xcdatamodeld in Sources */,
 				E5D464AD163578AC006A4730 /* Tools_version.xcdatamodeld in Sources */,
+				A167CE581AC1A60F00F867E6 /* ⾞⻋.swift in Sources */,
 				E5D464B0163578C7006A4730 /* Deployment_target.xcdatamodeld in Sources */,
 				A1CFC16619E48F59004D3230 /* 🍷.swift in Sources */,
 				E5D464B416357954006A4730 /* Version_identifier.xcdatamodeld in Sources */,

--- a/spec/plist_helper_spec.rb
+++ b/spec/plist_helper_spec.rb
@@ -221,39 +221,5 @@ EOS
         write_temp_file_and_compare(read_sample)
       end
     end
-
-    #-------------------------------------------------------------------------#
-
-    describe 'Xcode equivalency' do
-      extend SpecHelper::TemporaryDirectory
-
-      def setup_fixture(name)
-        fixture_path("Sample Project/#{name}/project.pbxproj")
-      end
-
-      def setup_temporary(name)
-        dir = File.join(SpecHelper.temporary_directory, name)
-        FileUtils.mkdir_p(dir)
-        File.join(dir, 'project.pbxproj')
-      end
-
-      def touch_project(name)
-        fixture = setup_fixture(name)
-        temporary = setup_temporary(name)
-
-        hash = Xcodeproj.read_plist(fixture)
-        Xcodeproj.write_plist(hash, temporary)
-
-        File.open(fixture).read.should == File.open(temporary).read
-      end
-
-      it 'touches the project at the given path' do
-        touch_project('Cocoa Application.xcodeproj')
-      end
-
-      it 'retains emoji when touching a project' do
-        touch_project('Emoji.xcodeproj')
-      end
-    end
   end
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -486,5 +486,41 @@ module ProjectSpecs
     end
 
     #-------------------------------------------------------------------------#
+
+    describe 'Xcode equivalency' do
+      extend SpecHelper::TemporaryDirectory
+
+      def setup_fixture(name)
+        fixture_path("Sample Project/#{name}")
+      end
+
+      def setup_temporary(name)
+        dir = File.join(SpecHelper.temporary_directory, name)
+        FileUtils.mkdir_p(dir)
+        dir
+      end
+
+      def touch_project(name)
+        fixture = setup_fixture(name)
+        temporary = setup_temporary(name)
+
+        project = Xcodeproj::Project.open(fixture)
+        project.save(temporary)
+
+        fixture = File.join(fixture, '/project.pbxproj')
+        temporary = File.join(temporary, '/project.pbxproj')
+        File.open(fixture).read.should == File.open(temporary).read
+      end
+
+      it 'touches the project at the given path' do
+        touch_project('Cocoa Application.xcodeproj')
+      end
+
+      it 'retains emoji when touching a project' do
+        touch_project('Emoji.xcodeproj')
+      end
+    end
+
+    #-------------------------------------------------------------------------#
   end
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -491,13 +491,13 @@ module ProjectSpecs
       extend SpecHelper::TemporaryDirectory
 
       def setup_fixture(name)
-        fixture_path("Sample Project/#{name}")
+        Pathname.new(fixture_path("Sample Project/#{name}"))
       end
 
       def setup_temporary(name)
         dir = File.join(SpecHelper.temporary_directory, name)
         FileUtils.mkdir_p(dir)
-        dir
+        Pathname.new(dir)
       end
 
       def touch_project(name)
@@ -507,9 +507,7 @@ module ProjectSpecs
         project = Xcodeproj::Project.open(fixture)
         project.save(temporary)
 
-        fixture = File.join(fixture, '/project.pbxproj')
-        temporary = File.join(temporary, '/project.pbxproj')
-        File.open(fixture).read.should == File.open(temporary).read
+        (fixture + 'project.pbxproj').read.should == (temporary + 'project.pbxproj').read
       end
 
       it 'touches the project at the given path' do


### PR DESCRIPTION
Turns out :tm: that there was still a workaround in place at a higher level which replaced non-ASCII characters with their XML entity equivalent, even when writing ASCII plists. 

This PR fixes the specs so that they actually ensure the whole saving process retains the project file 1:1 and moves the encoding fix so that it is only ever applied when writing XML.

Fixes CocoaPods/CocoaPods#3298 

cc @kylef @segiddins 