### PR TITLE
[Config] 'includes' affect equality.

### DIFF
--- a/lib/xcodeproj/config.rb
+++ b/lib/xcodeproj/config.rb
@@ -61,7 +61,7 @@ module Xcodeproj
     end
 
     def ==(other)
-      other.respond_to?(:to_hash) && other.to_hash == to_hash
+      other.attributes == attributes && other.other_linker_flags == other_linker_flags && other.includes == includes
     end
 
     public


### PR DESCRIPTION
I was running into issues where I would load an xcconfig from disk, edit `includes` and try to save, but the change would not actually be saved.  The issue was the equality check in `save_as`.  Since equality was based on `to_hash`, if there were only changes that didn't affect the hash they would never be saved.
:rainbow: 