### PR TITLE
Allow manipulation of existing xcscheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Xcodeproj Changelog
 
+## Master
+
+##### Enhancements
+
+* Added the ability to load an existing `.xcscheme` file and manipulate
+  it using `Xcodeproj::XCScheme`.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [Xcodeproj#288](https://github.com/CocoaPods/Xcodeproj/pull/288)
+
 ## 0.26.3
 
 ##### Bug Fixes

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -32,6 +32,10 @@ module Xcodeproj
     #
     LAST_SWIFT_UPGRADE_CHECK = '0700'
 
+    # @return [String] The version of `.xcscheme` files supported by Xcodeproj
+    #
+    XCSCHEME_FORMAT_VERSION = '1.3'
+
     # @return [Hash] The all the known ISAs grouped by superclass.
     #
     KNOWN_ISAS = {

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -104,6 +104,7 @@ module Xcodeproj
       :dynamic_library   => 'com.apple.product-type.library.dynamic',
       :static_library    => 'com.apple.product-type.library.static',
       :bundle            => 'com.apple.product-type.bundle',
+      :octest_bundle     => 'com.apple.product-type.bundle',
       :unit_test_bundle  => 'com.apple.product-type.bundle.unit-test',
       :app_extension     => 'com.apple.product-type.app-extension',
       :command_line_tool => 'com.apple.product-type.tool',
@@ -116,11 +117,13 @@ module Xcodeproj
     # @return [Hash] The extensions or the various product UTIs.
     #
     PRODUCT_UTI_EXTENSIONS = {
-      :application     => 'app',
-      :framework       => 'framework',
-      :dynamic_library => 'dylib',
-      :static_library  => 'a',
-      :bundle          => 'bundle',
+      :application      => 'app',
+      :framework        => 'framework',
+      :dynamic_library  => 'dylib',
+      :static_library   => 'a',
+      :bundle           => 'bundle',
+      :octest_bundle    => 'octest',
+      :unit_test_bundle => 'xctest',
     }.freeze
 
     # @return [Hash] The common build settings grouped by platform, and build

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -45,7 +45,12 @@ module Xcodeproj
         @scheme.attributes['LastUpgradeVersion'] = Constants::LAST_UPGRADE_CHECK
         @scheme.attributes['version'] = XCSCHEME_FORMAT_VERSION
 
-        self.build_action = BuildAction.new
+        self.build_action   = BuildAction.new
+        self.test_action    = TestAction.new
+        self.launch_action  = LaunchAction.new
+        self.profile_action = ProfileAction.new
+        self.analyze_action = AnalyzeAction.new
+        self.archive_action = ArchiveAction.new
       end
     end
 
@@ -61,22 +66,12 @@ module Xcodeproj
     #        The target to use for the 'Test' action
     #
     def configure_with_targets(runnable_target, test_target)
-      build_action = BuildAction.new
       build_action.add_entry BuildAction::Entry.new(runnable_target) if runnable_target
       build_action.add_entry BuildAction::Entry.new(test_target) if test_target
 
-      test_action = TestAction.new
       test_action.add_testable TestAction::TestableReference.new(test_target) if test_target
-
-      launch_action = LaunchAction.new
       launch_action.build_product_runnable = BuildableProductRunnable.new(runnable_target) if runnable_target
-
-      profile_action = ProfileAction.new
       profile_action.build_product_runnable = BuildableProductRunnable.new(runnable_target) if runnable_target
-
-      analyze_action = AnalyzeAction.new
-
-      archive_action = ArchiveAction.new
     end
 
     public
@@ -172,7 +167,6 @@ module Xcodeproj
     #
     def add_test_target(test_target)
       testable = TestAction::TestableReference.new(test_target)
-
       test_action.add_testable(testable)
     end
 
@@ -183,11 +177,11 @@ module Xcodeproj
     #
     def set_launch_target(build_target)
       launch_runnable = BuildableProductRunnable.new(build_target)
-      launch_runnable.buildable_reference.buildable_name = "#{build_target.name}.app"
+      #launch_runnable.buildable_reference.buildable_name = "#{build_target.name}.app"
       launch_action.build_product_runnable = launch_runnable
 
       profile_runnable = BuildableProductRunnable.new(build_target)
-      profile_runnable.buildable_reference.buildable_name = "#{build_target.name}.app"
+      #profile_runnable.buildable_reference.buildable_name = "#{build_target.name}.app"
       profile_action.build_product_runnable = profile_runnable
 
       macro_exp = MacroExpansion.new(build_target)

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -76,60 +76,96 @@ module Xcodeproj
 
     # @!group Access Action nodes
 
+    # @return [XCScheme::BuildAction]
+    #         The Build Action associated with this scheme
+    #
     def build_action
       @build_action ||= BuildAction.new(@scheme.elements['BuildAction'])
     end
 
+    # @param [XCScheme::BuildAction] action
+    #        The Build Action to associate to this scheme
+    #
     def build_action=(action)
       @scheme.delete_element('BuildAction')
       @scheme.add_element(action.xml_element)
       @build_action = action
     end
 
+    # @return [XCScheme::TestAction]
+    #         The Test Action associated with this scheme
+    #
     def test_action
       @test_action ||= TestAction.new(@scheme.elements['TestAction'])
     end
 
+    # @param [XCScheme::TestAction] action
+    #        The Test Action to associate to this scheme
+    #
     def test_action=(action)
       @scheme.delete_element('TestAction')
       @scheme.add_element(action.xml_element)
       @test_action = action
     end
 
+    # @return [XCScheme::LaunchAction]
+    #         The Launch Action associated with this scheme
+    #
     def launch_action
       @launch_action ||= LaunchAction.new(@scheme.elements['LaunchAction'])
     end
 
+    # @param [XCScheme::LaunchAction] action
+    #        The Launch Action to associate to this scheme
+    #
     def launch_action=(action)
       @scheme.delete_element('LaunchAction')
       @scheme.add_element(action.xml_element)
       @launch_action = action
     end
 
+    # @return [XCScheme::ProfileAction]
+    #         The Profile Action associated with this scheme
+    #
     def profile_action
       @profile_action ||= ProfileAction.new(@scheme.elements['ProfileAction'])
     end
 
+    # @param [XCScheme::ProfileAction] action
+    #        The Profile Action to associate to this scheme
+    #
     def profile_action=(action)
       @scheme.delete_element('ProfileAction')
       @scheme.add_element(action.xml_element)
       @profile_action = action
     end
 
+    # @return [XCScheme::AnalyzeAction]
+    #         The Analyze Action associated with this scheme
+    #
     def analyze_action
       @analyze_action ||= AnalyzeAction.new(@scheme.elements['AnalyzeAction'])
     end
 
+    # @param [XCScheme::AnalyzeAction] action
+    #        The Analyze Action to associate to this scheme
+    #
     def analyze_action=(action)
       @scheme.delete_element('AnalyzeAction')
       @scheme.add_element(action.xml_element)
       @analyze_action = action
     end
 
+    # @return [XCScheme::ArchiveAction]
+    #         The Archive Action associated with this scheme
+    #
     def archive_action
       @archive_action ||= ArchiveAction.new(@scheme.elements['ArchiveAction'])
     end
 
+    # @param [XCScheme::ArchiveAction] action
+    #        The Archive Action to associate to this scheme
+    #
     def archive_action=(action)
       @scheme.delete_element('ArchiveAction')
       @scheme.add_element(action.xml_element)

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -33,9 +33,9 @@ module Xcodeproj
       if file_path
         @doc = REXML::Document.new(File.new(file_path))
         @doc.context[:attribute_quote] = :quote
-        
+
         @scheme = @doc.elements['Scheme']
-        raise Informative , 'Unsupported scheme version' unless @scheme.attributes['version'] == XCSCHEME_FORMAT_VERSION
+        raise Informative, 'Unsupported scheme version' unless @scheme.attributes['version'] == XCSCHEME_FORMAT_VERSION
       else
         @doc = REXML::Document.new
         @doc.context[:attribute_quote] = :quote

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -33,7 +33,6 @@ module Xcodeproj
         @doc.context[:attribute_quote] = :quote
 
         @scheme = @doc.elements['Scheme']
-        raise Informative, 'Unsupported scheme version' unless @scheme.attributes['version'] == Xcodeproj::Constants::XCSCHEME_FORMAT_VERSION
       else
         @doc = REXML::Document.new
         @doc.context[:attribute_quote] = :quote

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -70,8 +70,8 @@ module Xcodeproj
       build_action.add_entry BuildAction::Entry.new(test_target) if test_target
 
       test_action.add_testable TestAction::TestableReference.new(test_target) if test_target
-      launch_action.build_product_runnable = BuildableProductRunnable.new(runnable_target, 0) if runnable_target
-      profile_action.build_product_runnable = BuildableProductRunnable.new(runnable_target) if runnable_target
+      launch_action.buildable_product_runnable = BuildableProductRunnable.new(runnable_target, 0) if runnable_target
+      profile_action.buildable_product_runnable = BuildableProductRunnable.new(runnable_target) if runnable_target
     end
 
     public
@@ -177,10 +177,10 @@ module Xcodeproj
     #
     def set_launch_target(build_target)
       launch_runnable = BuildableProductRunnable.new(build_target, 0)
-      launch_action.build_product_runnable = launch_runnable
+      launch_action.buildable_product_runnable = launch_runnable
 
       profile_runnable = BuildableProductRunnable.new(build_target)
-      profile_action.build_product_runnable = profile_runnable
+      profile_action.buildable_product_runnable = profile_runnable
 
       macro_exp = MacroExpansion.new(build_target)
       test_action.add_macro_expansion(macro_exp)

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -70,7 +70,7 @@ module Xcodeproj
       build_action.add_entry BuildAction::Entry.new(test_target) if test_target
 
       test_action.add_testable TestAction::TestableReference.new(test_target) if test_target
-      launch_action.build_product_runnable = BuildableProductRunnable.new(runnable_target) if runnable_target
+      launch_action.build_product_runnable = BuildableProductRunnable.new(runnable_target, 0) if runnable_target
       profile_action.build_product_runnable = BuildableProductRunnable.new(runnable_target) if runnable_target
     end
 
@@ -176,12 +176,10 @@ module Xcodeproj
     #        A target used by scheme in the launch step.
     #
     def set_launch_target(build_target)
-      launch_runnable = BuildableProductRunnable.new(build_target)
-      #launch_runnable.buildable_reference.buildable_name = "#{build_target.name}.app"
+      launch_runnable = BuildableProductRunnable.new(build_target, 0)
       launch_action.build_product_runnable = launch_runnable
 
       profile_runnable = BuildableProductRunnable.new(build_target)
-      #profile_runnable.buildable_reference.buildable_name = "#{build_target.name}.app"
       profile_action.build_product_runnable = profile_runnable
 
       macro_exp = MacroExpansion.new(build_target)

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -17,8 +17,6 @@ module Xcodeproj
   # folder.
   #
   class XCScheme
-    XCSCHEME_FORMAT_VERSION = '1.3'
-
     # @return [REXML::Document] the XML object that will be manipulated to save
     #         the scheme file after.
     #
@@ -35,7 +33,7 @@ module Xcodeproj
         @doc.context[:attribute_quote] = :quote
 
         @scheme = @doc.elements['Scheme']
-        raise Informative, 'Unsupported scheme version' unless @scheme.attributes['version'] == XCSCHEME_FORMAT_VERSION
+        raise Informative, 'Unsupported scheme version' unless @scheme.attributes['version'] == Xcodeproj::Constants::XCSCHEME_FORMAT_VERSION
       else
         @doc = REXML::Document.new
         @doc.context[:attribute_quote] = :quote
@@ -43,7 +41,7 @@ module Xcodeproj
 
         @scheme = @doc.add_element 'Scheme'
         @scheme.attributes['LastUpgradeVersion'] = Constants::LAST_UPGRADE_CHECK
-        @scheme.attributes['version'] = XCSCHEME_FORMAT_VERSION
+        @scheme.attributes['version'] = Xcodeproj::Constants::XCSCHEME_FORMAT_VERSION
 
         self.build_action   = BuildAction.new
         self.test_action    = TestAction.new

--- a/lib/xcodeproj/scheme/abstract_scheme_action.rb
+++ b/lib/xcodeproj/scheme/abstract_scheme_action.rb
@@ -1,0 +1,15 @@
+require 'xcodeproj/scheme/xml_element_wrapper'
+
+module Xcodeproj
+  class XCScheme
+    class AbstractSchemeAction < XMLElementWrapper
+      def build_configuration
+        @xml_element.attributes['buildConfiguration']
+      end
+
+      def build_configuration=(config_name)
+        @xml_element.attributes['buildConfiguration'] = config_name
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/abstract_scheme_action.rb
+++ b/lib/xcodeproj/scheme/abstract_scheme_action.rb
@@ -2,11 +2,22 @@ require 'xcodeproj/scheme/xml_element_wrapper'
 
 module Xcodeproj
   class XCScheme
+    # This abstract class aims to be the base class for every XxxAction class
+    # that have a #build_configuration attribute
+    #
     class AbstractSchemeAction < XMLElementWrapper
+      # @return [String]
+      #         The build configuration associated with this action
+      #         (usually either 'Debug' or 'Release')
+      #
       def build_configuration
         @xml_element.attributes['buildConfiguration']
       end
 
+      # @param [String] config_name
+      #        The build configuration to associate with this action
+      #        (usually either 'Debug' or 'Release')
+      #
       def build_configuration=(config_name)
         @xml_element.attributes['buildConfiguration'] = config_name
       end

--- a/lib/xcodeproj/scheme/analyze_action.rb
+++ b/lib/xcodeproj/scheme/analyze_action.rb
@@ -1,18 +1,12 @@
+require 'xcodeproj/scheme/abstract_scheme_action'
+
 module Xcodeproj
   class XCScheme
-    class AnalyzeAction < XMLElementWrapper
+    class AnalyzeAction < AbstractSchemeAction
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'AnalyzeAction') do
           self.build_configuration = 'Debug'
         end
-      end
-
-      def build_configuration
-        @xml_element.attributes['buildConfiguration']
-      end
-
-      def build_configuration=(config_name)
-        @xml_element.attributes['buildConfiguration'] = config_name
       end
     end
   end

--- a/lib/xcodeproj/scheme/analyze_action.rb
+++ b/lib/xcodeproj/scheme/analyze_action.rb
@@ -1,0 +1,20 @@
+module Xcodeproj
+  class XCScheme
+    class AnalyzeAction < XMLElementWrapper
+
+      def initialize(node = nil)
+        create_xml_element_with_fallback(node, 'AnalyzeAction') do
+          self.build_configuration = 'Debug'
+        end
+      end
+
+      def build_configuration
+        @xml_element.attributes['buildConfiguration']
+      end
+
+      def build_configuration=(config_name)
+        @xml_element.attributes['buildConfiguration'] = config_name
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/analyze_action.rb
+++ b/lib/xcodeproj/scheme/analyze_action.rb
@@ -1,7 +1,6 @@
 module Xcodeproj
   class XCScheme
     class AnalyzeAction < XMLElementWrapper
-
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'AnalyzeAction') do
           self.build_configuration = 'Debug'

--- a/lib/xcodeproj/scheme/analyze_action.rb
+++ b/lib/xcodeproj/scheme/analyze_action.rb
@@ -2,7 +2,13 @@ require 'xcodeproj/scheme/abstract_scheme_action'
 
 module Xcodeproj
   class XCScheme
+    # This class wraps the AnalyzeAction node of a .xcscheme XML file
+    #
     class AnalyzeAction < AbstractSchemeAction
+      # @param [REXML::Element] node
+      #        The 'AnalyzeAction' XML node that this object will wrap.
+      #        If nil, will create a default XML node to use.
+      #
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'AnalyzeAction') do
           self.build_configuration = 'Debug'

--- a/lib/xcodeproj/scheme/archive_action.rb
+++ b/lib/xcodeproj/scheme/archive_action.rb
@@ -1,19 +1,13 @@
+require 'xcodeproj/scheme/abstract_scheme_action'
+
 module Xcodeproj
   class XCScheme
-    class ArchiveAction < XMLElementWrapper
+    class ArchiveAction < AbstractSchemeAction
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'ArchiveAction') do
           self.build_configuration = 'Release'
           self.reveal_archive_in_organizer = true
         end
-      end
-
-      def build_configuration
-        @xml_element.attributes['buildConfiguration']
-      end
-
-      def build_configuration=(config_name)
-        @xml_element.attributes['buildConfiguration'] = config_name
       end
 
       def reveal_archive_in_organizer?

