### PR TITLE
Fixes ordering to be case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   it using `Xcodeproj::XCScheme`.  
   [Olivier Halligon](https://github.com/AliSoftware)
   [Xcodeproj#288](https://github.com/CocoaPods/Xcodeproj/pull/288)
+  
+ * The pods will now be ordered case insensitively in the Project navigator and where the targets are listed in Xcode.
+  [Emma Koszinowski](http://github.com/emkosz)
+  [#3684](https://github.com/CocoaPods/CocoaPods/issues/3684)
 
 ## 0.26.3
 

--- a/lib/xcodeproj/project/object.rb
+++ b/lib/xcodeproj/project/object.rb
@@ -145,7 +145,7 @@ module Xcodeproj
           to_many_attributes.each do |attrb|
             list = attrb.get_value(self)
             list.sort! do |x, y|
-              x.display_name <=> y.display_name
+              x.display_name.downcase <=> y.display_name.downcase
             end
           end
         end

--- a/lib/xcodeproj/project/object/group.rb
+++ b/lib/xcodeproj/project/object/group.rb
@@ -406,9 +406,9 @@ module Xcodeproj
               end
             end
 
-            result = File.basename(x.display_name, '.*') <=> File.basename(y.display_name, '.*')
+            result = File.basename(x.display_name.downcase, '.*') <=> File.basename(y.display_name.downcase, '.*')
             if result.zero?
-              File.extname(x.display_name) <=> File.extname(y.display_name)
+              File.extname(x.display_name.downcase) <=> File.extname(y.display_name.downcase)
             else
               result
             end

--- a/spec/project/object/group_spec.rb
+++ b/spec/project/object/group_spec.rb
@@ -291,6 +291,15 @@ module ProjectSpecs
           @group.sort(:groups_position => :below)
           @group.children.map(&:display_name).should == %w(A.h A.m B.h B.m A)
         end
+
+        it 'sorts case insensitive' do
+          files = 'JSAnimatedImageView', 'MSWeakTimer', 'Pods-CPtestAlphabetic', 'iRate'
+          files.each do |file|
+            @group.new_group(file)
+          end
+          @group.sort
+          @group.children.map(&:display_name).should == ['iRate', 'JSAnimatedImageView', 'MSWeakTimer', 'Pods-CPtestAlphabetic']
+        end
       end
     end
 

--- a/spec/project/object_spec.rb
+++ b/spec/project/object_spec.rb
@@ -283,6 +283,13 @@ module ProjectSpecs
       end
     end
 
+      it 'sorts display_names case insensitively' do
+        @test_instance.files << @project.new_file('Classes/JSAnimatedImageView.m')
+        @test_instance.files << @project.new_file('Classes/MSWeakTimer.m')
+        @test_instance.files << @project.new_file('Classes/iRate.m')
+        @test_instance.sort
+        @test_instance.files.map(&:display_name).should == ['iRate.m', 'JSAnimatedImageView.m', 'MSWeakTimer.m']
+      end
     #-------------------------------------------------------------------------#
   end
 end

--- a/spec/project/object_spec.rb
+++ b/spec/project/object_spec.rb
@@ -281,7 +281,6 @@ module ProjectSpecs
         @test_instance.files << f
         f.referrers.should.include?(@test_instance)
       end
-    end
 
       it 'sorts display_names case insensitively' do
         @test_instance.files << @project.new_file('Classes/JSAnimatedImageView.m')
@@ -290,6 +289,7 @@ module ProjectSpecs
         @test_instance.sort
         @test_instance.files.map(&:display_name).should == ['iRate.m', 'JSAnimatedImageView.m', 'MSWeakTimer.m']
       end
+    end
     #-------------------------------------------------------------------------#
   end
 end


### PR DESCRIPTION
Fixes the issue: https://github.com/CocoaPods/CocoaPods/issues/3684

The pods are sorted case insensitively in the Project navigator and where the Targets are listed in Xcode. 

![screenshot 2015-08-06 16 35 09](https://cloud.githubusercontent.com/assets/10301979/9125801/332e4e38-3c59-11e5-8ba4-4eda70ce8810.png)

Happy to hear your feedback :-)
