### PR TITLE
PBXContainerItemProxy proxyType is a numeric field

### DIFF
--- a/lib/xcodeproj/project/object/container_item_proxy.rb
+++ b/lib/xcodeproj/project/object/container_item_proxy.rb
@@ -44,7 +44,7 @@ module Xcodeproj
         #
         # @note   @see {Constants::PROXY_TYPE.values} for valid values.
         #
-        attribute :proxy_type, String
+        attribute :proxy_type, Fixnum
 
         # @return [String] apparently the UUID of the represented
         #         object.

--- a/spec/project/object/container_item_proxy_spec.rb
+++ b/spec/project/object/container_item_proxy_spec.rb
@@ -12,8 +12,8 @@ module ProjectSpecs
     end
 
     it 'returns the type of the proxy' do
-      @proxy.proxy_type = '1'
-      @proxy.proxy_type.should == '1'
+      @proxy.proxy_type = 1
+      @proxy.proxy_type.should == 1
     end
 
     it 'returns the remote global id string' do

--- a/spec/project/object/helpers/file_references_factory_spec.rb
+++ b/spec/project/object/helpers/file_references_factory_spec.rb
@@ -225,7 +225,7 @@ module ProjectSpecs
 
         container_proxies.uniq.count.should == 3
         container_proxies.map(&:container_portal).uniq.should == [@ref.uuid]
-        container_proxies.map(&:proxy_type).uniq.should == ['2']
+        container_proxies.map(&:proxy_type).uniq.should == [2]
         container_proxies.map(&:remote_info).uniq.should == ['Subproject']
 
         container_proxy = container_proxies.first

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -201,7 +201,7 @@ module ProjectSpecs
           target_dependency.target.should == dependency_target
           container_proxy = target_dependency.target_proxy
           container_proxy.container_portal.should == @project.root_object.uuid
-          container_proxy.proxy_type.should == '1'
+          container_proxy.proxy_type.should == 1
           container_proxy.remote_global_id_string.should == dependency_target.uuid
           container_proxy.remote_info.should == dependency_target.name
         end

--- a/spec/project/object/target_dependency_spec.rb
+++ b/spec/project/object/target_dependency_spec.rb
@@ -23,7 +23,7 @@ module ProjectSpecs
       proxy = @project.new(PBXContainerItemProxy)
       proxy.container_portal = @project.root_object.uuid
       proxy.remote_info = 'Pods'
-      proxy.proxy_type = '1'
+      proxy.proxy_type = 1
       proxy.remote_global_id_string = target.uuid
 
       @target_dependency.target_proxy = proxy

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -1,7 +1,6 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/xcodeproj/gem_version', __FILE__)
- 
- 
+
 Gem::Specification.new do |s|
   s.name     = "xcodeproj"
   s.version  = Xcodeproj::VERSION

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -1,6 +1,7 @@
 # -*- encoding: utf-8 -*-
 require File.expand_path('../lib/xcodeproj/gem_version', __FILE__)
-
+ 
+ 
 Gem::Specification.new do |s|
   s.name     = "xcodeproj"
   s.version  = Xcodeproj::VERSION


### PR DESCRIPTION
proxyType is a numeric field not a string. This change corrects the type expected