--- a/lib/xcodeproj/scheme/archive_action.rb
+++ b/lib/xcodeproj/scheme/archive_action.rb
@@ -1,0 +1,41 @@
+module Xcodeproj
+  class XCScheme
+    class ArchiveAction < XMLElementWrapper
+
+      def initialize(node = nil)
+        create_xml_element_with_fallback(node, 'ArchiveAction') do
+          self.build_configuration = 'Release'
+          self.reveal_archive_in_organizer = true
+        end
+      end
+
+      def build_configuration
+        @xml_element.attributes['buildConfiguration']
+      end
+
+      def build_configuration=(config_name)
+        @xml_element.attributes['buildConfiguration'] = config_name
+      end
+
+      def reveal_archive_in_organizer?
+        string_to_bool(@xml_element.attributes['revealArchiveInOrganizer'])
+      end
+
+      def reveal_archive_in_organizer=(flag)
+        @xml_element.attributes['revealArchiveInOrganizer'] = bool_to_string(flag)
+      end
+
+      def custom_archive_name
+        @xml_element.attributes['customArchiveName']
+      end
+
+      def custom_archive_name=(name)
+        if name
+          @xml_element.attributes['customArchiveName'] = name
+        else
+          @xml_element.delete_attribute('customArchiveName')
+        end
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/archive_action.rb
+++ b/lib/xcodeproj/scheme/archive_action.rb
@@ -1,7 +1,6 @@
 module Xcodeproj
   class XCScheme
     class ArchiveAction < XMLElementWrapper
-
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'ArchiveAction') do
           self.build_configuration = 'Release'

--- a/lib/xcodeproj/scheme/archive_action.rb
+++ b/lib/xcodeproj/scheme/archive_action.rb
@@ -2,7 +2,13 @@ require 'xcodeproj/scheme/abstract_scheme_action'
 
 module Xcodeproj
   class XCScheme
+    # This class wraps the ArchiveAction node of a .xcscheme XML file
+    #
     class ArchiveAction < AbstractSchemeAction
+      # @param [REXML::Element] node
+      #        The 'ArchiveAction' XML node that this object will wrap.
+      #        If nil, will create a default XML node to use.
+      #
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'ArchiveAction') do
           self.build_configuration = 'Release'
@@ -10,18 +16,37 @@ module Xcodeproj
         end
       end
 
+      # @return [Bool]
+      #         Whether the Archive will be revealed in Xcode's Organizer
+      #         after it's done building.
+      #
       def reveal_archive_in_organizer?
         string_to_bool(@xml_element.attributes['revealArchiveInOrganizer'])
       end
 
+      # @param [Bool] flag
+      #        Set whether the Archive will be revealed in Xcode's Organizer
+      #        after it's done building.
+      #
       def reveal_archive_in_organizer=(flag)
         @xml_element.attributes['revealArchiveInOrganizer'] = bool_to_string(flag)
       end
 
+      # @return [String]
+      #         The custom name to give to the archive.
+      #         If nil, the generated archive will have the same name as the one
+      #         set in the associated target's Build Settings for the built product.
+      #
       def custom_archive_name
         @xml_element.attributes['customArchiveName']
       end
 
+      # @param [String] name
+      #        Set the custom name to use for the built archive
+      #        If nil, the customization of the archive name will be removed and
+      #        the generated archive will have the same name as the one set in the
+      #        associated target's Build Settings for the build product.
+      #
       def custom_archive_name=(name)
         if name
           @xml_element.attributes['customArchiveName'] = name

--- a/lib/xcodeproj/scheme/build_action.rb
+++ b/lib/xcodeproj/scheme/build_action.rb
@@ -24,7 +24,7 @@ module Xcodeproj
       end
 
       def build_implicit_dependencies?
-        bool_to_string(@xml_element.attributes['buildImplicitDependencies'])
+        string_to_bool(@xml_element.attributes['buildImplicitDependencies'])
       end
 
       def build_implicit_dependencies=(flag)

--- a/lib/xcodeproj/scheme/build_action.rb
+++ b/lib/xcodeproj/scheme/build_action.rb
@@ -2,12 +2,16 @@ require 'xcodeproj/scheme/xml_element_wrapper'
 
 module Xcodeproj
   class XCScheme
-    # Scheme action for "Build"
+    # This class wraps the BuildAction node of a .xcscheme XML file
     #
     # Note: It's not a AbstractSchemeAction like the others because it is
     # a special case of action (with no build_configuration, etc)
     #
     class BuildAction < XMLElementWrapper
+      # @param [REXML::Element] node
+      #        The 'BuildAction' XML node that this object will wrap.
+      #        If nil, will create a default XML node to use.
+      #
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'BuildAction') do
           self.parallelize_buildables = true
@@ -15,23 +19,37 @@ module Xcodeproj
         end
       end
 
+      # @return [Bool]
+      #         Whether or not to build the various targets in parallel
+      #
       def parallelize_buildables?
         string_to_bool(@xml_element.attributes['parallelizeBuildables'])
       end
 
+      # @param [Bool] flag
+      #        Set whether or not to build the various targets in parallel
+      #
       def parallelize_buildables=(flag)
         @xml_element.attributes['parallelizeBuildables'] = bool_to_string(flag)
       end
 
+      # @return [Bool]
+      #          Whether or not to detect and build implicit dependencies for each target
+      #
       def build_implicit_dependencies?
         string_to_bool(@xml_element.attributes['buildImplicitDependencies'])
       end
 
+      # @param [Bool] flag
+      #        Whether or not to detect and build implicit dependencies for each target
+      #
       def build_implicit_dependencies=(flag)
         @xml_element.attributes['buildImplicitDependencies'] = bool_to_string(flag)
       end
 
-      # [Array<BuildAction::Entry>]
+      # @return [Array<BuildAction::Entry>]
+      #         The list of BuildActionEntry nodes associated with this Build Action.
+      #         Each entry represent a target to build and tells for which action it's needed to be built.
       #
       def entries
         @xml_element.elements['BuildActionEntries'].get_elements('BuildActionEntry').map do |entry_node|
@@ -40,6 +58,7 @@ module Xcodeproj
       end
 
       # @param [BuildAction::Entry] entry
+      #        The BuildActionEntry to add to the list of targets to build for the various actions
       #
       def add_entry(entry)
         entries = @xml_element.elements['BuildActionEntries'] || @xml_element.add_element('BuildActionEntries')
@@ -75,47 +94,79 @@ module Xcodeproj
           end
         end
 
+        # @return [Bool]
+        #         Whether or not to build this target when building for Testing
+        #
         def build_for_testing?
           string_to_bool(@xml_element.attributes['buildForTesting'])
         end
 
+        # @param [Bool]
+        #        Set whether or not to build this target when building for Testing
+        #
         def build_for_testing=(flag)
           @xml_element.attributes['buildForTesting'] = bool_to_string(flag)
         end
 
+        # @return [Bool]
+        #         Whether or not to build this target when building for Running
+        #
         def build_for_running?
           string_to_bool(@xml_element.attributes['buildForRunning'])
         end
 
+        # @param [Bool]
+        #        Set whether or not to build this target when building for Running
+        #
         def build_for_running=(flag)
           @xml_element.attributes['buildForRunning'] = bool_to_string(flag)
         end
 
+        # @return [Bool]
+        #         Whether or not to build this target when building for Profiling
+        #
         def build_for_profiling?
           string_to_bool(@xml_element.attributes['buildForProfiling'])
         end
 
+        # @param [Bool]
+        #        Set whether or not to build this target when building for Profiling
+        #
         def build_for_profiling=(flag)
           @xml_element.attributes['buildForProfiling'] = bool_to_string(flag)
         end
 
+        # @return [Bool]
+        #         Whether or not to build this target when building for Archiving
+        #
         def build_for_archiving?
           string_to_bool(@xml_element.attributes['buildForArchiving'])
         end
 
+        # @param [Bool]
+        #        Set whether or not to build this target when building for Archiving
+        #
         def build_for_archiving=(flag)
           @xml_element.attributes['buildForArchiving'] = bool_to_string(flag)
         end
 
+        # @return [Bool]
+        #         Whether or not to build this target when building for Analyzing
+        #
         def build_for_analyzing?
           string_to_bool(@xml_element.attributes['buildForAnalyzing'])
         end
 
+        # @param [Bool]
+        #        Set whether or not to build this target when building for Analyzing
+        #
         def build_for_analyzing=(flag)
           @xml_element.attributes['buildForAnalyzing'] = bool_to_string(flag)
         end
 
         # @return [Array<BuildableReference>]
+        #         The list of BuildableReferences this entry will build.
+        #         (The list usually contains only one element)
         #
         def buildable_references
           @xml_element.get_elements('BuildableReference').map do |node|
@@ -124,6 +175,7 @@ module Xcodeproj
         end
 
         # @param [BuildableReference] ref
+        #         The BuildableReference to add to the list of targets this entry will build
         #
         def add_buildable_reference(ref)
           @xml_element.add_element(ref.xml_element)

--- a/lib/xcodeproj/scheme/build_action.rb
+++ b/lib/xcodeproj/scheme/build_action.rb
@@ -1,0 +1,127 @@
+require 'xcodeproj/scheme/xml_element_wrapper'
+
+module Xcodeproj
+  class XCScheme
+    class BuildAction < XMLElementWrapper
+
+      def initialize(node = nil)
+        create_xml_element_with_fallback(node, 'BuildAction') do
+          self.parallelize_buildables = true
+          self.build_implicit_dependencies = true
+        end
+      end
+
+      def parallelize_buildables?
+        string_to_bool(@xml_element.attributes['parallelizeBuildables'])
+      end
+
+      def parallelize_buildables=(flag)
+        @xml_element.attributes['parallelizeBuildables'] = bool_to_string(flag)
+      end
+
+      def build_implicit_dependencies?
+        bool_to_string(@xml_element.attributes['buildImplicitDependencies'])
+      end
+
+      def build_implicit_dependencies=(flag)
+        @xml_element.attributes['buildImplicitDependencies'] = bool_to_string(flag)
+      end
+
+      # [Array<BuildAction::Entry>]
+      #
+      def entries
+        @xml_element.elements['BuildActionEntries'].get_elements('BuildActionEntry').map do |entry_node|
+          BuildAction::Entry.new(entry_node)
+        end
+      end
+
+      # @param [BuildAction::Entry] entry
+      #
+      def add_entry(entry)
+        unless @xml_element.elements['BuildActionEntries']
+          @xml_element.add_element('BuildActionEntries')
+        end
+        @xml_element.elements['BuildActionEntries'].add_element(entry.xml_element)
+      end
+
+      #-------------------------------------------------------------------------#
+
+      class Entry < XMLElementWrapper
+
+        # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
+        #        Either the Xcode target to reference, 
+        #        or an existing XML 'BuildActionEntry' node element to reference,
+        #        or nil to create an new, empty Entry with default values
+        #
+        def initialize(target_or_node = nil)
+          create_xml_element_with_fallback(target_or_node, 'BuildActionEntry') do
+            native_target = target_or_node && target_or_node.is_a?(::Xcodeproj::Project::Object::PBXNativeTarget)
+            is_test_target = native_target && target_or_node.product_type == 'com.apple.product-type.bundle.unit-test'
+            is_app_target = native_target && target_or_node.product_type == 'com.apple.product-type.application'
+
+            self.build_for_analyzing = true
+            self.build_for_testing   = is_test_target
+            self.build_for_running   = is_app_target
+            self.build_for_profiling = is_app_target
+            self.build_for_archiving = is_app_target
+
+            self.add_buildable_reference BuildableReference.new(target_or_node) if target_or_node
+          end
+        end
+
+        def build_for_testing?
+          string_to_bool(@xml_element.attributes['buildForTesting'])
+        end
+
+        def build_for_testing=(flag)
+          @xml_element.attributes['buildForTesting'] = bool_to_string(flag)
+        end
+
+        def build_for_running?
+          string_to_bool(@xml_element.attributes['buildForRunning'])
+        end
+
+        def build_for_running=(flag)
+          @xml_element.attributes['buildForRunning'] = bool_to_string(flag)
+        end
+
+        def build_for_profiling?
+          string_to_bool(@xml_element.attributes['buildForProfiling'])
+        end
+        def build_for_profiling=(flag)
+          @xml_element.attributes['buildForProfiling'] = bool_to_string(flag)
+        end
+
+        def build_for_archiving?
+          string_to_bool(@xml_element.attributes['buildForArchiving'])
+        end
+        def build_for_archiving=(flag)
+          @xml_element.attributes['buildForArchiving'] = bool_to_string(flag)
+        end
+
+        def build_for_analyzing?
+          string_to_bool(@xml_element.attributes['buildForAnalyzing'])
+        end
+
+        def build_for_analyzing=(flag)
+          @xml_element.attributes['buildForAnalyzing'] = bool_to_string(flag)
+        end
+
+        # @return [Array<BuildableReference>]
+        #
+        def buildable_references
+          @xml_element.get_elements('BuildableReference').map do |node|
+            BuildableReference.new(node)
+          end
+        end
+
+        # @param [BuildableReference] ref
+        #
+        def add_buildable_reference(ref)
+          @xml_element.add_element(ref.xml_element)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/build_action.rb
+++ b/lib/xcodeproj/scheme/build_action.rb
@@ -3,7 +3,6 @@ require 'xcodeproj/scheme/xml_element_wrapper'
 module Xcodeproj
   class XCScheme
     class BuildAction < XMLElementWrapper
-
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'BuildAction') do
           self.parallelize_buildables = true
@@ -47,9 +46,8 @@ module Xcodeproj
       #-------------------------------------------------------------------------#
 
       class Entry < XMLElementWrapper
-
         # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
-        #        Either the Xcode target to reference, 
+        #        Either the Xcode target to reference,
         #        or an existing XML 'BuildActionEntry' node element to reference,
         #        or nil to create an new, empty Entry with default values
         #
@@ -65,7 +63,7 @@ module Xcodeproj
             self.build_for_profiling = is_app_target
             self.build_for_archiving = is_app_target
 
-            self.add_buildable_reference BuildableReference.new(target_or_node) if target_or_node
+            add_buildable_reference BuildableReference.new(target_or_node) if target_or_node
           end
         end
 
@@ -88,6 +86,7 @@ module Xcodeproj
         def build_for_profiling?
           string_to_bool(@xml_element.attributes['buildForProfiling'])
         end
+
         def build_for_profiling=(flag)
           @xml_element.attributes['buildForProfiling'] = bool_to_string(flag)
         end
@@ -95,6 +94,7 @@ module Xcodeproj
         def build_for_archiving?
           string_to_bool(@xml_element.attributes['buildForArchiving'])
         end
+
         def build_for_archiving=(flag)
           @xml_element.attributes['buildForArchiving'] = bool_to_string(flag)
         end
@@ -120,7 +120,6 @@ module Xcodeproj
         def add_buildable_reference(ref)
           @xml_element.add_element(ref.xml_element)
         end
-
       end
     end
   end

--- a/lib/xcodeproj/scheme/build_action.rb
+++ b/lib/xcodeproj/scheme/build_action.rb
@@ -2,6 +2,11 @@ require 'xcodeproj/scheme/xml_element_wrapper'
 
 module Xcodeproj
   class XCScheme
+    # Scheme action for "Build"
+    #
+    # Note: It's not a AbstractSchemeAction like the others because it is
+    # a special case of action (with no build_configuration, etc)
+    #
     class BuildAction < XMLElementWrapper
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'BuildAction') do

--- a/lib/xcodeproj/scheme/buildable_product_runnable.rb
+++ b/lib/xcodeproj/scheme/buildable_product_runnable.rb
@@ -1,9 +1,8 @@
 module Xcodeproj
   class XCScheme
     class BuildableProductRunnable < XMLElementWrapper
-
       # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
-      #        Either the Xcode target to reference, 
+      #        Either the Xcode target to reference,
       #        or an existing XML 'BuildableProductRunnable' node element to reference
       #        or nil to create an new, empty BuildableProductRunnable
       #
@@ -38,7 +37,6 @@ module Xcodeproj
         @xml_element.add_element(ref.xml_element)
         @buildable_reference = ref
       end
-
     end
   end
 end

--- a/lib/xcodeproj/scheme/buildable_product_runnable.rb
+++ b/lib/xcodeproj/scheme/buildable_product_runnable.rb
@@ -1,0 +1,38 @@
+module Xcodeproj
+  class XCScheme
+    class BuildableProductRunnable < XMLElementWrapper
+
+      # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
+      #        Either the Xcode target to reference, 
+      #        or an existing XML 'BuildableProductRunnable' node element to reference
+      #        or nil to create an new, empty BuildableProductRunnable
+      #
+      def initialize(target_or_node = nil)
+        create_xml_element_with_fallback(target_or_node, 'BuildableProductRunnable') do
+          # Add some attributes (that are not handled by this wrapper class yet but expected in the XML)
+          @xml_element.attributes['runnableDebuggingMode'] = '0'
+
+          # Setup default values for other (handled) attributes
+          self.buildable_reference = BuildableReference.new(target_or_node) if target_or_node
+        end
+      end
+
+      # @todo handle 'runnableDebuggingMode' attrbute
+
+      # @return [BuildableReference]
+      #
+      def buildable_reference
+        @buildable_reference ||= BuildableReference.new @xml_element.elements['BuildableReference']
+      end
+
+      # @param [BuildableReference] ref
+      #
+      def buildable_reference=(ref)
+        @xml_element.delete_element('BuildableReference')
+        @xml_element.add_element(ref.xml_element)
+        @buildable_reference = ref
+      end
+
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/buildable_product_runnable.rb
+++ b/lib/xcodeproj/scheme/buildable_product_runnable.rb
@@ -1,5 +1,10 @@
 module Xcodeproj
   class XCScheme
