### PR TITLE
Project Helper for different Target Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Master
 
+##### Enhancements
+
+* Return a list of project targets including only native targets by
+  `native_targets`.  
+  [Marc Boquet](https://github.com/apalancat)
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [Xcodeproj#256](https://github.com/CocoaPods/Xcodeproj/pull/256)
+
 #### Bug Fixes
 
 * Save xcconfig files also if only the includes where modified by fixing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
   [Marius Rackwitz](https://github.com/mrackwitz)
   [Xcodeproj#256](https://github.com/CocoaPods/Xcodeproj/pull/256)
 
+* `ProjectHelper`: Allow to create aggregate targets.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [Xcodeproj#260](https://github.com/CocoaPods/Xcodeproj/pull/260)
+
+* `ProjectHelper`: Give optional parameter of `configuration_list`
+  and `common_build_settings` the default value `nil`.  
+  [Marius Rackwitz](https://github.com/mrackwitz)
+  [Xcodeproj#260](https://github.com/CocoaPods/Xcodeproj/pull/260)
+
 #### Bug Fixes
 
 * Save xcconfig files also if only the includes where modified by fixing the

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -607,6 +607,31 @@ module Xcodeproj
       ProjectHelper.new_resources_bundle(self, name, platform, product_group)
     end
 
+    # Creates a new target and adds it to the project.
+    #
+    # The target is configured for the given platform and its file reference it
+    # is added to the {products_group}.
+    #
+    # The target is pre-populated with common build settings, and the
+    # appropriate Framework according to the platform is added to to its
+    # Frameworks phase.
+    #
+    # @param  [String] name
+    #         the name of the target.
+    #
+    # @param  [Array<AbstractTarget>] target_dependencies
+    #         targets, which should be added as dependencies.
+    #
+    # @return [PBXNativeTarget] the target.
+    #
+    def new_aggregate_target(name, target_dependencies = [])
+      ProjectHelper.new_aggregate_target(self, name).tap do |aggregate_target|
+        target_dependencies.each do |dep|
+          aggregate_target.add_dependency(dep)
+        end
+      end
+    end
+
     # Adds a new build configuration to the project and populates its with
     # default settings according to the provided type.
     #

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -469,11 +469,20 @@ module Xcodeproj
       end
     end
 
-    # @return [ObjectList<PBXNativeTarget>] A list of all the targets in the
+    # @return [ObjectList<AbstractTarget>] A list of all the targets in the
     #         project.
     #
     def targets
       root_object.targets
+    end
+
+    # @return [ObjectList<PBXNativeTarget>] A list of all the targets in the
+    #         project excluding aggregate targets.
+    #
+    def native_targets
+      root_object.targets.reject do |target|
+        target.is_a? PBXAggregateTarget
+      end
     end
 
     # @return [PBXGroup] The group which holds the product file references.

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -480,8 +480,8 @@ module Xcodeproj
     #         project excluding aggregate targets.
     #
     def native_targets
-      root_object.targets.reject do |target|
-        target.is_a? PBXAggregateTarget
+      root_object.targets.select do |target|
+        target.is_a? PBXNativeTarget
       end
     end
 

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -148,7 +148,7 @@ module Xcodeproj
       #
       # @return [XCConfigurationList] the generated configuration list.
       #
-      def self.configuration_list(project, platform, deployment_target = nil, target_product_type, language)
+      def self.configuration_list(project, platform = nil, deployment_target = nil, target_product_type, language)
         cl = project.new(XCConfigurationList)
         cl.default_configuration_is_visible = '0'
         cl.default_configuration_name = 'Release'
@@ -199,7 +199,7 @@ module Xcodeproj
       #
       # @return [Hash] The common build settings
       #
-      def self.common_build_settings(type, platform, deployment_target = nil, target_product_type = nil, language = :objc)
+      def self.common_build_settings(type, platform = nil, deployment_target = nil, target_product_type = nil, language = :objc)
         target_product_type = (Constants::PRODUCT_TYPE_UTI.find { |_, v| v == target_product_type } || [target_product_type || :application])[0]
         common_settings = Constants::COMMON_BUILD_SETTINGS
 

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -148,7 +148,7 @@ module Xcodeproj
       #
       # @return [XCConfigurationList] the generated configuration list.
       #
-      def self.configuration_list(project, platform = nil, deployment_target = nil, target_product_type, language)
+      def self.configuration_list(project, platform = nil, deployment_target = nil, target_product_type = nil, language = nil)
         cl = project.new(XCConfigurationList)
         cl.default_configuration_is_visible = '0'
         cl.default_configuration_name = 'Release'

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -123,6 +123,26 @@ module Xcodeproj
         target
       end
 
+      # Creates a new aggregate target and adds it to the project.
+      #
+      # The target is configured for the given platform.
+      #
+      # @param  [Project] project
+      #         the project to which the target should be added.
+      #
+      # @param  [String] name
+      #         the name of the aggregate target.
+      #
+      # @return [PBXAggregateTarget] the target.
+      #
+      def self.new_aggregate_target(project, name)
+        target = project.new(PBXAggregateTarget)
+        project.targets << target
+        target.name = name
+        target.build_configuration_list = configuration_list(project)
+        target
+      end
+
       # @!group Private Helpers
 
       #-----------------------------------------------------------------------#

--- a/spec/project/project_helper_spec.rb
+++ b/spec/project/project_helper_spec.rb
@@ -63,6 +63,20 @@ module ProjectSpecs
 
         target.build_phases.map(&:isa).sort.should == %w(PBXFrameworksBuildPhase PBXResourcesBuildPhase PBXSourcesBuildPhase)
       end
+
+      it 'creates a new aggregate target' do
+        target = @helper.new_aggregate_target(@project, 'Pods')
+        target.name.should == 'Pods'
+        target.product_name.should.be.nil
+
+        target.build_configuration_list.should.not.be.nil
+        configurations = target.build_configuration_list.build_configurations
+        configurations.map(&:name).sort.should == %w(Debug Release)
+
+        @project.targets.should.include target
+
+        target.build_phases.count.should == 0
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -315,6 +315,14 @@ module ProjectSpecs
         @project.targets.should.include?(target)
       end
 
+      it 'returns the native targets' do
+        native_target = @project.new_target(:static_library, 'Pods', :ios)
+        aggregate_target = @project.new_aggregate_target('Trees')
+        native_targets = @project.native_targets
+        native_targets.should.include?(native_target)
+        native_targets.should.not.include?(aggregate_target)
+      end
+
       it 'returns the products group' do
         g = @project.products_group
         g.class.should == PBXGroup

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -317,10 +317,11 @@ module ProjectSpecs
 
       it 'returns the native targets' do
         native_target = @project.new_target(:static_library, 'Pods', :ios)
-        aggregate_target = @project.new_aggregate_target('Trees')
+        @project.new_aggregate_target('Trees')
+        @project.targets << @project.new(PBXLegacyTarget)
         native_targets = @project.native_targets
         native_targets.should.include?(native_target)
-        native_targets.should.not.include?(aggregate_target)
+        native_targets.count.should == 1
       end
 
       it 'returns the products group' do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -412,6 +412,13 @@ module ProjectSpecs
         target.product_type.should == 'com.apple.product-type.bundle'
       end
 
+      it 'creates a new aggregate target' do
+        native_target = @project.new_target(:static_library, 'BananaLib', :ios, '6.0')
+        aggregate_target = @project.new_aggregate_target('Pods', [native_target])
+        aggregate_target.name.should == 'Pods'
+        aggregate_target.dependencies.first.target.should == native_target
+      end
+
       #----------------------------------------#
 
       describe '#add_build_configuration' do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -311,8 +311,8 @@ module ProjectSpecs
       end
 
       it 'returns the targets' do
-        target = @project.new_target(:static_library, 'Pods', :ios).product_reference
-        @project.products.should.include?(target)
+        target = @project.new_target(:static_library, 'Pods', :ios)
+        @project.targets.should.include?(target)
       end
 
       it 'returns the products group' do


### PR DESCRIPTION
This supersedes #256.
This adds methods to:
* Return a list of project targets ~~excluding aggregate targets~~ including only native targets
* Create new aggregate targets