### PR TITLE
Fixed - Parse the available SDKs instead of using the constants

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -4,11 +4,11 @@ module Xcodeproj
   module Constants
     # @return [String] The last known iOS SDK (stable).
     #
-    LAST_KNOWN_IOS_SDK = '8.3'
+    LAST_KNOWN_IOS_SDK = '9.0'
 
     # @return [String] The last known OS X SDK (stable).
     #
-    LAST_KNOWN_OSX_SDK  = '10.10'
+    LAST_KNOWN_OSX_SDK  = '10.11'
 
     # @return [String] The last known watchOS SDK (unstable).
     LAST_KNOWN_WATCHOS_SDK = '2.0'

--- a/lib/xcodeproj/gem_version.rb
+++ b/lib/xcodeproj/gem_version.rb
@@ -1,5 +1,5 @@
 module Xcodeproj
   # The version of the xcodeproj gem.
   #
-  VERSION = '0.27.0' unless defined? Xcodeproj::VERSION
+  VERSION = '0.27.0-pm' unless defined? Xcodeproj::VERSION
 end

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -5,8 +5,8 @@ Gem::Specification.new do |s|
   s.name     = "xcodeproj"
   s.version  = Xcodeproj::VERSION
   s.license  = "MIT"
-  s.email    = "eloy.de.enige@gmail.com"
-  s.homepage = "https://github.com/cocoapods/xcodeproj"
+  s.email    = "carles@pacemaker.net"
+  s.homepage = "https://github.com/pacemakermusic/Xcodeproj.git"
   s.authors  = ["Eloy Duran"]
 
   s.summary     = "Create and modify Xcode projects from Ruby."


### PR DESCRIPTION
The current LAST_KNOWN_IOS_SDK is 8.3 but watchOS2 apps require 9.0.
We think it makes more sense to get the latest SDK from the current system rather than blindly assigning from a constant which may not exist in file.

In our case, Xcode 7 beta 6 comes with 9.0 but not with 8.3. So all the system frameworks would be pointing to nowhere.

NOTICE: There's a noticeable impact on performance when parsing the SDKs instead of using the constants. Probably we're doing it in a dumb way and there's a smarter alternative.