+    # This class wraps the BuildableProductRunnable node of a .xcscheme XML file
+    #
+    # A BuildableProductRunnable is a product that is both buildable
+    # (it contains a BuildableReference) and runnable (it can be launched and debugged)
+    #
     class BuildableProductRunnable < XMLElementWrapper
       # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
       #        Either the Xcode target to reference,
@@ -16,21 +21,29 @@ module Xcodeproj
         end
       end
 
+      # @return [String]
+      #         The Runnable debugging mode (usually either empty or equal to '0')
+      #
       def runnable_debugging_mode
         @xml_element.attributes['runnableDebuggingMode']
       end
 
+      # @param [String] value
+      #        Set the runnable debugging mode of this buildable product runnable
+      #
       def runnable_debugging_mode=(value)
         @xml_element.attributes['runnableDebuggingMode'] = value.to_s
       end
 
       # @return [BuildableReference]
+      #         The Buildable Reference this Buildable Product Runnable is gonna build and run
       #
       def buildable_reference
         @buildable_reference ||= BuildableReference.new @xml_element.elements['BuildableReference']
       end
 
       # @param [BuildableReference] ref
+      #        Set the Buildable Reference this Buildable Product Runnable is gonna build and run
       #
       def buildable_reference=(ref)
         @xml_element.delete_element('BuildableReference')

--- a/lib/xcodeproj/scheme/buildable_product_runnable.rb
+++ b/lib/xcodeproj/scheme/buildable_product_runnable.rb
@@ -7,17 +7,23 @@ module Xcodeproj
       #        or an existing XML 'BuildableProductRunnable' node element to reference
       #        or nil to create an new, empty BuildableProductRunnable
       #
-      def initialize(target_or_node = nil)
+      # @param [#to_s] runnable_debugging_mode
+      #        The debugging mode (usually '0')
+      #
+      def initialize(target_or_node = nil, runnable_debugging_mode = nil)
         create_xml_element_with_fallback(target_or_node, 'BuildableProductRunnable') do
-          # Add some attributes (that are not handled by this wrapper class yet but expected in the XML)
-          @xml_element.attributes['runnableDebuggingMode'] = '0'
-
-          # Setup default values for other (handled) attributes
           self.buildable_reference = BuildableReference.new(target_or_node) if target_or_node
+          @xml_element.attributes['runnableDebuggingMode'] = runnable_debugging_mode.to_s if runnable_debugging_mode
         end
       end
 
-      # @todo handle 'runnableDebuggingMode' attrbute
+      def runnable_debugging_mode
+        @xml_element.attributes['runnableDebuggingMode']
+      end
+
+      def runnable_debugging_mode=(value)
+        @xml_element.attributes['runnableDebuggingMode'] = value.to_s
+      end
 
       # @return [BuildableReference]
       #

--- a/lib/xcodeproj/scheme/buildable_reference.rb
+++ b/lib/xcodeproj/scheme/buildable_reference.rb
@@ -38,7 +38,7 @@ module Xcodeproj
         @xml_element.attributes['BlueprintIdentifier'] = target.uuid
         @xml_element.attributes['BlueprintName'] = target.name
         @xml_element.attributes['ReferencedContainer'] = construct_referenced_container_uri(target)
-        buildable_name = construct_buildable_name(target) if override_buildable_name
+        self.buildable_name = construct_buildable_name(target) if override_buildable_name
       end
 
       def buildable_name

--- a/lib/xcodeproj/scheme/buildable_reference.rb
+++ b/lib/xcodeproj/scheme/buildable_reference.rb
@@ -1,5 +1,10 @@
 module Xcodeproj
   class XCScheme
+    # This class wraps the BuildableReference node of a .xcscheme XML file
+    #
+    # A BuildableReference is a reference to a buildable product (which is
+    # typically is synonymous for an Xcode target)
+    #
     class BuildableReference < XMLElementWrapper
       # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
       #        Either the Xcode target to reference,
@@ -12,14 +17,28 @@ module Xcodeproj
         end
       end
 
+      # @return [String]
+      #         The name of the target this Buildable Reference points to
+      #
       def target_name
         @xml_element.attributes['BlueprintName']
       end
 
+      # @return [String]
+      #         The Unique Identifier of the target (target.uuid) this Buildable Reference points to.
+      #
+      # @note You can use this to `#find` the `Xcodeproj::Project::Object::AbstractTarget`
+      #       instance in your Xcodeproj::Project object.
+      #       e.g. `project.targets.find { |t| t.uuid == ref.target_uuid }`
+      #
       def target_uuid
         @xml_element.attributes['BlueprintIdentifier']
       end
 
+      # @return [String]
+      #         The string representing the container of that target.
+      #         Typically in the form of 'container:xxxx.xcodeproj'
+      #
       def target_referenced_container
         @xml_element.attributes['ReferencedContainer']
       end
@@ -40,10 +59,16 @@ module Xcodeproj
         self.buildable_name = construct_buildable_name(target) if override_buildable_name
       end
 
+      # @return [String]
+      #         The name of the final product when building this Buildable Reference
+      #
       def buildable_name
         @xml_element.attributes['BuildableName']
       end
 
+      # @param [String] value
+      #        Set the name of the final product when building this Buildable Reference
+      #
       def buildable_name=(value)
         @xml_element.attributes['BuildableName'] = value
       end

--- a/lib/xcodeproj/scheme/buildable_reference.rb
+++ b/lib/xcodeproj/scheme/buildable_reference.rb
@@ -1,0 +1,87 @@
+module Xcodeproj
+  class XCScheme
+    class BuildableReference < XMLElementWrapper
+
+      # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
+      #        Either the Xcode target to reference, 
+      #        or an existing XML 'BuildableReference' node element to reference
+      #
+      def initialize(target_or_node)
+        create_xml_element_with_fallback(target_or_node, 'BuildableReference') do
+          @xml_element.attributes['BuildableIdentifier'] = 'primary'
+          self.set_reference_target(target_or_node, true) if target_or_node
+        end
+      end
+
+      def target_name
+        @xml_element.attributes['BlueprintName']
+      end
+
+      def target_uuid
+        @xml_element.attributes['BlueprintIdentifier']
+      end
+
+      def target_referenced_container
+        @xml_element.attributes['ReferencedContainer']
+      end
+
+      # Set the BlueprintIdentifier (target.uuid), BlueprintName (target.name)
+      #     and TerefencedContainer (URI pointing to target's projet) all at once
+      #
+      # @param [Xcodeproj::Project::Object::AbstractTarget] target
+      #        The target this BuildableReference refers to.
+      #
+      # @param [Bool] override_buildable_name
+      #        If true, buildable_name will also be updated by computing a name from the target
+      #
+      def set_reference_target(target, override_buildable_name = false)
+        @xml_element.attributes['BlueprintIdentifier'] = target.uuid
+        @xml_element.attributes['BlueprintName'] = target.name
+        @xml_element.attributes['ReferencedContainer'] = construct_referenced_container_uri(target)
+        buildable_name = construct_buildable_name(target) if override_buildable_name
+      end
+
+      def buildable_name
+        @xml_element.attributes['BuildableName']
+      end
+
+      def buildable_name=(value)
+        @xml_element.attributes['BuildableName'] = value
+      end
+
+      #-------------------------------------------------------------------------#
+
+      private
+
+      # @!group Private helpers
+
+      # @param [Xcodeproj::Project::Object::AbstractTarget] target
+      #
+      # @return [String] The buildable name of the scheme.
+      #
+      def construct_buildable_name(build_target)
+        case build_target.isa
+        when 'PBXNativeTarget'
+          File.basename(build_target.product_reference.path)
+        when 'PBXAggregateTarget'
+          build_target.name
+        else
+          raise ArgumentError, "Unsupported build target type #{build_target.isa}"
+        end
+      end
+
+      # @param [Xcodeproj::Project::Object::AbstractTarget] target
+      #
+      # @return [String] A string in the format "container:[path to the project
+      #                  file relative to the project_dir_path, always ending with
+      #                  the actual project directory name]"
+      #
+      def construct_referenced_container_uri(target)
+        project = target.project
+        relative_path = project.path.relative_path_from(project.path + project.root_object.project_dir_path).to_s
+        relative_path = project.path.basename if relative_path == '.'
+        "container:#{relative_path}"
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/buildable_reference.rb
+++ b/lib/xcodeproj/scheme/buildable_reference.rb
@@ -1,15 +1,14 @@
 module Xcodeproj
   class XCScheme
     class BuildableReference < XMLElementWrapper
-
       # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
-      #        Either the Xcode target to reference, 
+      #        Either the Xcode target to reference,
       #        or an existing XML 'BuildableReference' node element to reference
       #
       def initialize(target_or_node)
         create_xml_element_with_fallback(target_or_node, 'BuildableReference') do
           @xml_element.attributes['BuildableIdentifier'] = 'primary'
-          self.set_reference_target(target_or_node, true) if target_or_node
+          set_reference_target(target_or_node, true) if target_or_node
         end
       end
 

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -40,14 +40,14 @@ module Xcodeproj
       # @return [BuildableProductRunnable]
       #         The BuildReference to launch when testing
       #
-      def build_product_runnable
+      def buildable_product_runnable
         BuildableProductRunnable.new(@xml_element.elements['BuildableProductRunnable'], 0)
       end
 
       # @param [BuildableProductRunnable] runnable
       #        The BuildableProductRunnable referencing the target to launch
       #
-      def build_product_runnable=(runnable)
+      def buildable_product_runnable=(runnable)
         @xml_element.delete_element('BuildableProductRunnable')
         @xml_element.add_element(runnable.xml_element) if runnable
       end

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -2,8 +2,12 @@ require 'xcodeproj/scheme/abstract_scheme_action'
 
 module Xcodeproj
   class XCScheme
+    # This class wraps the LaunchAction node of a .xcscheme XML file
+    #
     class LaunchAction < AbstractSchemeAction
       # @param [REXML::Element] node
+      #        The 'LaunchAction' XML node that this object will wrap.
+      #        If nil, will create a default XML node to use.
       #
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'LaunchAction') do
@@ -29,23 +33,29 @@ module Xcodeproj
       # @todo handle 'debugDocumentVersioning' attribute
       # @todo handle 'debugServiceExtension'
 
+      # @return [Bool]
+      #         Whether or not to allow GPS location simulation when launching this target
+      #
       def allow_location_simulation?
         string_to_bool(@xml_element.attributes['allowLocationSimulation'])
       end
 
+      # @param [Bool] flag
+      #        Set whether or not to allow GPS location simulation when launching this target
+      #
       def allow_location_simulation=(flag)
         @xml_element.attributes['allowLocationSimulation'] = bool_to_string(flag)
       end
 
       # @return [BuildableProductRunnable]
-      #         The BuildReference to launch when testing
+      #         The BuildReference to launch when executing the Launch Action
       #
       def buildable_product_runnable
         BuildableProductRunnable.new(@xml_element.elements['BuildableProductRunnable'], 0)
       end
 
       # @param [BuildableProductRunnable] runnable
-      #        The BuildableProductRunnable referencing the target to launch
+      #        Set the BuildableProductRunnable referencing the target to launch
       #
       def buildable_product_runnable=(runnable)
         @xml_element.delete_element('BuildableProductRunnable')

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -1,0 +1,65 @@
+module Xcodeproj
+  class XCScheme
+    class LaunchAction < XMLElementWrapper
+
+      # @param [REXML::Element] node
+      #
+      def initialize(node = nil)
+        create_xml_element_with_fallback(node, 'LaunchAction') do
+          # Add some attributes (that are not handled by this wrapper class yet but expected in the XML)
+          @xml_element.attributes['selectedDebuggerIdentifier'] = 'Xcode.DebuggerFoundation.Debugger.LLDB'
+          @xml_element.attributes['selectedLauncherIdentifier'] = 'Xcode.DebuggerFoundation.Launcher.LLDB'
+          @xml_element.attributes['launchStyle'] = '0'
+          @xml_element.attributes['useCustomWorkingDirectory'] = bool_to_string(false)
+          @xml_element.attributes['ignoresPersistentStateOnLaunch'] = bool_to_string(false)
+          @xml_element.attributes['debugDocumentVersioning'] = bool_to_string(true)
+          @xml_element.attributes['debugServiceExtension'] = 'internal'
+          @xml_element.add_element('AdditionalOptions')
+
+          # Setup default values for other (handled) attributes
+          self.build_configuration = 'Debug'
+          self.allow_location_simulation = true
+        end
+      end
+
+      def build_configuration
+        @xml_element.attributes['buildConfiguration']
+      end
+
+      def build_configuration=(config_name)
+        @xml_element.attributes['buildConfiguration'] = config_name
+      end
+
+      # @todo handle 'launchStyle' attribute
+      # @todo handle 'useCustomWorkingDirectory attribute
+      # @todo handle 'ignoresPersistentStateOnLaunch' attribute
+      # @todo handle 'debugDocumentVersioning' attribute
+      # @todo handle 'debugServiceExtension'
+
+      def allow_location_simulation?
+        string_to_bool(@xml_element.attributes['allowLocationSimulation'])
+      end
+      
+      def allow_location_simulation=(flag)
+        @xml_element.attributes['allowLocationSimulation'] = bool_to_string(flag)
+      end
+
+      # @return [BuildableProductRunnable]
+      #         The BuildReference to launch when testing
+      #
+      def build_product_runnable
+        BuildableProductRunnable.new @xml_element.elements['BuildableProductRunnable']
+      end
+
+      # @param [BuildableProductRunnable] runnable
+      #        The BuildableProductRunnable referencing the target to launch
+      #
+      def build_product_runnable=(runnable)
+        @xml_element.delete_element('BuildableProductRunnable')
+        @xml_element.add_element(runnable.xml_element) if runnable
+      end
+
+      # @todo handle 'AdditionalOptions' tag
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -1,7 +1,6 @@
 module Xcodeproj
   class XCScheme
     class LaunchAction < XMLElementWrapper
-
       # @param [REXML::Element] node
       #
       def initialize(node = nil)
@@ -39,7 +38,7 @@ module Xcodeproj
       def allow_location_simulation?
         string_to_bool(@xml_element.attributes['allowLocationSimulation'])
       end
-      
+
       def allow_location_simulation=(flag)
         @xml_element.attributes['allowLocationSimulation'] = bool_to_string(flag)
       end

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -48,7 +48,7 @@ module Xcodeproj
       #         The BuildReference to launch when testing
       #
       def build_product_runnable
-        BuildableProductRunnable.new @xml_element.elements['BuildableProductRunnable']
+        BuildableProductRunnable.new(@xml_element.elements['BuildableProductRunnable'], 0)
       end
 
       # @param [BuildableProductRunnable] runnable

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -1,6 +1,8 @@
+require 'xcodeproj/scheme/abstract_scheme_action'
+
 module Xcodeproj
   class XCScheme
-    class LaunchAction < XMLElementWrapper
+    class LaunchAction < AbstractSchemeAction
       # @param [REXML::Element] node
       #
       def initialize(node = nil)
@@ -19,14 +21,6 @@ module Xcodeproj
           self.build_configuration = 'Debug'
           self.allow_location_simulation = true
         end
-      end
-
-      def build_configuration
-        @xml_element.attributes['buildConfiguration']
-      end
-
-      def build_configuration=(config_name)
-        @xml_element.attributes['buildConfiguration'] = config_name
       end
 
       # @todo handle 'launchStyle' attribute

--- a/lib/xcodeproj/scheme/macro_expansion.rb
+++ b/lib/xcodeproj/scheme/macro_expansion.rb
@@ -1,0 +1,32 @@
+module Xcodeproj
+  class XCScheme
+    class MacroExpansion < XMLElementWrapper
+
+      # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
+      #        Either the Xcode target to reference, 
+      #        or an existing XML 'MacroExpansion' node element 
+      #        or nil to create an empty MacroExpansion object
+      #
+      def initialize(target_or_node = nil)
+        create_xml_element_with_fallback(target_or_node, 'MacroExpansion') do
+          self.buildable_reference = BuildableReference.new(target_or_node) if target_or_node
+        end
+      end
+
+      # @return [BuildableReference]
+      #
+      def buildable_reference
+        @buildable_reference ||= BuildableReference.new @xml_element.elements['BuildableReference']
+      end
+
+      # @param [BuildableReference] ref
+      #
+      def buildable_reference=(ref)
+        @xml_element.delete_element('BuildableReference')
+        @xml_element.add_element(ref.xml_element)
+        @buildable_reference = ref
+      end
+
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/macro_expansion.rb
+++ b/lib/xcodeproj/scheme/macro_expansion.rb
@@ -1,5 +1,7 @@
 module Xcodeproj
   class XCScheme
