### PR TITLE
fix incorrect SDKROOT parser

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -138,13 +138,13 @@ module Xcodeproj
         'MTL_ENABLE_DEBUG_INFO'             => 'NO',
       }.freeze,
       [:ios] => {
-        #'SDKROOT'                           => 'iphoneos',
+        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS" + LAST_KNOWN_IOS_SDK + ".sdk",
       }.freeze,
       [:osx] => {
-        'SDKROOT'                           => 'macosx',
+        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX" + LAST_KNOWN_OSX_SDK + ".sdk",
       }.freeze,
       [:watchos] => {
-        'SDKROOT'                           => 'watchos',
+        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/WatchOS.platform/Developer/SDKs/WatchOS" + LAST_KNOWN_WATCHOS_SDK + ".sdk",
       }.freeze,
       [:debug, :osx] => {
         # Empty?
@@ -225,11 +225,11 @@ module Xcodeproj
         'SKIP_INSTALL'                      => 'YES',
       }.freeze,
       [:ios, :bundle] => {
-        #'SDKROOT'                           => 'iphoneos',
+        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS" + LAST_KNOWN_IOS_SDK + ".sdk",
       }.freeze,
       [:osx, :bundle] => {
         'COMBINE_HIDPI_IMAGES'              => 'YES',
-        'SDKROOT'                           => 'macosx',
+        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX" + LAST_KNOWN_OSX_SDK + ".sdk",
         'INSTALL_PATH'                      => '$(LOCAL_LIBRARY_DIR)/Bundles',
       }.freeze,
     }.freeze

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -138,13 +138,13 @@ module Xcodeproj
         'MTL_ENABLE_DEBUG_INFO'             => 'NO',
       }.freeze,
       [:ios] => {
-        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS" + LAST_KNOWN_IOS_SDK + ".sdk",
+        'SDKROOT'                           => `xcrun xcode-select --print-path`.strip + "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS" + LAST_KNOWN_IOS_SDK + ".sdk",
       }.freeze,
       [:osx] => {
-        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX" + LAST_KNOWN_OSX_SDK + ".sdk",
+        'SDKROOT'                           => `xcrun xcode-select --print-path`.strip + "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX" + LAST_KNOWN_OSX_SDK + ".sdk",
       }.freeze,
       [:watchos] => {
-        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/WatchOS.platform/Developer/SDKs/WatchOS" + LAST_KNOWN_WATCHOS_SDK + ".sdk",
+        'SDKROOT'                           => `xcrun xcode-select --print-path`.strip + "/Platforms/WatchOS.platform/Developer/SDKs/WatchOS" + LAST_KNOWN_WATCHOS_SDK + ".sdk",
       }.freeze,
       [:debug, :osx] => {
         # Empty?
@@ -225,11 +225,11 @@ module Xcodeproj
         'SKIP_INSTALL'                      => 'YES',
       }.freeze,
       [:ios, :bundle] => {
-        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS" + LAST_KNOWN_IOS_SDK + ".sdk",
+        'SDKROOT'                           => `xcrun xcode-select --print-path`.strip + "/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS" + LAST_KNOWN_IOS_SDK + ".sdk",
       }.freeze,
       [:osx, :bundle] => {
         'COMBINE_HIDPI_IMAGES'              => 'YES',
-        'SDKROOT'                           => `xcode-select -print-path`.chomp('\n') + "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX" + LAST_KNOWN_OSX_SDK + ".sdk",
+        'SDKROOT'                           => `xcrun xcode-select --print-path`.strip + "/Platforms/MacOSX.platform/Developer/SDKs/MacOSX" + LAST_KNOWN_OSX_SDK + ".sdk",
         'INSTALL_PATH'                      => '$(LOCAL_LIBRARY_DIR)/Bundles',
       }.freeze,
     }.freeze

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -138,7 +138,7 @@ module Xcodeproj
         'MTL_ENABLE_DEBUG_INFO'             => 'NO',
       }.freeze,
       [:ios] => {
-        'SDKROOT'                           => 'iphoneos',
+        #'SDKROOT'                           => 'iphoneos',
       }.freeze,
       [:osx] => {
         'SDKROOT'                           => 'macosx',
@@ -225,7 +225,7 @@ module Xcodeproj
         'SKIP_INSTALL'                      => 'YES',
       }.freeze,
       [:ios, :bundle] => {
-        'SDKROOT'                           => 'iphoneos',
+        #'SDKROOT'                           => 'iphoneos',
       }.freeze,
       [:osx, :bundle] => {
         'COMBINE_HIDPI_IMAGES'              => 'YES',

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -89,12 +89,14 @@ module Xcodeproj
         # @return [Symbol] the name of the platform of the target.
         #
         def platform_name
-          if sdk.include? 'iphoneos'
-            :ios
-          elsif sdk.include? 'macosx'
-            :osx
-          elsif sdk.include? 'watchos'
-            :watchos
+          if sdk
+            if sdk.scan(/iphoneos/i)
+              :ios
+            elsif sdk.scan(/macosx/i)
+              :osx
+            elsif sdk.scan(/watchos/i)
+              :watchos
+            end
           end
         end
 
@@ -102,7 +104,10 @@ module Xcodeproj
         #
         def sdk_version
           if sdk
-            sdk.scan(/[0-9.]+/).first
+            value = sdk.scan(/[0-9][0-9.]*/).last
+            if value
+              value.chomp(".")
+            end
           end
         end
 


### PR DESCRIPTION
Hi, I think this function `sdk_version` in native_target.rb can't handle the full SDKROOT path well, for example,
```rb
main_target_settings = {"SDKROOT"=>"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.1.sdk"}

main_target_settings.each{|key, value| target.build_settings("Debug")[key] = value}
main_target_settings.each{|key, value| target.build_settings("Release")[key] = value}

puts target.sdk_version()  # this line will output "." not "8.1"
```
Because of this, the function `add_system_framework` will add the wrong path if I set the SDKROOT.
so, I changed some lines to fix this.  
