### PR TITLE
Support for native watch app targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Ensure that duplicate resources or source files aren't added to a target.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Support for native watch app targets.  
+  [Boris Bügling](https://github.com/neonichu)
+  [Xcodeproj#272](https://github.com/CocoaPods/Xcodeproj/pull/272)
+
 ##### Bug Fixes
 
 * Fix the help output for `xcodeproj config-dump`.  

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -10,6 +10,9 @@ module Xcodeproj
     #
     LAST_KNOWN_OSX_SDK  = '10.10'
 
+    # @return [String] The last known watchOS SDK (unstable).
+    LAST_KNOWN_WATCHOS_SDK = '2.0'
+
     # @return [String] The last known archive version to Xcodeproj.
     #
     LAST_KNOWN_ARCHIVE_VERSION = 1
@@ -101,7 +104,9 @@ module Xcodeproj
       :app_extension     => 'com.apple.product-type.app-extension',
       :command_line_tool => 'com.apple.product-type.tool',
       :watch_app         => 'com.apple.product-type.application.watchapp',
+      :watch2_app        => 'com.apple.product-type.application.watchapp2',
       :watch_extension   => 'com.apple.product-type.watchkit-extension',
+      :watch2_extension  => 'com.apple.product-type.watchkit2-extension',
     }.freeze
 
     # @return [Hash] The extensions or the various product UTIs.
@@ -133,6 +138,9 @@ module Xcodeproj
       }.freeze,
       [:osx] => {
         'SDKROOT'                           => 'macosx',
+      }.freeze,
+      [:watchos] => {
+        'SDKROOT'                           => 'watchos',
       }.freeze,
       [:debug, :osx] => {
         # Empty?

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -23,7 +23,7 @@ module Xcodeproj
 
     # @return [String] The last known object version to Xcodeproj.
     #
-    LAST_UPGRADE_CHECK  = '0640'
+    LAST_UPGRADE_CHECK  = '0700'
 
     # @return [Hash] The all the known ISAs grouped by superclass.
     #

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -110,10 +110,10 @@ module Xcodeproj
         #         platform.
         #
         def deployment_target
-          if platform_name == :ios
-            common_resolved_build_setting('IPHONEOS_DEPLOYMENT_TARGET')
-          else
-            common_resolved_build_setting('MACOSX_DEPLOYMENT_TARGET')
+          case platform_name
+          when :ios then common_resolved_build_setting('IPHONEOS_DEPLOYMENT_TARGET')
+          when :osx then common_resolved_build_setting('MACOSX_DEPLOYMENT_TARGET')
+          when :watchos then common_resolved_build_setting('WATCHOS_DEPLOYMENT_TARGET')
           end
         end
 

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -93,6 +93,8 @@ module Xcodeproj
             :ios
           elsif sdk.include? 'macosx'
             :osx
+          elsif sdk.include? 'watchos'
+            :watchos
           end
         end
 
@@ -294,6 +296,10 @@ module Xcodeproj
               group = project.frameworks_group['OS X'] || project.frameworks_group.new_group('OS X')
               path_sdk_name = 'MacOSX'
               path_sdk_version = sdk_version || Constants::LAST_KNOWN_OSX_SDK
+            when :watchos
+              group = project.frameworks_group['watchOS'] || project.frameworks_group.new_group('watchOS')
+              path_sdk_name = 'WatchOS'
+              path_sdk_version = sdk_version || Constants::LAST_KNOWN_WATCHOS_SDK
             else
               raise 'Unknown platform for target'
             end

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -59,7 +59,7 @@ module Xcodeproj
         target.build_phases << project.new(PBXFrameworksBuildPhase)
 
         # Frameworks
-        framework_name = (platform == :ios) ? 'Foundation' : 'Cocoa'
+        framework_name = (platform == :osx) ? 'Cocoa' : 'Foundation'
         target.add_system_framework(framework_name)
 
         target

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -234,10 +234,10 @@ module Xcodeproj
         end
 
         if deployment_target
-          if platform == :ios
-            settings['IPHONEOS_DEPLOYMENT_TARGET'] = deployment_target
-          elsif platform == :osx
-            settings['MACOSX_DEPLOYMENT_TARGET'] = deployment_target
+          case platform
+          when :ios then settings['IPHONEOS_DEPLOYMENT_TARGET'] = deployment_target
+          when :osx then settings['MACOSX_DEPLOYMENT_TARGET'] = deployment_target
+          when :watchos then settings['WATCHOS_DEPLOYMENT_TARGET'] = deployment_target
           end
         end
 

--- a/lib/xcodeproj/xcodebuild_helper.rb
+++ b/lib/xcodeproj/xcodebuild_helper.rb
@@ -20,6 +20,13 @@ module Xcodeproj
       verions_by_sdk[:osx].sort.last
     end
 
+    # @return [String] The version of the last watchOS sdk.
+    #
+    def last_watchos_sdk
+      parse_sdks_if_needed
+      verions_by_sdk[:watchos].sort.last
+    end
+
     private
 
     # !@group Private Helpers
@@ -38,12 +45,14 @@ module Xcodeproj
         @verions_by_sdk = {}
         @verions_by_sdk[:osx] = []
         @verions_by_sdk[:ios] = []
+        @verions_by_sdk[:watchos] = []
         if xcodebuild_available?
           skds = parse_sdks_information(xcodebuild_sdks)
           skds.each do |(name, version)|
             case
             when name == 'macosx' then @verions_by_sdk[:osx] << version
             when name == 'iphoneos' then @verions_by_sdk[:ios] << version
+            when name == 'watchos' then @verions_by_sdk[:watchos] << version
             end
           end
         end
@@ -64,7 +73,7 @@ module Xcodeproj
     #         is the name of the SDK and the second is the version.
     #
     def parse_sdks_information(output)
-      output.scan(/-sdk (macosx|iphoneos)(.+\w)/)
+      output.scan(/-sdk (macosx|iphoneos|watchos)(.+\w)/)
     end
 
     # @return [String] The sdk information reported by xcodebuild.

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -122,6 +122,10 @@ module ProjectSpecs
         t2 = @project.new_target(:static_library, 'Pods', :osx)
         t2.build_configuration_list.set_setting('SDKROOT', 'macosx10.8')
         t2.sdk_version.should == '10.8'
+
+        t3 = @project.new_target(:static_library, 'Pods', :watchos)
+        t3.build_configuration_list.set_setting('SDKROOT', 'watchos2.0')
+        t3.sdk_version.should == '2.0'
       end
 
       describe 'returns the deployment target specified in its build configuration' do
@@ -133,6 +137,11 @@ module ProjectSpecs
         it 'works for OSX' do
           @project.build_configuration_list.set_setting('MACOSX_DEPLOYMENT_TARGET', nil)
           @project.new_target(:static_library, 'Pods', :osx, '10.7').deployment_target.should == '10.7'
+        end
+
+        it 'works for watchOS' do
+          @project.build_configuration_list.set_setting('WATCHOS_DEPLOYMENT_TARGET', nil)
+          @project.new_target(:static_library, 'Pods', :watchos, '2.0').deployment_target.should == '2.0'
         end
       end
 
@@ -149,6 +158,13 @@ module ProjectSpecs
           osx_target = @project.new_target(:static_library, 'Pods', :osx)
           osx_target.build_configurations.first.build_settings['MACOSX_DEPLOYMENT_TARGET'] = nil
           osx_target.deployment_target.should == '10.7'
+        end
+
+        it 'works for watchOS' do
+          @project.build_configuration_list.set_setting('WATCHOS_DEPLOYMENT_TARGET', '2.0')
+          watch_target = @project.new_target(:static_library, 'Pods', :watchos)
+          watch_target.build_configurations.first.build_settings['WATCHOS_DEPLOYMENT_TARGET'] = nil
+          watch_target.deployment_target.should == '2.0'
         end
       end
 
@@ -345,6 +361,13 @@ module ProjectSpecs
           @target.add_system_framework('QuartzCore')
           file = @project['Frameworks/iOS'].files.first
           file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_IOS_SDK
+        end
+
+        it 'uses the last known watchOS SDK version if none is specified in the target' do
+          @target.build_configuration_list.set_setting('SDKROOT', 'watchos')
+          @target.add_system_framework('WatchConnectivity')
+          file = @project['Frameworks/watchOS'].files.first
+          file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_WATCHOS_SDK
         end
 
         it "doesn't duplicate references to a frameworks if one already exists" do

--- a/spec/project/project_helper_spec.rb
+++ b/spec/project/project_helper_spec.rb
@@ -27,6 +27,24 @@ module ProjectSpecs
         target.build_phases.map(&:isa).sort.should == %w(PBXFrameworksBuildPhase PBXSourcesBuildPhase)
       end
 
+      it 'creates a new watchOS target' do
+        target = @helper.new_target(@project, :static_library, 'Pods', :watchos, '2.0', @project.products_group, :objc)
+        target.name.should == 'Pods'
+        target.product_type.should == 'com.apple.product-type.library.static'
+
+        target.build_configuration_list.should.not.be.nil
+        configurations = target.build_configuration_list.build_configurations
+        configurations.map(&:name).sort.should == %w(Debug Release)
+        build_settings = configurations.first.build_settings
+        build_settings['WATCHOS_DEPLOYMENT_TARGET'].should == '2.0'
+        build_settings['SDKROOT'].should == 'watchos'
+
+        @project.targets.should.include target
+        @project.products.should.include target.product_reference
+
+        target.build_phases.map(&:isa).sort.should == %w(PBXFrameworksBuildPhase PBXSourcesBuildPhase)
+      end
+
       it 'uses default build settings for Release and Debug configurations' do
         target = @helper.new_target(@project, :static_library, 'Pods', :ios, '6.0', @project.products_group, :objc)
         debug_settings = @helper.common_build_settings(:debug, :ios, '6.0', :static_library)

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -29,7 +29,7 @@ module ProjectSpecs
         @scheme.to_s[0..190].should == <<-DOC.strip_heredoc
         <?xml version="1.0" encoding="UTF-8"?>
         <Scheme
-           LastUpgradeVersion = "0640"
+           LastUpgradeVersion = "0700"
            version = "1.3">
            <BuildAction
               parallelizeBuildables = "YES"

--- a/spec/xcodebuild_helper_spec.rb
+++ b/spec/xcodebuild_helper_spec.rb
@@ -11,6 +11,12 @@ iOS SDKs:
 
 iOS Simulator SDKs:
 	Simulator - iOS 6.1           	-sdk iphonesimulator6.1
+
+watchOS SDKs:
+  Watch OS 2.0                    -sdk watchos2.0
+
+watchOS Simulator SDKs:
+  Simulator - Watch OS 2.0        -sdk watchsimulator2.0
 DOC
 # rubocop:enable Style/Tab
 
@@ -35,6 +41,10 @@ module Xcodeproj
       it 'returns the last OS X SDK' do
         @helper.last_osx_sdk.should == '10.8'
       end
+
+      it 'returns the last watchOS SDK' do
+        @helper.last_watchos_sdk.should == '2.0'
+      end
     end
 
     #--------------------------------------------------------------------------------#
@@ -55,7 +65,7 @@ module Xcodeproj
       describe '#parse_sdks_information' do
         it 'parses the skds information returned by xcodebuild' do
           result = @helper.send(:parse_sdks_information, SPEC_XCODEBUILD_SAMPLE_SDK_OTPUT)
-          result.should == [['macosx', '10.7'], ['macosx', '10.8'], ['iphoneos', '6.1']]
+          result.should == [['macosx', '10.7'], ['macosx', '10.8'], ['iphoneos', '6.1'], ['watchos', '2.0']]
         end
       end
     end


### PR DESCRIPTION
This adds support for the new `com.apple.product-type.application.watchapp2` and `com.apple.product-type.watchkit2-extension`, as well as the minimum support for a `watchos` platform.

This lays the groundwork for supporting watchOS as a new platform in CocoaPods.

Things yet to be addressed:

- [x] Specs
- [x] Changelog

See also CocoaPods/Core#249 and CocoaPods/Xcodeproj#272