+    # This class wraps the MacroExpansion node of a .xcscheme XML file
+    #
     class MacroExpansion < XMLElementWrapper
       # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
       #        Either the Xcode target to reference,
@@ -13,12 +15,14 @@ module Xcodeproj
       end
 
       # @return [BuildableReference]
+      #         The BuildableReference this MacroExpansion refers to
       #
       def buildable_reference
         @buildable_reference ||= BuildableReference.new @xml_element.elements['BuildableReference']
       end
 
       # @param [BuildableReference] ref
+      #        Set the BuildableReference this MacroExpansion refers to
       #
       def buildable_reference=(ref)
         @xml_element.delete_element('BuildableReference')

--- a/lib/xcodeproj/scheme/macro_expansion.rb
+++ b/lib/xcodeproj/scheme/macro_expansion.rb
@@ -1,10 +1,9 @@
 module Xcodeproj
   class XCScheme
     class MacroExpansion < XMLElementWrapper
-
       # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
-      #        Either the Xcode target to reference, 
-      #        or an existing XML 'MacroExpansion' node element 
+      #        Either the Xcode target to reference,
+      #        or an existing XML 'MacroExpansion' node element
       #        or nil to create an empty MacroExpansion object
       #
       def initialize(target_or_node = nil)
@@ -26,7 +25,6 @@ module Xcodeproj
         @xml_element.add_element(ref.xml_element)
         @buildable_reference = ref
       end
-
     end
   end
 end

--- a/lib/xcodeproj/scheme/profile_action.rb
+++ b/lib/xcodeproj/scheme/profile_action.rb
@@ -1,0 +1,50 @@
+module Xcodeproj
+  class XCScheme
+    class ProfileAction < XMLElementWrapper
+
+      def initialize(node = nil)
+        create_xml_element_with_fallback(node, 'ProfileAction') do
+          # Add some attributes (that are not handled by this wrapper class yet but expected in the XML)
+          @xml_element.attributes['savedToolIdentifier'] = ''
+          @xml_element.attributes['useCustomWorkingDirectory'] = bool_to_string(false)
+          @xml_element.attributes['debugDocumentVersioning'] = bool_to_string(true)
+
+          # Setup default values for other (handled) attributes
+          self.build_configuration = 'Debug'
+          self.should_use_launch_scheme_args_env = true
+        end
+      end
+
+      def build_configuration
+        @xml_element.attributes['buildConfiguration']
+      end
+
+      def build_configuration=(config_name)
+        @xml_element.attributes['buildConfiguration'] = config_name
+      end
+
+      def should_use_launch_scheme_args_env?
+        string_to_bool(@xml_element.attributes['shouldUseLaunchSchemeArgsEnv'])
+      end
+
+      def should_use_launch_scheme_args_env=(flag)
+        @xml_element.attributes['shouldUseLaunchSchemeArgsEnv'] = bool_to_string(flag)
+      end
+
+      # @return [BuildableProductRunnable]
+      #         The BuildReference to launch when testing
+      #
+      def build_product_runnable
+        BuildableProductRunnable.new @xml_element.elements['BuildableProductRunnable']
+      end
+
+      # @param [BuildableProductRunnable] runnable
+      #         The BuildableProductRunnable referencing the target to launch when profiling
+      #
+      def build_product_runnable=(runnable)
+        @xml_element.delete_element('BuildableProductRunnable')
+        @xml_element.add_element(runnable.xml_element) if runnable
+      end      
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/profile_action.rb
+++ b/lib/xcodeproj/scheme/profile_action.rb
@@ -1,6 +1,8 @@
+require 'xcodeproj/scheme/abstract_scheme_action'
+
 module Xcodeproj
   class XCScheme
-    class ProfileAction < XMLElementWrapper
+    class ProfileAction < AbstractSchemeAction
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'ProfileAction') do
           # Add some attributes (that are not handled by this wrapper class yet but expected in the XML)
@@ -12,14 +14,6 @@ module Xcodeproj
           self.build_configuration = 'Release'
           self.should_use_launch_scheme_args_env = true
         end
-      end
-
-      def build_configuration
-        @xml_element.attributes['buildConfiguration']
-      end
-
-      def build_configuration=(config_name)
-        @xml_element.attributes['buildConfiguration'] = config_name
       end
 
       def should_use_launch_scheme_args_env?

--- a/lib/xcodeproj/scheme/profile_action.rb
+++ b/lib/xcodeproj/scheme/profile_action.rb
@@ -27,14 +27,14 @@ module Xcodeproj
       # @return [BuildableProductRunnable]
       #         The BuildReference to launch when testing
       #
-      def build_product_runnable
+      def buildable_product_runnable
         BuildableProductRunnable.new @xml_element.elements['BuildableProductRunnable']
       end
 
       # @param [BuildableProductRunnable] runnable
       #         The BuildableProductRunnable referencing the target to launch when profiling
       #
-      def build_product_runnable=(runnable)
+      def buildable_product_runnable=(runnable)
         @xml_element.delete_element('BuildableProductRunnable')
         @xml_element.add_element(runnable.xml_element) if runnable
       end

--- a/lib/xcodeproj/scheme/profile_action.rb
+++ b/lib/xcodeproj/scheme/profile_action.rb
@@ -1,7 +1,6 @@
 module Xcodeproj
   class XCScheme
     class ProfileAction < XMLElementWrapper
-
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'ProfileAction') do
           # Add some attributes (that are not handled by this wrapper class yet but expected in the XML)
@@ -44,7 +43,7 @@ module Xcodeproj
       def build_product_runnable=(runnable)
         @xml_element.delete_element('BuildableProductRunnable')
         @xml_element.add_element(runnable.xml_element) if runnable
-      end      
+      end
     end
   end
 end

--- a/lib/xcodeproj/scheme/profile_action.rb
+++ b/lib/xcodeproj/scheme/profile_action.rb
@@ -10,7 +10,7 @@ module Xcodeproj
           @xml_element.attributes['debugDocumentVersioning'] = bool_to_string(true)
 
           # Setup default values for other (handled) attributes
-          self.build_configuration = 'Debug'
+          self.build_configuration = 'Release'
           self.should_use_launch_scheme_args_env = true
         end
       end

--- a/lib/xcodeproj/scheme/profile_action.rb
+++ b/lib/xcodeproj/scheme/profile_action.rb
@@ -2,7 +2,13 @@ require 'xcodeproj/scheme/abstract_scheme_action'
 
 module Xcodeproj
   class XCScheme
+    # This class wraps the ProfileAction node of a .xcscheme XML file
+    #
     class ProfileAction < AbstractSchemeAction
+      # @param [REXML::Element] node
+      #        The 'ProfileAction' XML node that this object will wrap.
+      #        If nil, will create a default XML node to use.
+      #
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'ProfileAction') do
           # Add some attributes (that are not handled by this wrapper class yet but expected in the XML)
@@ -16,23 +22,31 @@ module Xcodeproj
         end
       end
 
+      # @return [Bool]
+      #         Whether this Profile Action should use the same arguments and environment variables
+      #         as the Launch Action.
+      #
       def should_use_launch_scheme_args_env?
         string_to_bool(@xml_element.attributes['shouldUseLaunchSchemeArgsEnv'])
       end
 
+      # @param [Bool] flag
+      #        Set Whether this Profile Action should use the same arguments and environment variables
+      #        as the Launch Action.
+      #
       def should_use_launch_scheme_args_env=(flag)
         @xml_element.attributes['shouldUseLaunchSchemeArgsEnv'] = bool_to_string(flag)
       end
 
       # @return [BuildableProductRunnable]
-      #         The BuildReference to launch when testing
+      #         The BuildableProductRunnable to launch when launching the Profile action
       #
       def buildable_product_runnable
         BuildableProductRunnable.new @xml_element.elements['BuildableProductRunnable']
       end
 
       # @param [BuildableProductRunnable] runnable
-      #         The BuildableProductRunnable referencing the target to launch when profiling
+      #        Set the BuildableProductRunnable referencing the target to launch when profiling
       #
       def buildable_product_runnable=(runnable)
         @xml_element.delete_element('BuildableProductRunnable')

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -40,10 +40,8 @@ module Xcodeproj
       # @param [TestableReference] testable
       #
       def add_testable(testable)
-        unless @xml_element.elements['Testables']
-          @xml_element.add_element('Testables')
-        end
-        @xml_element.elements['Testables'].add_element(testable.xml_element)
+        testables = @xml_element.elements['Testables'] || @xml_element.add_element('Testables')
+        testables.add_element(testable.xml_element)
       end
 
       # @return [Array<MacroExpansion>]

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -26,6 +26,8 @@ module Xcodeproj
       # @return [Array<TestableReference>]
       #
       def testables
+        return [] unless @xml_element.elements['Testables']
+
         @xml_element.elements['Testables'].get_elements('TestableReference').map do |node|
           TestableReference.new(node)
         end

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -54,7 +54,7 @@ module Xcodeproj
         end
       end
 
-      # @param [TestableReference] testable
+      # @param [MacroExpansion] macro_expansion
       #
       def add_macro_expansion(macro_expansion)
         @xml_element.add_element(macro_expansion.xml_element)
@@ -97,7 +97,6 @@ module Xcodeproj
           @xml_element.add_element(ref.xml_element)
         end
 
-        # @todo handle 'MacroExpansion' tag
         # @todo handle 'AdditionalOptions' tag
       end
     end

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -1,0 +1,107 @@
+module Xcodeproj
+  class XCScheme
+    class TestAction < XMLElementWrapper
+
+      # @param [REXML::Element] node
+      #
+      def initialize(node = nil)
+        create_xml_element_with_fallback(node, 'TestAction') do
+          @xml_element.attributes['selectedDebuggerIdentifier'] = 'Xcode.DebuggerFoundation.Debugger.LLDB'
+          @xml_element.attributes['selectedLauncherIdentifier'] = 'Xcode.DebuggerFoundation.Launcher.LLDB'
+          @xml_element.add_element('AdditionalOptions')
+          self.should_use_launch_scheme_args_env = true
+          self.build_configuration = 'Debug'
+        end
+      end
+
+      def should_use_launch_scheme_args_env?
+        string_to_bool(@xml_element.attributes['shouldUseLaunchSchemeArgsEnv'])
+      end
+      
+      def should_use_launch_scheme_args_env=(flag)
+        @xml_element.attributes['shouldUseLaunchSchemeArgsEnv'] = bool_to_string(flag)
+      end
+
+      def build_configuration
+        @xml_element.attributes['buildConfiguration']
+      end
+
+      def build_configuration=(config_name)
+        @xml_element.attributes['buildConfiguration'] = config_name
+      end
+
+      # @return [Array<TestableReference>]
+      #
+      def testables
+        @xml_element.elements['Testables'].get_elements('TestableReference').map do |node|
+          TestableReference.new(node)
+        end
+      end
+
+      # @param [TestableReference] testable
+      #
+      def add_testable(testable)
+        unless @xml_element.elements['Testables']
+          @xml_element.add_element('Testables')
+        end
+        @xml_element.elements['Testables'].add_element(testable.xml_element)
+      end
+
+      # @return [Array<MacroExpansion>]
+      #
+      def macro_expansions
+        @xml_element.get_elements('MacroExpansion').map do |node|
+          MacroExpansion.new(node)
+        end
+      end
+
+      # @param [TestableReference] testable
+      #
+      def add_macro_expansion(macro_expansion)
+        @xml_element.add_element(macro_expansion.xml_element)
+      end
+
+      #-------------------------------------------------------------------------#
+
+      class TestableReference < XMLElementWrapper
+
+        # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
+        #        Either the Xcode target to reference, 
+        #        or an existing XML 'TestableReference' node element to reference,
+        #        or nil to create an new, empty TestableReference
+        #
+        def initialize(target_or_node = nil)
+          create_xml_element_with_fallback(target_or_node, 'TestableReference') do
+            self.skipped = false
+            self.add_buildable_reference BuildableReference.new(target_or_node) unless target_or_node.nil?
+          end
+        end
+
+        def skipped?
+          string_to_bool(@xml_element.attributes['skipped'])
+        end
+        
+        def skipped=(flag)
+          @xml_element.attributes['skipped'] = bool_to_string(flag)
+        end
+
+        # @return [Array<BuildableReference>]
+        #
+        def buildable_references
+          @xml_element.get_elements('BuildableReference').map do |node|
+            BuildableReference.new(node)
+          end
+        end
+
+        # @param [BuildableReference] ref
+        #
+        def add_buildable_reference(ref)
+          @xml_element.add_element(ref.xml_element)
+        end
+
+        # @todo handle 'MacroExpansion' tag
+        # @todo handle 'AdditionalOptions' tag
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -1,7 +1,6 @@
 module Xcodeproj
   class XCScheme
     class TestAction < XMLElementWrapper
-
       # @param [REXML::Element] node
       #
       def initialize(node = nil)
@@ -17,7 +16,7 @@ module Xcodeproj
       def should_use_launch_scheme_args_env?
         string_to_bool(@xml_element.attributes['shouldUseLaunchSchemeArgsEnv'])
       end
-      
+
       def should_use_launch_scheme_args_env=(flag)
         @xml_element.attributes['shouldUseLaunchSchemeArgsEnv'] = bool_to_string(flag)
       end
@@ -64,23 +63,22 @@ module Xcodeproj
       #-------------------------------------------------------------------------#
 
       class TestableReference < XMLElementWrapper
-
         # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
-        #        Either the Xcode target to reference, 
+        #        Either the Xcode target to reference,
         #        or an existing XML 'TestableReference' node element to reference,
         #        or nil to create an new, empty TestableReference
         #
         def initialize(target_or_node = nil)
           create_xml_element_with_fallback(target_or_node, 'TestableReference') do
             self.skipped = false
-            self.add_buildable_reference BuildableReference.new(target_or_node) unless target_or_node.nil?
+            add_buildable_reference BuildableReference.new(target_or_node) unless target_or_node.nil?
           end
         end
 
         def skipped?
           string_to_bool(@xml_element.attributes['skipped'])
         end
-        
+
         def skipped=(flag)
           @xml_element.attributes['skipped'] = bool_to_string(flag)
         end

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -2,8 +2,12 @@ require 'xcodeproj/scheme/abstract_scheme_action'
 
 module Xcodeproj
   class XCScheme
+    # This class wraps the TestAction node of a .xcscheme XML file
+    #
     class TestAction < AbstractSchemeAction
       # @param [REXML::Element] node
+      #        The 'TestAction' XML node that this object will wrap.
+      #        If nil, will create a default XML node to use.
       #
       def initialize(node = nil)
         create_xml_element_with_fallback(node, 'TestAction') do
@@ -15,15 +19,24 @@ module Xcodeproj
         end
       end
 
+      # @return [Bool]
+      #         Whether this Test Action should use the same arguments and environment variables
+      #         as the Launch Action.
+      #
       def should_use_launch_scheme_args_env?
         string_to_bool(@xml_element.attributes['shouldUseLaunchSchemeArgsEnv'])
       end
 
+      # @param [Bool] flag
+      #        Set Whether this Test Action should use the same arguments and environment variables
+      #        as the Launch Action.
+      #
       def should_use_launch_scheme_args_env=(flag)
         @xml_element.attributes['shouldUseLaunchSchemeArgsEnv'] = bool_to_string(flag)
       end
 
       # @return [Array<TestableReference>]
+      #         The list of TestableReference (test bundles) associated with this Test Action
       #
       def testables
         return [] unless @xml_element.elements['Testables']
@@ -34,6 +47,7 @@ module Xcodeproj
       end
 
       # @param [TestableReference] testable
+      #        Add a TestableReference (test bundle) to this Test Action
       #
       def add_testable(testable)
         testables = @xml_element.elements['Testables'] || @xml_element.add_element('Testables')
@@ -41,6 +55,7 @@ module Xcodeproj
       end
 
       # @return [Array<MacroExpansion>]
+      #         The list of MacroExpansion bound with this TestAction
       #
       def macro_expansions
         @xml_element.get_elements('MacroExpansion').map do |node|
@@ -49,6 +64,7 @@ module Xcodeproj
       end
 
       # @param [MacroExpansion] macro_expansion
+      #        Add a MacroExpansion to this TestAction
       #
       def add_macro_expansion(macro_expansion)
         @xml_element.add_element(macro_expansion.xml_element)
@@ -69,15 +85,23 @@ module Xcodeproj
           end
         end
 
+        # @return [Bool]
+        #         Whether or not this TestableReference (test bundle) should be skipped or not
+        #
         def skipped?
           string_to_bool(@xml_element.attributes['skipped'])
         end
 
