### PR TITLE
#192 xcdatamodeld not handled properly

### DIFF
--- a/lib/xcodeproj/project/object/helpers/file_references_factory.rb
+++ b/lib/xcodeproj/project/object/helpers/file_references_factory.rb
@@ -126,7 +126,11 @@ module Xcodeproj
           # @return [XCVersionGroup] The new reference.
           #
           def new_xcdatamodeld(group, path, source_tree)
-            path = Pathname.new(group.parent.path).realpath().join(group.path).join(path)
+            if group.parent.path
+              path = Pathname.new(group.parent.path).realpath.join(group.path).join(path)
+            else
+              path = Pathname.new(path)
+            end
             ref = group.project.new(XCVersionGroup)
             group.children << ref
             GroupableHelper.set_path_with_source_tree(ref, path, source_tree)

--- a/lib/xcodeproj/project/object/helpers/file_references_factory.rb
+++ b/lib/xcodeproj/project/object/helpers/file_references_factory.rb
@@ -126,7 +126,7 @@ module Xcodeproj
           # @return [XCVersionGroup] The new reference.
           #
           def new_xcdatamodeld(group, path, source_tree)
-            path = Pathname.new(path)
+            path = Pathname.new(group.parent.path).realpath().join(group.path).join(path)
             ref = group.project.new(XCVersionGroup)
             group.children << ref
             GroupableHelper.set_path_with_source_tree(ref, path, source_tree)


### PR DESCRIPTION
- Actually worked correclty if xcdatamodeld is in root of project but not if the data model is inside a folder off the root
- Added code to construct correct path from group.parent.path, group.path and path
- Original code would skip children and current version code since path.exists? for data models in a subdirectory would fail
- [ ] Needs a test to simulate datamodel in a sub-directory to prove this fixes the problem 
