### PR TITLE
[Config] Ignore inherited-only values when serializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 * Trailing whitespace is stripped when serializing XCConfig files.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* XCConfig values that are only `$(inherited)` will be omitted during
+  serialization.  
+  [Samuel Giddins](https://github.com/segiddins)
+
 
 ## 0.26.3 (2015-07-26)
 

--- a/lib/xcodeproj/config.rb
+++ b/lib/xcodeproj/config.rb
@@ -131,6 +131,7 @@ module Xcodeproj
 
       result = attributes.dup
       result['OTHER_LDFLAGS'] = list.join(' ') unless list.empty?
+      result.reject! { |_, v| %w($(inherited) ${inherited}).freeze.any? { |i| i == v.strip } }
 
       if prefix
         Hash[result.map { |k, v| [prefix + k, v] }]

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -79,6 +79,11 @@ describe Xcodeproj::Config do
       @config.to_hash.should.be.equal @hash
     end
 
+    it 'ignores settings that are only inherited in #to_hash' do
+      config = Xcodeproj::Config.new('Y' => '$(inherited)', 'Z' => '${inherited}', 'X' => '$(inherited) 1')
+      config.to_hash.should == { 'X' => '$(inherited) 1' }
+    end
+
     it 'can prefix values during serialization' do
       @prefix_hash = { 'PODS_PREFIX_OTHER_LDFLAGS' => @hash['OTHER_LDFLAGS'] }
       @config.to_hash('PODS_PREFIX_').should.be.equal @prefix_hash


### PR DESCRIPTION
This way, we can be much more liberal about the settings that start off as `inherited` without cluttering up config files with redundant values.

\c @alloy @neonichu 