+        # @param [Bool] flag
+        #        Set whether or not this TestableReference (test bundle) should be skipped or not
+        #
         def skipped=(flag)
           @xml_element.attributes['skipped'] = bool_to_string(flag)
         end
 
         # @return [Array<BuildableReference>]
+        #         The list of BuildableReferences this action will build.
+        #         (The list usually contains only one element)
         #
         def buildable_references
           @xml_element.get_elements('BuildableReference').map do |node|
@@ -86,6 +110,7 @@ module Xcodeproj
         end
 
         # @param [BuildableReference] ref
+        #         The BuildableReference to add to the list of targets this action will build
         #
         def add_buildable_reference(ref)
           @xml_element.add_element(ref.xml_element)

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -1,6 +1,8 @@
+require 'xcodeproj/scheme/abstract_scheme_action'
+
 module Xcodeproj
   class XCScheme
-    class TestAction < XMLElementWrapper
+    class TestAction < AbstractSchemeAction
       # @param [REXML::Element] node
       #
       def initialize(node = nil)
@@ -19,14 +21,6 @@ module Xcodeproj
 
       def should_use_launch_scheme_args_env=(flag)
         @xml_element.attributes['shouldUseLaunchSchemeArgsEnv'] = bool_to_string(flag)
-      end
-
-      def build_configuration
-        @xml_element.attributes['buildConfiguration']
-      end
-
-      def build_configuration=(config_name)
-        @xml_element.attributes['buildConfiguration'] = config_name
       end
 
       # @return [Array<TestableReference>]

--- a/lib/xcodeproj/scheme/xml_element_wrapper.rb
+++ b/lib/xcodeproj/scheme/xml_element_wrapper.rb
@@ -1,0 +1,39 @@
+module Xcodeproj
+  class XCScheme
+    # Abstract base class used for scheme/* internal classes
+    #
+    class XMLElementWrapper
+      attr_reader :xml_element
+
+      def to_s
+        formatter = XMLFormatter.new(2)
+        formatter.compact = false
+        out = ''
+        formatter.write(@xml_element, out)
+        out.gsub!("<?xml version='1.0' encoding='UTF-8'?>", '')
+        out << "\n"
+        out
+      end
+
+      def create_xml_element_with_fallback(node, tag_name)
+        if node && node.is_a?(REXML::Element)
+          raise Informative, 'Wrong XML tag name' unless node.name == tag_name
+          @xml_element = node
+        else
+          @xml_element = REXML::Element.new(tag_name)
+          yield if block_given?
+        end
+      end
+
+      private
+
+      def bool_to_string(flag)
+        flag ? 'YES' : 'NO'
+      end
+
+      def string_to_bool(str)
+        str == 'YES'
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/xml_element_wrapper.rb
+++ b/lib/xcodeproj/scheme/xml_element_wrapper.rb
@@ -32,6 +32,7 @@ module Xcodeproj
       end
 
       def string_to_bool(str)
+        raise Informative, 'Invalid tag value. Expected YES or NO.' unless %w(YES NO).include?(str)
         str == 'YES'
       end
     end

--- a/lib/xcodeproj/scheme/xml_element_wrapper.rb
+++ b/lib/xcodeproj/scheme/xml_element_wrapper.rb
@@ -1,10 +1,16 @@
 module Xcodeproj
   class XCScheme
-    # Abstract base class used for scheme/* internal classes
+    # Abstract base class used for other XCScheme classes wrapping an XML element
     #
     class XMLElementWrapper
+      # @return [REXML::Element]
+      #         The XML node wrapped and manipulated by this XMLElementWrapper object
+      #
       attr_reader :xml_element
 
+      # @return [String]
+      #         The XML representation of the node this XMLElementWrapper wraps,
+      #         formatted in the same way that Xcode would.
       def to_s
         formatter = XMLFormatter.new(2)
         formatter.compact = false
@@ -15,6 +21,29 @@ module Xcodeproj
         out
       end
 
+      private
+
+      # This is a method intended to be used to facilitate the implementation of the initializers.
+      #
+      # - Create the @xml_element attribute based on the node passed as parameter, only if
+      #   that parameter is of type REXML::Element and its name matches the tag_name given.
+      # - Otherwise, create a brand new REXML::Element with the proper tag name and
+      #   execute the block given as a fallback to let the caller the chance to configure it
+      #
+      # @param [REXML::Element, *] node
+      #        The node this XMLElementWrapper is expected to wrap
+      #        or any other object (typically an AbstractTarget instance, or nil) the initializer might expect
+      #
+      # @param [String] tag_name
+      #        The expected name for the node, which will also be the name used to create the new node
+      #        if that `node` parameter is not a REXML::Element itself.
+      #
+      # @yield a parameter-less block if the `node` parameter is not actually a REXML::Element
+      #
+      # @raise Informative
+      #        If the `node` parameter is a REXML::Element instance but the node's name
+      #        doesn't match the one provided by the `tag_name` parameter.
+      #
       def create_xml_element_with_fallback(node, tag_name)
         if node && node.is_a?(REXML::Element)
           raise Informative, 'Wrong XML tag name' unless node.name == tag_name
@@ -25,12 +54,25 @@ module Xcodeproj
         end
       end
 
-      private
-
+      # @param [Bool]
+      #        The boolean we want to represent as a string
+      #
+      # @return [String]
+      #         The string representaiton of that boolean used in the XML ('YES' or 'NO')
+      #
       def bool_to_string(flag)
         flag ? 'YES' : 'NO'
       end
 
+      # @param [String]
+      #        The string representaiton of a boolean used in the XML ('YES' or 'NO')
+      #
+      # @return [Bool]
+      #        The boolean interpretation of that string
+      #
+      # @raise Informative
+      #        If the string is not representing a boolean (i.e. is neither 'YES' nor 'NO')
+      #
       def string_to_bool(str)
         raise Informative, 'Invalid tag value. Expected YES or NO.' unless %w(YES NO).include?(str)
         str == 'YES'

--- a/spec/scheme/abstract_scheme_action_spec.rb
+++ b/spec/scheme/abstract_scheme_action_spec.rb
@@ -1,0 +1,26 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::AbstractSchemeAction do
+    before do
+      @action = Xcodeproj::XCScheme::AbstractSchemeAction.new
+      @action.instance_eval { @xml_element = REXML::Element.new('Foo') }
+    end
+
+    describe '#build_configuration' do
+      it 'get the value if it exists' do
+        @action.xml_element.attributes['buildConfiguration'] = 'Bar'
+        @action.build_configuration.should == 'Bar'
+      end
+
+      it 'return nil if it does not exist' do
+        @action.build_configuration.should.nil?
+      end
+
+      it 'sets the value' do
+        @action.build_configuration = 'Baz'
+        @action.xml_element.attributes['buildConfiguration'].should == 'Baz'
+      end
+    end
+  end
+end

--- a/spec/scheme/analyze_action_spec.rb
+++ b/spec/scheme/analyze_action_spec.rb
@@ -1,0 +1,19 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::AnalyzeAction do
+    it 'Creates a default XML node when created from scratch' do
+      action = Xcodeproj::XCScheme::AnalyzeAction.new(nil)
+      action.xml_element.name.should == 'AnalyzeAction'
+      action.xml_element.attributes.count.should == 1
+      action.xml_element.attributes['buildConfiguration'].should == 'Debug'
+    end
+
+    it 'raises if created with an invalid XML node' do
+      node = REXML::Element.new('Foo')
+      should.raise(Informative) do
+        Xcodeproj::XCScheme::AnalyzeAction.new(node)
+      end.message.should.match /Wrong XML tag name/
+    end
+  end
+end

--- a/spec/scheme/archive_action_spec.rb
+++ b/spec/scheme/archive_action_spec.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::ArchiveAction do
+    it 'Creates a default XML node when created from scratch' do
+      action = Xcodeproj::XCScheme::ArchiveAction.new(nil)
+      action.xml_element.name.should == 'ArchiveAction'
+      action.xml_element.attributes.count.should == 2
+      action.xml_element.attributes['revealArchiveInOrganizer'].should == 'YES'
+      action.xml_element.attributes['buildConfiguration'].should == 'Release'
+    end
+
+    it 'raises if created with an invalid XML node' do
+      node = REXML::Element.new('Foo')
+      should.raise(Informative) do
+        Xcodeproj::XCScheme::ArchiveAction.new(node)
+      end.message.should.match /Wrong XML tag name/
+    end
+
+    describe 'Map attributes to XML' do
+      before do
+        node = REXML::Element.new('ArchiveAction')
+        @sut = Xcodeproj::XCScheme::ArchiveAction.new(node)
+      end
+
+      extend SpecHelper::XCScheme
+      specs_for_bool_attr(:reveal_archive_in_organizer => 'revealArchiveInOrganizer')
+
+      xit '#custom_archive_name' do
+        # @todo
+      end
+
+      xit '#custom_archive_name=' do
+        # @todo
+      end
+    end
+  end
+end

--- a/spec/scheme/archive_action_spec.rb
+++ b/spec/scheme/archive_action_spec.rb
@@ -26,12 +26,21 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:reveal_archive_in_organizer => 'revealArchiveInOrganizer')
 
-      xit '#custom_archive_name' do
-        # @todo
-      end
+      describe 'custom_archive_name' do
+        it '#custom_archive_name' do
+          @sut.xml_element.attributes['customArchiveName'] = 'Foo'
+          @sut.custom_archive_name.should == 'Foo'
+        end
 
-      xit '#custom_archive_name=' do
-        # @todo
+        it '#custom_archive_name= sets a new name' do
+          @sut.custom_archive_name = 'Bar'
+          @sut.xml_element.attributes['customArchiveName'].should == 'Bar'
+        end
+
+        it '#custom_archive_name= removes custom name' do
+          @sut.custom_archive_name = nil
+          @sut.xml_element.attributes['customArchiveName'].should.nil?
+        end
       end
     end
   end

--- a/spec/scheme/build_action_spec.rb
+++ b/spec/scheme/build_action_spec.rb
@@ -3,12 +3,12 @@ require File.expand_path('../../spec_helper', __FILE__)
 module Xcodeproj
   describe XCScheme::BuildAction do
     it 'Creates a default XML node when created from scratch' do
-      build_action = Xcodeproj::XCScheme::BuildAction.new(nil)
-      build_action.xml_element.name.should == 'BuildAction'
-      build_action.xml_element.attributes.count.should == 2
-      build_action.xml_element.attributes['parallelizeBuildables'].should == 'YES'
-      build_action.xml_element.attributes['buildImplicitDependencies'].should == 'YES'
-      build_action.xml_element.elements.count.should == 0
+      action = Xcodeproj::XCScheme::BuildAction.new(nil)
+      action.xml_element.name.should == 'BuildAction'
+      action.xml_element.attributes.count.should == 2
+      action.xml_element.attributes['parallelizeBuildables'].should == 'YES'
+      action.xml_element.attributes['buildImplicitDependencies'].should == 'YES'
+      action.xml_element.elements.count.should == 0
     end
 
     it 'raises if created with an invalid XML node' do
@@ -19,13 +19,12 @@ module Xcodeproj
     end
 
     describe 'Map attributes to XML' do
-      extend SpecHelper::XCScheme
-
       before do
         node = REXML::Element.new('BuildAction')
         @sut = Xcodeproj::XCScheme::BuildAction.new(node)
       end
 
+      extend SpecHelper::XCScheme
       attributes = {
         :parallelize_buildables => 'parallelizeBuildables',
         :build_implicit_dependencies => 'buildImplicitDependencies'
@@ -86,7 +85,7 @@ module Xcodeproj
         before do
           @project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
         end
-        it 'Uses the proper XML node when' do
+        it 'Uses the proper XML node' do
           target = @project.new_target(:application, 'FooApp', :ios)
           entry = Xcodeproj::XCScheme::BuildAction::Entry.new(target)
           entry.xml_element.name.should == 'BuildActionEntry'
@@ -124,12 +123,11 @@ module Xcodeproj
       end
 
       describe 'Map attributes to XML' do
-        extend SpecHelper::XCScheme
-
         before do
           @sut = Xcodeproj::XCScheme::BuildAction::Entry.new(nil)
         end
 
+        extend SpecHelper::XCScheme
         attributes = {
           :build_for_testing => 'buildForTesting',
           :build_for_running => 'buildForRunning',

--- a/spec/scheme/build_action_spec.rb
+++ b/spec/scheme/build_action_spec.rb
@@ -1,0 +1,173 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::BuildAction do
+    it 'Creates a default XML node when created from scratch' do
+      build_action = Xcodeproj::XCScheme::BuildAction.new(nil)
+      build_action.xml_element.name.should == 'BuildAction'
+      build_action.xml_element.attributes.count.should == 2
+      build_action.xml_element.attributes['parallelizeBuildables'].should == 'YES'
+      build_action.xml_element.attributes['buildImplicitDependencies'].should == 'YES'
+      build_action.xml_element.elements.count.should == 0
+    end
+
+    it 'raises if created with an invalid XML node' do
+      node = REXML::Element.new('Foo')
+      should.raise(Informative) do
+        Xcodeproj::XCScheme::BuildAction.new(node)
+      end.message.should.match /Wrong XML tag name/
+    end
+
+    describe 'Map attributes to XML' do
+      extend SpecHelper::XCScheme
+
+      before do
+        node = REXML::Element.new('BuildAction')
+        @sut = Xcodeproj::XCScheme::BuildAction.new(node)
+      end
+
+      attributes = {
+        :parallelize_buildables => 'parallelizeBuildables',
+        :build_implicit_dependencies => 'buildImplicitDependencies'
+      }
+      specs_for_bool_attr(attributes)
+
+      it '#add_entry' do
+        @sut.xml_element.elements['BuildActionEntries'].should.nil?
+        entry = XCScheme::BuildAction::Entry.new
+        @sut.add_entry(entry)
+        @sut.xml_element.elements['BuildActionEntries'].should.not.nil?
+        @sut.xml_element.elements['BuildActionEntries'].count.should == 1
+        @sut.xml_element.elements['BuildActionEntries'].elements['BuildActionEntry'].should == entry.xml_element
+      end
+
+      it '#entries' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        entry1 = XCScheme::BuildAction::Entry.new
+        entry1.add_buildable_reference(XCScheme::BuildableReference.new(target1))
+        @sut.add_entry(entry1)
+
+        target2 = project.new_target(:static_library, 'FooLib', :ios)
+        entry2 = XCScheme::BuildAction::Entry.new
+        entry2.add_buildable_reference(XCScheme::BuildableReference.new(target2))
+        @sut.add_entry(entry2)
+
+        @sut.entries.count.should == 2
+        @sut.entries.all? { |e| e.class.should == XCScheme::BuildAction::Entry }
+        @sut.entries[0].xml_element.should == entry1.xml_element
+        @sut.entries[1].xml_element.should == entry2.xml_element
+      end
+    end
+
+    describe XCScheme::BuildAction::Entry do
+      it 'Creates a default XML node when created from scratch' do
+        entry = Xcodeproj::XCScheme::BuildAction::Entry.new(nil)
+
+        entry.xml_element.name.should == 'BuildActionEntry'
+        entry.xml_element.attributes.count.should == 5
+        entry.xml_element.attributes['buildForAnalyzing'].should == 'YES'
+        entry.xml_element.attributes['buildForTesting'].should == 'NO'
+        entry.xml_element.attributes['buildForRunning'].should == 'NO'
+        entry.xml_element.attributes['buildForProfiling'].should == 'NO'
+        entry.xml_element.attributes['buildForArchiving'].should == 'NO'
+        entry.xml_element.elements.count.should == 0
+      end
+
+      it 'raises if created with an invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::BuildAction::Entry.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
+      describe 'Created from a target' do
+        before do
+          @project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        end
+        it 'Uses the proper XML node when' do
+          target = @project.new_target(:application, 'FooApp', :ios)
+          entry = Xcodeproj::XCScheme::BuildAction::Entry.new(target)
+          entry.xml_element.name.should == 'BuildActionEntry'
+        end
+
+        it 'Use proper defaults for app target' do
+          target = @project.new_target(:application, 'FooApp', :ios)
+          entry = Xcodeproj::XCScheme::BuildAction::Entry.new(target)
+          entry.build_for_testing?.should == false
+          entry.build_for_running?.should == true
+          entry.build_for_profiling?.should == true
+          entry.build_for_archiving?.should == true
+          entry.build_for_analyzing?.should == true
+        end
+
+        it 'Use proper defaults for lib target' do
+          target = @project.new_target(:static_library, 'FooLib', :ios)
+          entry = Xcodeproj::XCScheme::BuildAction::Entry.new(target)
+          entry.build_for_testing?.should == false
+          entry.build_for_running?.should == false
+          entry.build_for_profiling?.should == false
+          entry.build_for_archiving?.should == false
+          entry.build_for_analyzing?.should == true
+        end
+
+        it 'Use proper defaults for test target' do
+          target = @project.new_target(:unit_test_bundle, 'FooAppTests', :ios)
+          entry = Xcodeproj::XCScheme::BuildAction::Entry.new(target)
+          entry.build_for_testing?.should == true
+          entry.build_for_running?.should == false
+          entry.build_for_profiling?.should == false
+          entry.build_for_archiving?.should == false
+          entry.build_for_analyzing?.should == true
+        end
+      end
+
+      describe 'Map attributes to XML' do
+        extend SpecHelper::XCScheme
+
+        before do
+          @sut = Xcodeproj::XCScheme::BuildAction::Entry.new(nil)
+        end
+
+        attributes = {
+          :build_for_testing => 'buildForTesting',
+          :build_for_running => 'buildForRunning',
+          :build_for_profiling => 'buildForProfiling',
+          :build_for_archiving => 'buildForArchiving',
+          :build_for_analyzing => 'buildForAnalyzing',
+        }
+        specs_for_bool_attr(attributes)
+      end
+
+      it '#add_buildable_reference' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        entry = XCScheme::BuildAction::Entry.new
+
+        target = project.new_target(:application, 'FooApp', :ios)
+        ref = XCScheme::BuildableReference.new(target)
+        entry.add_buildable_reference(ref)
+        
+        entry.xml_element.elements['BuildableReference'].should == ref.xml_element
+      end
+
+      it '#buildable_references' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        entry = XCScheme::BuildAction::Entry.new
+        
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        ref1 = XCScheme::BuildableReference.new(target1)
+        entry.add_buildable_reference(ref1)
+        
+        target2 = project.new_target(:static_library, 'FooLib', :ios)
+        ref2 = XCScheme::BuildableReference.new(target2)
+        entry.add_buildable_reference(ref2)
+        
+        entry.buildable_references.count.should == 2
+        entry.buildable_references.all? { |e| e.class.should == XCScheme::BuildableReference }
+        entry.buildable_references[0].xml_element.should == ref1.xml_element
+        entry.buildable_references[1].xml_element.should == ref2.xml_element
+      end
+    end
+  end
+end

--- a/spec/scheme/build_action_spec.rb
+++ b/spec/scheme/build_action_spec.rb
@@ -27,7 +27,7 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       attributes = {
         :parallelize_buildables => 'parallelizeBuildables',
-        :build_implicit_dependencies => 'buildImplicitDependencies'
+        :build_implicit_dependencies => 'buildImplicitDependencies',
       }
       specs_for_bool_attr(attributes)
 
@@ -42,7 +42,7 @@ module Xcodeproj
 
       it '#entries' do
         project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
-        
+
         target1 = project.new_target(:application, 'FooApp', :ios)
         entry1 = XCScheme::BuildAction::Entry.new
         entry1.add_buildable_reference(XCScheme::BuildableReference.new(target1))
@@ -145,22 +145,22 @@ module Xcodeproj
         target = project.new_target(:application, 'FooApp', :ios)
         ref = XCScheme::BuildableReference.new(target)
         entry.add_buildable_reference(ref)
-        
+
         entry.xml_element.elements['BuildableReference'].should == ref.xml_element
       end
 
       it '#buildable_references' do
         project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
         entry = XCScheme::BuildAction::Entry.new
-        
+
         target1 = project.new_target(:application, 'FooApp', :ios)
         ref1 = XCScheme::BuildableReference.new(target1)
         entry.add_buildable_reference(ref1)
-        
+
         target2 = project.new_target(:static_library, 'FooLib', :ios)
         ref2 = XCScheme::BuildableReference.new(target2)
         entry.add_buildable_reference(ref2)
-        
+
         entry.buildable_references.count.should == 2
         entry.buildable_references.all? { |e| e.class.should == XCScheme::BuildableReference }
         entry.buildable_references[0].xml_element.should == ref1.xml_element

--- a/spec/scheme/buildable_product_runnable_spec.rb
+++ b/spec/scheme/buildable_product_runnable_spec.rb
@@ -1,0 +1,72 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::BuildableProductRunnable do
+    describe 'Created from scratch' do
+      it 'Creates an initial, empty XML node' do
+        bpr = Xcodeproj::XCScheme::BuildableProductRunnable.new(nil)
+        bpr.xml_element.name.should == 'BuildableProductRunnable'
+        bpr.xml_element.attributes.count.should == 0
+        bpr.xml_element.elements.count.should == 0
+      end
+
+      it 'Creates an initial, empty XML node with runnableDebuggingMode' do
+        bpr = Xcodeproj::XCScheme::BuildableProductRunnable.new(nil, 1)
+        bpr.xml_element.name.should == 'BuildableProductRunnable'
+        bpr.xml_element.attributes.count.should == 1
+        bpr.xml_element.attributes['runnableDebuggingMode'].should == '1'
+        bpr.xml_element.elements.count.should == 0
+      end
+    end
+
+    describe 'Created from a XML node' do
+      before do
+        node = REXML::Element.new('BuildableProductRunnable')
+        ref = REXML::Element.new('BuildableReference')
+        node.add_element(ref)
+        @bpr = Xcodeproj::XCScheme::BuildableProductRunnable.new(node)
+      end
+
+      it 'raises if invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::BuildableProductRunnable.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
+      it '#buildable_reference' do
+        @bpr.buildable_reference.xml_element.should == @bpr.xml_element.elements['BuildableReference']
+      end
+
+      it '#buildable_reference=' do
+        other_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+        @bpr.buildable_reference = other_ref
+        @bpr.xml_element.elements.count.should == 1
+        @bpr.xml_element.elements['BuildableReference'].should == other_ref.xml_element
+      end
+    end
+
+    describe 'Created from a target' do
+      before do
+        @project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        @target = @project.new_target(:application, 'FooApp', :ios)
+        @bpr = Xcodeproj::XCScheme::BuildableProductRunnable.new(@target)
+      end
+
+      it 'Uses the proper XML node' do
+        @bpr.xml_element.name.should == 'BuildableProductRunnable'
+      end
+
+      it '#buildable_reference' do
+        @bpr.buildable_reference.xml_element.should == @bpr.xml_element.elements['BuildableReference']
+      end
+
+      it '#buildable_name=' do
+        other_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+        @bpr.buildable_reference = other_ref
+        @bpr.xml_element.elements.count.should == 1
+        @bpr.xml_element.elements['BuildableReference'].should == other_ref.xml_element
+      end
+    end
+  end
+end

--- a/spec/scheme/buildable_reference_spec.rb
+++ b/spec/scheme/buildable_reference_spec.rb
@@ -1,0 +1,132 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::BuildableReference do
+    describe 'Created from scratch' do
+      before do
+        @ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+      end
+
+      it 'Creates an initial, quite empty XML node' do
+        @ref.xml_element.name.should == 'BuildableReference'
+        @ref.xml_element.attributes.count.should == 1
+        @ref.xml_element.attributes['BuildableIdentifier'].should == 'primary'
+      end
+    end
+
+    describe 'Created from a XML node' do
+      before do
+        node = REXML::Element.new('BuildableReference')
+        attributes = {
+          'BuildableIdentifier' => 'primary',
+          'BuildableName' => 'FooApp.app',
+          'BlueprintName' => 'SomeTargetName',
+          'BlueprintIdentifier' => '0000-DEAD-BEAF-6666',
+          'ReferencedContainer' => 'container:baz.xcodeproj',
+        }
+        node.add_attributes(attributes)
+        @ref = Xcodeproj::XCScheme::BuildableReference.new(node)
+      end
+
+      it '#target_name' do
+        @ref.target_name.should == @ref.xml_element.attributes['BlueprintName']
+      end
+
+      it '#target_uuid' do
+        @ref.target_uuid.should == @ref.xml_element.attributes['BlueprintIdentifier']
+      end
+
+      it '#target_referenced_container' do
+        @ref.target_referenced_container.should == @ref.xml_element.attributes['ReferencedContainer']
+      end
+
+      it '#buildable_name' do
+        @ref.buildable_name.should == @ref.xml_element.attributes['BuildableName']
+      end
+
+      it '#buildable_name=' do
+        @ref.buildable_name = 'Custom'
+        @ref.xml_element.attributes['BuildableName'].should == 'Custom'
+      end
+
+      it '#set_reference_target without overriding buildable_name' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        other_target = project.new_target(:static_library, 'FooLib', :ios)
+        @ref.set_reference_target(other_target, false)
+
+        @ref.target_name.should == 'FooLib'
+        @ref.target_uuid.should == other_target.uuid
+        @ref.target_referenced_container.should == 'container:baz.xcodeproj'
+        @ref.buildable_name.should == 'FooApp.app'
+      end
+
+      it '#set_reference_target with overriding of buildable_name' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        other_target = project.new_target(:static_library, 'FooLib', :ios)
+        @ref.set_reference_target(other_target, true)
+
+        @ref.target_name.should == 'FooLib'
+        @ref.target_uuid.should == other_target.uuid
+        @ref.target_referenced_container.should == 'container:baz.xcodeproj'
+        @ref.buildable_name.should == 'libFooLib.a'
+      end
+    end
+
+    describe 'Created from a target' do
+      before do
+        @project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        @target = @project.new_target(:application, 'FooApp', :ios)
+        @ref = Xcodeproj::XCScheme::BuildableReference.new(@target)
+      end
+
+      it 'Uses the proper XML node' do
+        @ref.xml_element.name.should == 'BuildableReference'
+      end
+
+      it '#target_name' do
+        @ref.target_name.should == @ref.xml_element.attributes['BlueprintName']
+        @ref.target_name.should == @target.name
+      end
+
+      it '#target_uuid' do
+        @ref.target_uuid.should == @ref.xml_element.attributes['BlueprintIdentifier']
+        @ref.target_uuid.should == @target.uuid
+      end
+
+      it '#target_referenced_container' do
+        @ref.target_referenced_container.should == @ref.xml_element.attributes['ReferencedContainer']
+        @ref.target_referenced_container.should == 'container:baz.xcodeproj'
+      end
+
+      it '#buildable_name' do
+        @ref.buildable_name.should == @ref.xml_element.attributes['BuildableName']
+        @ref.buildable_name.should == 'FooApp.app'
+      end
+
+      it '#buildable_name=' do
+        @ref.buildable_name = 'Custom'
+        @ref.xml_element.attributes['BuildableName'].should == 'Custom'
+      end
+
+      it '#set_reference_target without overriding buildable_name' do
+        other_target = @project.new_target(:static_library, 'FooLib', :ios)
+        @ref.set_reference_target(other_target, false)
+
+        @ref.target_name.should == 'FooLib'
+        @ref.target_uuid.should == other_target.uuid
+        @ref.target_referenced_container.should == 'container:baz.xcodeproj'
+        @ref.buildable_name.should == 'FooApp.app'
+      end
+
+      it '#set_reference_target with overriding of buildable_name' do
+        other_target = @project.new_target(:static_library, 'FooLib', :ios)
+        @ref.set_reference_target(other_target, true)
+
+        @ref.target_name.should == 'FooLib'
+        @ref.target_uuid.should == other_target.uuid
+        @ref.target_referenced_container.should == 'container:baz.xcodeproj'
+        @ref.buildable_name.should == 'libFooLib.a'
+      end
+    end
+  end
+end

--- a/spec/scheme/buildable_reference_spec.rb
+++ b/spec/scheme/buildable_reference_spec.rb
@@ -28,6 +28,13 @@ module Xcodeproj
         @ref = Xcodeproj::XCScheme::BuildableReference.new(node)
       end
 
+      it 'raise if invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::BuildableReference.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
       it '#target_name' do
         @ref.target_name.should == @ref.xml_element.attributes['BlueprintName']
       end

--- a/spec/scheme/launch_action_spec.rb
+++ b/spec/scheme/launch_action_spec.rb
@@ -13,7 +13,7 @@ module Xcodeproj
       action.xml_element.attributes['ignoresPersistentStateOnLaunch'].should == 'NO'
       action.xml_element.attributes['debugDocumentVersioning'].should == 'YES'
       action.xml_element.attributes['debugServiceExtension'].should == 'internal'
-      
+
       action.xml_element.attributes['buildConfiguration'].should == 'Debug'
       action.xml_element.attributes['allowLocationSimulation'].should == 'YES'
     end
@@ -34,12 +34,26 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:allow_location_simulation => 'allowLocationSimulation')
 
-      xit '#build_product_runnable' do
-        # @todo
-      end
+      describe 'build_product_runnable' do
+        it '#build_product_runnable' do
+          project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+          target = project.new_target(:application, 'FooApp', :ios)
+          bpr = XCScheme::BuildableProductRunnable.new(target)
 
-      xit '#build_product_runnable=' do
-        # @todo
+          node = bpr.xml_element
+          @sut.xml_element.elements['BuildableProductRunnable'] = node
+          @sut.build_product_runnable.class.should == XCScheme::BuildableProductRunnable
+          @sut.build_product_runnable.xml_element.should == node
+        end
+
+        it '#build_product_runnable=' do
+          project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+          target = project.new_target(:application, 'FooApp', :ios)
+          bpr = XCScheme::BuildableProductRunnable.new(target)
+
+          @sut.build_product_runnable = bpr
+          @sut.xml_element.elements['BuildableProductRunnable'].should == bpr.xml_element
+        end
       end
     end
   end

--- a/spec/scheme/launch_action_spec.rb
+++ b/spec/scheme/launch_action_spec.rb
@@ -34,24 +34,24 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:allow_location_simulation => 'allowLocationSimulation')
 
-      describe 'build_product_runnable' do
-        it '#build_product_runnable' do
+      describe 'buildable_product_runnable' do
+        it '#buildable_product_runnable' do
           project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
           target = project.new_target(:application, 'FooApp', :ios)
           bpr = XCScheme::BuildableProductRunnable.new(target)
 
           node = bpr.xml_element
           @sut.xml_element.elements['BuildableProductRunnable'] = node
-          @sut.build_product_runnable.class.should == XCScheme::BuildableProductRunnable
-          @sut.build_product_runnable.xml_element.should == node
+          @sut.buildable_product_runnable.class.should == XCScheme::BuildableProductRunnable
+          @sut.buildable_product_runnable.xml_element.should == node
         end
 
-        it '#build_product_runnable=' do
+        it '#buildable_product_runnable=' do
           project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
           target = project.new_target(:application, 'FooApp', :ios)
           bpr = XCScheme::BuildableProductRunnable.new(target)
 
-          @sut.build_product_runnable = bpr
+          @sut.buildable_product_runnable = bpr
           @sut.xml_element.elements['BuildableProductRunnable'].should == bpr.xml_element
         end
       end

--- a/spec/scheme/launch_action_spec.rb
+++ b/spec/scheme/launch_action_spec.rb
@@ -1,0 +1,46 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::LaunchAction do
+    it 'Creates a default XML node when created from scratch' do
+      action = Xcodeproj::XCScheme::LaunchAction.new(nil)
+      action.xml_element.name.should == 'LaunchAction'
+      action.xml_element.attributes.count.should == 9
+      action.xml_element.attributes['selectedDebuggerIdentifier'].should == 'Xcode.DebuggerFoundation.Debugger.LLDB'
+      action.xml_element.attributes['selectedLauncherIdentifier'].should == 'Xcode.DebuggerFoundation.Launcher.LLDB'
+      action.xml_element.attributes['launchStyle'].should == '0'
+      action.xml_element.attributes['useCustomWorkingDirectory'].should == 'NO'
+      action.xml_element.attributes['ignoresPersistentStateOnLaunch'].should == 'NO'
+      action.xml_element.attributes['debugDocumentVersioning'].should == 'YES'
+      action.xml_element.attributes['debugServiceExtension'].should == 'internal'
+      
+      action.xml_element.attributes['buildConfiguration'].should == 'Debug'
+      action.xml_element.attributes['allowLocationSimulation'].should == 'YES'
+    end
+
+    it 'raises if created with an invalid XML node' do
+      node = REXML::Element.new('Foo')
+      should.raise(Informative) do
+        Xcodeproj::XCScheme::LaunchAction.new(node)
+      end.message.should.match /Wrong XML tag name/
+    end
+
+    describe 'Map attributes to XML' do
+      before do
+        node = REXML::Element.new('LaunchAction')
+        @sut = Xcodeproj::XCScheme::LaunchAction.new(node)
+      end
+
+      extend SpecHelper::XCScheme
+      specs_for_bool_attr(:allow_location_simulation => 'allowLocationSimulation')
+
+      xit '#build_product_runnable' do
+        # @todo
+      end
+
+      xit '#build_product_runnable=' do
+        # @todo
+      end
+    end
+  end
+end

--- a/spec/scheme/macro_expansion_spec.rb
+++ b/spec/scheme/macro_expansion_spec.rb
@@ -1,0 +1,67 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::MacroExpansion do
+    describe 'Created from scratch' do
+      before do
+        @macro_exp = Xcodeproj::XCScheme::MacroExpansion.new(nil)
+      end
+
+      it 'Creates an initial, empty XML node' do
+        @macro_exp.xml_element.name.should == 'MacroExpansion'
+        @macro_exp.xml_element.attributes.count.should == 0
+        @macro_exp.xml_element.elements.count.should == 0
+      end
+    end
+
+    describe 'Created from a XML node' do
+      before do
+        node = REXML::Element.new('MacroExpansion')
+        ref = REXML::Element.new('BuildableReference')
+        node.add_element(ref)
+        @macro_exp = Xcodeproj::XCScheme::MacroExpansion.new(node)
+      end
+
+      it 'raises if invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::MacroExpansion.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
+      it '#buildable_reference' do
+        @macro_exp.buildable_reference.xml_element.should == @macro_exp.xml_element.elements['BuildableReference']
+      end
+
+      it '#buildable_reference=' do
+        other_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+        @macro_exp.buildable_reference = other_ref
+        @macro_exp.xml_element.elements.count.should == 1
+        @macro_exp.xml_element.elements['BuildableReference'].should == other_ref.xml_element
+      end
+    end
+
+    describe 'Created from a target' do
+      before do
+        @project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        @target = @project.new_target(:application, 'FooApp', :ios)
+        @macro_exp = Xcodeproj::XCScheme::MacroExpansion.new(@target)
+      end
+
+      it 'Uses the proper XML node' do
+        @macro_exp.xml_element.name.should == 'MacroExpansion'
+      end
+
+      it '#buildable_reference' do
+        @macro_exp.buildable_reference.xml_element.should == @macro_exp.xml_element.elements['BuildableReference']
+      end
+
+      it '#buildable_name=' do
+        other_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+        @macro_exp.buildable_reference = other_ref
+        @macro_exp.xml_element.elements.count.should == 1
+        @macro_exp.xml_element.elements['BuildableReference'].should == other_ref.xml_element
+      end
+    end
+  end
+end

--- a/spec/scheme/profile_action_spec.rb
+++ b/spec/scheme/profile_action_spec.rb
@@ -29,12 +29,26 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:should_use_launch_scheme_args_env => 'shouldUseLaunchSchemeArgsEnv')
 
-      xit '#build_product_runnable' do
-        # @todo
-      end
+      describe 'build_product_runnable' do
+        it '#build_product_runnable' do
+          project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+          target = project.new_target(:application, 'FooApp', :ios)
+          bpr = XCScheme::BuildableProductRunnable.new(target)
 
-      xit '#build_product_runnable=' do
-        # @todo
+          node = bpr.xml_element
+          @sut.xml_element.elements['BuildableProductRunnable'] = node
+          @sut.build_product_runnable.class.should == XCScheme::BuildableProductRunnable
+          @sut.build_product_runnable.xml_element.should == node
+        end
+
+        it '#build_product_runnable=' do
+          project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+          target = project.new_target(:application, 'FooApp', :ios)
+          bpr = XCScheme::BuildableProductRunnable.new(target)
+
+          @sut.build_product_runnable = bpr
+          @sut.xml_element.elements['BuildableProductRunnable'].should == bpr.xml_element
+        end
       end
     end
   end

--- a/spec/scheme/profile_action_spec.rb
+++ b/spec/scheme/profile_action_spec.rb
@@ -29,24 +29,24 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:should_use_launch_scheme_args_env => 'shouldUseLaunchSchemeArgsEnv')
 
-      describe 'build_product_runnable' do
-        it '#build_product_runnable' do
+      describe 'buildable_product_runnable' do
+        it '#buildable_product_runnable' do
           project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
           target = project.new_target(:application, 'FooApp', :ios)
           bpr = XCScheme::BuildableProductRunnable.new(target)
 
           node = bpr.xml_element
           @sut.xml_element.elements['BuildableProductRunnable'] = node
-          @sut.build_product_runnable.class.should == XCScheme::BuildableProductRunnable
-          @sut.build_product_runnable.xml_element.should == node
+          @sut.buildable_product_runnable.class.should == XCScheme::BuildableProductRunnable
+          @sut.buildable_product_runnable.xml_element.should == node
         end
 
-        it '#build_product_runnable=' do
+        it '#buildable_product_runnable=' do
           project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
           target = project.new_target(:application, 'FooApp', :ios)
           bpr = XCScheme::BuildableProductRunnable.new(target)
 
-          @sut.build_product_runnable = bpr
+          @sut.buildable_product_runnable = bpr
           @sut.xml_element.elements['BuildableProductRunnable'].should == bpr.xml_element
         end
       end

--- a/spec/scheme/profile_action_spec.rb
+++ b/spec/scheme/profile_action_spec.rb
@@ -1,0 +1,41 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::ProfileAction do
+    it 'Creates a default XML node when created from scratch' do
+      action = Xcodeproj::XCScheme::ProfileAction.new(nil)
+      action.xml_element.name.should == 'ProfileAction'
+      action.xml_element.attributes.count.should == 5
+      action.xml_element.attributes['savedToolIdentifier'].should == ''
+      action.xml_element.attributes['useCustomWorkingDirectory'].should == 'NO'
+      action.xml_element.attributes['debugDocumentVersioning'].should == 'YES'
+      action.xml_element.attributes['shouldUseLaunchSchemeArgsEnv'].should == 'YES'
+      action.xml_element.attributes['buildConfiguration'].should == 'Release'
+    end
+
+    it 'raises if created with an invalid XML node' do
+      node = REXML::Element.new('Foo')
+      should.raise(Informative) do
+        Xcodeproj::XCScheme::ProfileAction.new(node)
+      end.message.should.match /Wrong XML tag name/
+    end
+
+    describe 'Map attributes to XML' do
+      before do
+        node = REXML::Element.new('ProfileAction')
+        @sut = Xcodeproj::XCScheme::ProfileAction.new(node)
+      end
+
+      extend SpecHelper::XCScheme
+      specs_for_bool_attr(:should_use_launch_scheme_args_env => 'shouldUseLaunchSchemeArgsEnv')
+
+      xit '#build_product_runnable' do
+        # @todo
+      end
+
+      xit '#build_product_runnable=' do
+        # @todo
+      end
+    end
+  end
+end

--- a/spec/scheme/test_action_spec.rb
+++ b/spec/scheme/test_action_spec.rb
@@ -28,20 +28,72 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:should_use_launch_scheme_args_env => 'shouldUseLaunchSchemeArgsEnv')
 
-      xit '#testables' do
-        # @todo
+      it '#testables' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        @sut.xml_element.add_element('Testables')
+        
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        test_ref1 = XCScheme::TestAction::TestableReference.new(target1)
+        @sut.xml_element.elements['Testables'].add_element(test_ref1.xml_element)
+
+        target2 = project.new_target(:application, 'FooApp', :ios)
+        test_ref2 = XCScheme::TestAction::TestableReference.new(target2)
+        @sut.xml_element.elements['Testables'].add_element(test_ref2.xml_element)
+
+        @sut.testables.count.should == 2
+        @sut.testables.all? { |t| t.class.should == XCScheme::TestAction::TestableReference }
+        @sut.testables[0].xml_element.should == test_ref1.xml_element
+        @sut.testables[1].xml_element.should == test_ref2.xml_element
       end
 
-      xit '#add_testables' do
-        # @todo
+      it '#add_testables' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        test_ref1 = XCScheme::TestAction::TestableReference.new(target1)
+        @sut.add_testable(test_ref1)
+
+        target2 = project.new_target(:application, 'FooApp', :ios)
+        test_ref2 = XCScheme::TestAction::TestableReference.new(target2)
+        @sut.add_testable(test_ref2)
+
+        @sut.xml_element.elements['Testables'].count.should == 2
+        @sut.xml_element.elements['Testables/TestableReference[1]'].should == test_ref1.xml_element
+        @sut.xml_element.elements['Testables/TestableReference[2]'].should == test_ref2.xml_element
       end
 
-      xit '#macro_expansions' do
-        # @todo
+      it '#macro_expansions' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        @sut.xml_element.add_element('Testables')
+        
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        macro1 = XCScheme::MacroExpansion.new(target1)
+        @sut.xml_element.add_element(macro1.xml_element)
+
+        target2 = project.new_target(:application, 'FooApp', :ios)
+        macro2 = XCScheme::MacroExpansion.new(target2)
+        @sut.xml_element.add_element(macro2.xml_element)
+
+        @sut.macro_expansions.count.should == 2
+        @sut.macro_expansions.all? { |m| m.class.should == XCScheme::MacroExpansion }
+        @sut.macro_expansions[0].xml_element.should == macro1.xml_element
+        @sut.macro_expansions[1].xml_element.should == macro2.xml_element
       end
 
-      xit '#add_macro_expansion' do
-        # @todo
+      it '#add_macro_expansion' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        macro1 = XCScheme::MacroExpansion.new(target1)
+        @sut.add_macro_expansion(macro1)
+
+        target2 = project.new_target(:application, 'FooApp', :ios)
+        macro2 = XCScheme::MacroExpansion.new(target2)
+        @sut.add_macro_expansion(macro2)
+
+        @sut.xml_element.get_elements('MacroExpansion').count.should == 2
+        @sut.xml_element.elements['MacroExpansion[1]'].should == macro1.xml_element
+        @sut.xml_element.elements['MacroExpansion[2]'].should == macro2.xml_element
       end
     end
 
@@ -88,22 +140,22 @@ module Xcodeproj
         target = project.new_target(:application, 'FooApp', :ios)
         ref = XCScheme::BuildableReference.new(target)
         test_ref.add_buildable_reference(ref)
-        
+
         test_ref.xml_element.elements['BuildableReference'].should == ref.xml_element
       end
 
       it '#buildable_references' do
         project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
         test_ref = XCScheme::TestAction::TestableReference.new
-        
+
         target1 = project.new_target(:application, 'FooApp', :ios)
         ref1 = XCScheme::BuildableReference.new(target1)
         test_ref.add_buildable_reference(ref1)
-        
+
         target2 = project.new_target(:static_library, 'FooLib', :ios)
         ref2 = XCScheme::BuildableReference.new(target2)
         test_ref.add_buildable_reference(ref2)
-        
+
         test_ref.buildable_references.count.should == 2
         test_ref.buildable_references.all? { |e| e.class.should == XCScheme::BuildableReference }
         test_ref.buildable_references[0].xml_element.should == ref1.xml_element

--- a/spec/scheme/test_action_spec.rb
+++ b/spec/scheme/test_action_spec.rb
@@ -31,7 +31,7 @@ module Xcodeproj
       it '#testables' do
         project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
         @sut.xml_element.add_element('Testables')
-        
+
         target1 = project.new_target(:application, 'FooApp', :ios)
         test_ref1 = XCScheme::TestAction::TestableReference.new(target1)
         @sut.xml_element.elements['Testables'].add_element(test_ref1.xml_element)
@@ -65,7 +65,7 @@ module Xcodeproj
       it '#macro_expansions' do
         project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
         @sut.xml_element.add_element('Testables')
-        
+
         target1 = project.new_target(:application, 'FooApp', :ios)
         macro1 = XCScheme::MacroExpansion.new(target1)
         @sut.xml_element.add_element(macro1.xml_element)

--- a/spec/scheme/test_action_spec.rb
+++ b/spec/scheme/test_action_spec.rb
@@ -1,0 +1,114 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::TestAction do
+    it 'Creates a default XML node when created from scratch' do
+      test_action = Xcodeproj::XCScheme::TestAction.new(nil)
+      test_action.xml_element.name.should == 'TestAction'
+      test_action.xml_element.attributes.count.should == 4
+      test_action.xml_element.attributes['selectedDebuggerIdentifier'].should == 'Xcode.DebuggerFoundation.Debugger.LLDB'
+      test_action.xml_element.attributes['selectedLauncherIdentifier'].should == 'Xcode.DebuggerFoundation.Launcher.LLDB'
+      test_action.xml_element.attributes['shouldUseLaunchSchemeArgsEnv'].should == 'YES'
+      test_action.xml_element.attributes['buildConfiguration'].should == 'Debug'
+    end
+
+    it 'raises if created with an invalid XML node' do
+      node = REXML::Element.new('Foo')
+      should.raise(Informative) do
+        Xcodeproj::XCScheme::TestAction.new(node)
+      end.message.should.match /Wrong XML tag name/
+    end
+
+    describe 'Map attributes to XML' do
+      before do
+        node = REXML::Element.new('TestAction')
+        @sut = Xcodeproj::XCScheme::TestAction.new(node)
+      end
+
+      extend SpecHelper::XCScheme
+      specs_for_bool_attr(:should_use_launch_scheme_args_env => 'shouldUseLaunchSchemeArgsEnv')
+
+      xit '#testables' do
+        # @todo
+      end
+
+      xit '#add_testables' do
+        # @todo
+      end
+
+      xit '#macro_expansions' do
+        # @todo
+      end
+
+      xit '#add_macro_expansion' do
+        # @todo
+      end
+    end
+
+    describe XCScheme::TestAction::TestableReference do
+      it 'Creates a default XML node when created from scratch' do
+        test_ref = Xcodeproj::XCScheme::TestAction::TestableReference.new(nil)
+
+        test_ref.xml_element.name.should == 'TestableReference'
+        test_ref.xml_element.attributes.count.should == 1
+        test_ref.xml_element.attributes['skipped'].should == 'NO'
+      end
+
+      it 'raises if created with an invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::TestAction::TestableReference.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
+      it 'Uses the proper XML node when created from a target' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        target = project.new_target(:application, 'FooApp', :ios)
+        test_ref = Xcodeproj::XCScheme::TestAction::TestableReference.new(target)
+        test_ref.xml_element.name.should == 'TestableReference'
+      end
+
+      describe 'Map attributes to XML' do
+        extend SpecHelper::XCScheme
+
+        before do
+          @sut = Xcodeproj::XCScheme::TestAction::TestableReference.new(nil)
+        end
+
+        attributes = {
+          :skipped => 'skipped',
+        }
+        specs_for_bool_attr(attributes)
+      end
+
+      it '#add_buildable_reference' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        test_ref = XCScheme::TestAction::TestableReference.new
+
+        target = project.new_target(:application, 'FooApp', :ios)
+        ref = XCScheme::BuildableReference.new(target)
+        test_ref.add_buildable_reference(ref)
+        
+        test_ref.xml_element.elements['BuildableReference'].should == ref.xml_element
+      end
+
+      it '#buildable_references' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        test_ref = XCScheme::TestAction::TestableReference.new
+        
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        ref1 = XCScheme::BuildableReference.new(target1)
+        test_ref.add_buildable_reference(ref1)
+        
+        target2 = project.new_target(:static_library, 'FooLib', :ios)
+        ref2 = XCScheme::BuildableReference.new(target2)
+        test_ref.add_buildable_reference(ref2)
+        
+        test_ref.buildable_references.count.should == 2
+        test_ref.buildable_references.all? { |e| e.class.should == XCScheme::BuildableReference }
+        test_ref.buildable_references[0].xml_element.should == ref1.xml_element
+        test_ref.buildable_references[1].xml_element.should == ref2.xml_element
+      end
+    end
+  end
+end

--- a/spec/scheme/xml_element_wrapper_spec.rb
+++ b/spec/scheme/xml_element_wrapper_spec.rb
@@ -9,7 +9,7 @@ module Xcodeproj
     describe '#create_xml_element_with_fallback' do
       it 'uses node when tag match' do
         node = REXML::Element.new('Expected')
-        @wrapper.create_xml_element_with_fallback(node, 'Expected') do
+        @wrapper.send(:create_xml_element_with_fallback, node, 'Expected') do
           raise 'Block should not be executed'
         end
         @wrapper.xml_element.should == node
@@ -18,14 +18,14 @@ module Xcodeproj
       it 'raise when tag mismatch' do
         node = REXML::Element.new('BadTagName')
         should.raise Xcodeproj::Informative do
-          @wrapper.create_xml_element_with_fallback(node, 'Expected')
+          @wrapper.send(:create_xml_element_with_fallback, node, 'Expected')
         end.message.should.match /Wrong XML tag name/
         @wrapper.xml_element.should.nil?
       end
 
       it 'create a new node when target is not a node itself' do
         block_executed = false
-        @wrapper.create_xml_element_with_fallback('NotANode', 'Expected') do
+        @wrapper.send(:create_xml_element_with_fallback, 'NotANode', 'Expected') do
           block_executed = true
         end
         @wrapper.xml_element.class.should == REXML::Element
@@ -34,7 +34,7 @@ module Xcodeproj
       end
 
       it 'accept nil input and no block' do
-        @wrapper.create_xml_element_with_fallback(nil, 'Expected')
+        @wrapper.send(:create_xml_element_with_fallback, nil, 'Expected')
         @wrapper.xml_element.class.should == REXML::Element
         @wrapper.xml_element.name.should == 'Expected'
       end
@@ -42,26 +42,26 @@ module Xcodeproj
 
     describe '#bool_to_string' do
       it 'returns YES when true' do
-        @wrapper.instance_eval { bool_to_string(true) }.should == 'YES'
+        @wrapper.send(:bool_to_string, true).should == 'YES'
       end
 
       it 'returns NO when false' do
-        @wrapper.instance_eval { bool_to_string(false) }.should == 'NO'
+        @wrapper.send(:bool_to_string, false).should == 'NO'
       end
     end
 
     describe '#string_to_bool' do
       it 'returns true when YES' do
-        @wrapper.instance_eval { string_to_bool('YES') }.should == true
+        @wrapper.send(:string_to_bool, 'YES').should == true
       end
 
       it 'returns false when NO' do
-        @wrapper.instance_eval { string_to_bool('NO') }.should == false
+        @wrapper.send(:string_to_bool, 'NO').should == false
       end
 
       it 'raises when unknown string' do
         should.raise Xcodeproj::Informative do
-          @wrapper.instance_eval { string_to_bool('Meh') }
+          @wrapper.send(:string_to_bool, 'Meh')
         end.message.should.match /Invalid tag value. Expected YES or NO./
       end
     end

--- a/spec/scheme/xml_element_wrapper_spec.rb
+++ b/spec/scheme/xml_element_wrapper_spec.rb
@@ -1,0 +1,69 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::XMLElementWrapper do
+    before do
+      @wrapper = Xcodeproj::XCScheme::XMLElementWrapper.new
+    end
+
+    describe '#create_xml_element_with_fallback' do
+      it 'uses node when tag match' do
+        node = REXML::Element.new('Expected')
+        @wrapper.create_xml_element_with_fallback(node, 'Expected') do
+          raise 'Block should not be executed'
+        end
+        @wrapper.xml_element.should == node
+      end
+
+      it 'raise when tag mismatch' do
+        node = REXML::Element.new('BadTagName')
+        should.raise Xcodeproj::Informative do
+          @wrapper.create_xml_element_with_fallback(node, 'Expected')
+        end.message.should.match /Wrong XML tag name/
+        @wrapper.xml_element.should.nil?
+      end
+
+      it 'create a new node when target is not a node itself' do
+        block_executed = false
+        @wrapper.create_xml_element_with_fallback('NotANode', 'Expected') do
+          block_executed = true
+        end
+        @wrapper.xml_element.class.should == REXML::Element
+        @wrapper.xml_element.name.should == 'Expected'
+        block_executed.should == true
+      end
+
+      it 'accept nil input and no block' do
+        @wrapper.create_xml_element_with_fallback(nil, 'Expected')
+        @wrapper.xml_element.class.should == REXML::Element
+        @wrapper.xml_element.name.should == 'Expected'
+      end
+    end
+
+    describe '#bool_to_string' do
+      it 'returns YES when true' do
+        @wrapper.instance_eval { bool_to_string(true) }.should == 'YES'
+      end
+
+      it 'returns NO when false' do
+        @wrapper.instance_eval { bool_to_string(false) }.should == 'NO'
+      end
+    end
+
+    describe '#string_to_bool' do
+      it 'returns true when YES' do
+        @wrapper.instance_eval { string_to_bool('YES') }.should == true
+      end
+
+      it 'returns false when NO' do
+        @wrapper.instance_eval { string_to_bool('NO') }.should == false
+      end
+
+      it 'raises when unknown string' do
+        should.raise Xcodeproj::Informative do
+          @wrapper.instance_eval { string_to_bool('Meh') }
+        end.message.should.match /Invalid tag value. Expected YES or NO./
+      end
+    end
+  end
+end

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -115,11 +115,12 @@ module ProjectSpecs
       it 'Constructs ReferencedContainer attributes correctly' do
         project = Xcodeproj::Project.new('/project_dir/Project.xcodeproj')
         target = project.new_target(:application, 'iOS application', :osx)
+        buildable_ref = Xcodeproj::BuildableReference.new(nil)
 
-        @scheme.send(:construct_referenced_container_uri, target).should == 'container:Project.xcodeproj'
+        buildable_ref.send(:construct_referenced_container_uri, target).should == 'container:Project.xcodeproj'
 
         project.root_object.project_dir_path = '/a_dir'
-        @scheme.send(:construct_referenced_container_uri, target).should == 'container:../project_dir/Project.xcodeproj'
+        buildable_ref.send(:construct_referenced_container_uri, target).should == 'container:../project_dir/Project.xcodeproj'
       end
 
       describe 'For iOS Application' do

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -70,13 +70,13 @@ module ProjectSpecs
 
     describe 'Creating a Shared Scheme' do
       before do
-        @ios_application = @project.new_target(:application, 'iOS application', :osx)
+        @ios_application = @project.new_target(:application, 'iOS application', :ios)
         @ios_application.stubs(:uuid).returns('E52523F316245AB20012E2BA')
-        @ios_application_tests = @project.new_target(:bundle, 'iOS applicationTests', :osx)
+        @ios_application_tests = @project.new_target(:octest_bundle, 'iOS applicationTests', :ios)
         @ios_application_tests.stubs(:uuid).returns('E525241E16245AB20012E2BA')
         @ios_static_library = @project.new_target(:bundle, 'iOS staticLibrary', :osx)
         @ios_static_library.stubs(:uuid).returns('806F6FC217EFAF47001051EE')
-        @ios_static_library_tests = @project.new_target(:bundle, 'iOS staticLibraryTests', :osx)
+        @ios_static_library_tests = @project.new_target(:octest_bundle, 'iOS staticLibraryTests', :ios)
         @ios_static_library_tests.stubs(:uuid).returns('806F6FC217EFAF47001051EE')
 
         @scheme = Xcodeproj::XCScheme.new

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -115,7 +115,7 @@ module ProjectSpecs
       it 'Constructs ReferencedContainer attributes correctly' do
         project = Xcodeproj::Project.new('/project_dir/Project.xcodeproj')
         target = project.new_target(:application, 'iOS application', :osx)
-        buildable_ref = Xcodeproj::BuildableReference.new(nil)
+        buildable_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
 
         buildable_ref.send(:construct_referenced_container_uri, target).should == 'container:Project.xcodeproj'
 

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -13,6 +13,90 @@ module ProjectSpecs
 
     #-------------------------------------------------------------------------#
 
+    describe 'Load an existing scheme from file' do
+      before do
+        scheme_path = fixture_path('SharedSchemes', 'SharedSchemes.xcodeproj/xcshareddata/xcschemes/SharedSchemes.xcscheme')
+        @scheme = Xcodeproj::XCScheme.new(scheme_path)
+      end
+
+      it 'Properly map the scheme\'s BuildAction' do
+        @scheme.build_action.parallelize_buildables?.should == true
+        @scheme.build_action.build_implicit_dependencies?.should == true
+        @scheme.build_action.entries.count.should == 1
+
+        entry = @scheme.build_action.entries[0]
+        entry.class.should == Xcodeproj::XCScheme::BuildAction::Entry
+        entry.build_for_testing?.should == true
+        entry.build_for_running?.should == true
+        entry.build_for_profiling?.should == true
+        entry.build_for_archiving?.should == true
+        entry.build_for_analyzing?.should == true
+
+        entry.buildable_references.count.should == 1
+        ref = entry.buildable_references[0]
+        ref.target_name.should == 'SharedSchemes'
+        ref.target_uuid.should == '632143E8175736EE0038D40D'
+        ref.buildable_name.should == 'SharedSchemes.app'
+        ref.target_referenced_container.should == 'container:SharedSchemes.xcodeproj'
+      end
+
+      it 'Properly map the scheme\'s TestAction' do
+        @scheme.test_action.should_use_launch_scheme_args_env?.should == true
+        @scheme.test_action.build_configuration.should == 'Debug'
+
+        @scheme.test_action.testables.count.should == 0
+        @scheme.test_action.macro_expansions.count.should == 1
+
+        macro = @scheme.test_action.macro_expansions[0]
+        macro.class.should == Xcodeproj::XCScheme::MacroExpansion
+
+        ref = macro.buildable_reference
+        ref.target_name.should == 'SharedSchemes'
+        ref.target_uuid.should == '632143E8175736EE0038D40D'
+        ref.buildable_name.should == 'SharedSchemes.app'
+        ref.target_referenced_container.should == 'container:SharedSchemes.xcodeproj'
+      end
+
+      it 'Properly map the scheme\'s LaunchAction' do
+        @scheme.launch_action.allow_location_simulation?.should == true
+        @scheme.launch_action.build_configuration.should == 'Debug'
+
+        bpr = @scheme.launch_action.buildable_product_runnable
+        bpr.class.should == Xcodeproj::XCScheme::BuildableProductRunnable
+
+        ref = bpr.buildable_reference
+        ref.target_name.should == 'SharedSchemes'
+        ref.target_uuid.should == '632143E8175736EE0038D40D'
+        ref.buildable_name.should == 'SharedSchemes.app'
+        ref.target_referenced_container.should == 'container:SharedSchemes.xcodeproj'
+      end
+
+      it 'Properly map the scheme\'s ProfileAction' do
+        @scheme.profile_action.should_use_launch_scheme_args_env?.should == true
+        @scheme.profile_action.build_configuration.should == 'Release'
+
+        bpr = @scheme.launch_action.buildable_product_runnable
+        bpr.class.should == Xcodeproj::XCScheme::BuildableProductRunnable
+
+        ref = bpr.buildable_reference
+        ref.target_name.should == 'SharedSchemes'
+        ref.target_uuid.should == '632143E8175736EE0038D40D'
+        ref.buildable_name.should == 'SharedSchemes.app'
+        ref.target_referenced_container.should == 'container:SharedSchemes.xcodeproj'
+      end
+
+      it 'Properly map the scheme\'s AnalyzeAction' do
+        @scheme.analyze_action.build_configuration.should == 'Debug'
+      end
+
+      it 'Properly map the scheme\'s ArchiveAction' do
+        @scheme.archive_action.build_configuration.should == 'Release'
+        @scheme.archive_action.reveal_archive_in_organizer?.should == true
+      end
+    end
+
+    #-------------------------------------------------------------------------#
+
     describe 'Serialization' do
       before do
         app = @project.new_target(:application, 'iOS application', :osx)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,7 @@ $LOAD_PATH.unshift((ROOT + 'spec').to_s)
 require 'spec_helper/project'
 require 'spec_helper/project_helper'
 require 'spec_helper/temporary_directory'
+require 'spec_helper/xcscheme'
 
 def fixture_path(*path)
   File.join(File.dirname(__FILE__), 'fixtures', *path)

--- a/spec/spec_helper/xcscheme.rb
+++ b/spec/spec_helper/xcscheme.rb
@@ -2,32 +2,31 @@ module SpecHelper
   module XCScheme
     def specs_for_bool_attr(attributes_map)
       attributes_map.each do |property, xml_attribute_name|
-        attr_reader_sym = (property.to_s+'?').to_sym
-        attr_writer_sym = (property.to_s+'=').to_sym
+        attr_reader_sym = (property.to_s + '?').to_sym
+        attr_writer_sym = (property.to_s + '=').to_sym
 
         describe property do
-          it "##{property.to_s}? detect a true value" do
-            attr_reader_sym = (property.to_s+'?').to_sym
+          it "##{property}? detect a true value" do
             @sut.xml_element.attributes[xml_attribute_name] = 'YES'
             @sut.send(attr_reader_sym).should == true
           end
 
-          it "##{property.to_s}? detect a false value" do
+          it "##{property}? detect a false value" do
             @sut.xml_element.attributes[xml_attribute_name] = 'NO'
             @sut.send(attr_reader_sym).should == false
           end
 
-          it "##{property.to_s}? detect an invalid value" do
+          it "##{property}? detect an invalid value" do
             @sut.xml_element.attributes[xml_attribute_name] = 'BadValue'
             should.raise(Xcodeproj::Informative) { @sut.send(attr_reader_sym) }
           end
 
-          it "##{property.to_s}= set true value" do
+          it "##{property}= set true value" do
             @sut.send(attr_writer_sym, true)
             @sut.xml_element.attributes[xml_attribute_name].should == 'YES'
           end
 
-          it "##{property.to_s}= set false value" do
+          it "##{property}= set false value" do
             @sut.send(attr_writer_sym, false)
             @sut.xml_element.attributes[xml_attribute_name].should == 'NO'
           end

--- a/spec/spec_helper/xcscheme.rb
+++ b/spec/spec_helper/xcscheme.rb
@@ -2,24 +2,35 @@ module SpecHelper
   module XCScheme
     def specs_for_bool_attr(attributes_map)
       attributes_map.each do |property, xml_attribute_name|
-        it "##{property.to_s}?" do
-          attr_reader_sym = (property.to_s+'?').to_sym
-          @sut.xml_element.attributes[xml_attribute_name] = 'YES'
-          @sut.send(attr_reader_sym).should == true
-          
-          @sut.xml_element.attributes[xml_attribute_name] = 'NO'
-          @sut.send(attr_reader_sym).should == false
-          
-          @sut.xml_element.attributes[xml_attribute_name] = 'BadValue'
-          should.raise(Xcodeproj::Informative) { @sut.send(attr_reader_sym) }
-        end
+        attr_reader_sym = (property.to_s+'?').to_sym
+        attr_writer_sym = (property.to_s+'=').to_sym
 
-        it "##{property.to_s}=" do
-          attr_writer_sym = (property.to_s+'=').to_sym
-          @sut.send(attr_writer_sym, true)
-          @sut.xml_element.attributes[xml_attribute_name].should == 'YES'
-          @sut.send(attr_writer_sym, false)
-          @sut.xml_element.attributes[xml_attribute_name].should == 'NO'
+        describe property do
+          it "##{property.to_s}? detect a true value" do
+            attr_reader_sym = (property.to_s+'?').to_sym
+            @sut.xml_element.attributes[xml_attribute_name] = 'YES'
+            @sut.send(attr_reader_sym).should == true
+          end
+
+          it "##{property.to_s}? detect a false value" do
+            @sut.xml_element.attributes[xml_attribute_name] = 'NO'
+            @sut.send(attr_reader_sym).should == false
+          end
+
+          it "##{property.to_s}? detect an invalid value" do
+            @sut.xml_element.attributes[xml_attribute_name] = 'BadValue'
+            should.raise(Xcodeproj::Informative) { @sut.send(attr_reader_sym) }
+          end
+
+          it "##{property.to_s}= set true value" do
+            @sut.send(attr_writer_sym, true)
+            @sut.xml_element.attributes[xml_attribute_name].should == 'YES'
+          end
+
+          it "##{property.to_s}= set false value" do
+            @sut.send(attr_writer_sym, false)
+            @sut.xml_element.attributes[xml_attribute_name].should == 'NO'
+          end
         end
       end
     end

--- a/spec/spec_helper/xcscheme.rb
+++ b/spec/spec_helper/xcscheme.rb
@@ -1,0 +1,27 @@
+module SpecHelper
+  module XCScheme
+    def specs_for_bool_attr(attributes_map)
+      attributes_map.each do |property, xml_attribute_name|
+        it "##{property.to_s}?" do
+          attr_reader_sym = (property.to_s+'?').to_sym
+          @sut.xml_element.attributes[xml_attribute_name] = 'YES'
+          @sut.send(attr_reader_sym).should == true
+          
+          @sut.xml_element.attributes[xml_attribute_name] = 'NO'
+          @sut.send(attr_reader_sym).should == false
+          
+          @sut.xml_element.attributes[xml_attribute_name] = 'BadValue'
+          should.raise(Xcodeproj::Informative) { @sut.send(attr_reader_sym) }
+        end
+
+        it "##{property.to_s}=" do
+          attr_writer_sym = (property.to_s+'=').to_sym
+          @sut.send(attr_writer_sym, true)
+          @sut.xml_element.attributes[xml_attribute_name].should == 'YES'
+          @sut.send(attr_writer_sym, false)
+          @sut.xml_element.attributes[xml_attribute_name].should == 'NO'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The PR aims to refactor `Xcodeproj::XCScheme` to make it possible to **load and manipulate existing schemes** (as so far, creating `.xcscheme` files from scratch was the only option possible).

_Note: This refactoring is expected to avoid breaking the existing API. Only new features have been added to the existing `XCScheme` class, and the implementation of the existing API have been simply adapted to the new model while keeping the method signatures intact._

---

* [x] Refactoring of `Xcodeproj::XCScheme` to wrap xcscheme elements in nicer objects
* [x] Make existing specs pass to ensure non-regression
* [x] Add new specs for newly introduced features
   * [x] access to new xcscheme attributes that weren't exposed by the previous API
   * [x] creating a `XCScheme` instance by loading an existing `.xcscheme` file
   * [x] test the new code with `CocoaPods`, to ensure it does not break even if we missed some specs
* [x] Improve YARD doc
* [x] CHANGELOG


> :memo: :eyes:  Code reviews welcome (the code is conceptually finished, I only expect to make small bug fixes if future added specs fail or whatnot)