### PR TITLE
[GroupableHelper] Fix getting the parent of an xcdatamodel file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 * Allow opening and saving projects that have circular target dependencies.  
   [Samuel Giddins](https://github.com/segiddins)
-  [#4229](https://github.com/CocoaPods/CocoaPods/issues/4229)
+  [CocoaPods#4229](https://github.com/CocoaPods/CocoaPods/issues/4229)
+
+* Fix the generation of deterministic UUIDs for `.xcdatamodeld` bundles.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#4187](https://github.com/CocoaPods/CocoaPods/issues/4187)
 
 
 ## 0.27.2 (2015-09-02)

--- a/lib/xcodeproj/project/object/helpers/groupable_helper.rb
+++ b/lib/xcodeproj/project/object/helpers/groupable_helper.rb
@@ -11,7 +11,7 @@ module Xcodeproj
           def parent(object)
             referrers = object.referrers.uniq
             if referrers.count > 1
-              referrers = referrers.select { |obj| obj.isa == 'PBXGroup' }
+              referrers = referrers.grep(PBXGroup)
             end
 
             if referrers.count == 0


### PR DESCRIPTION
This causes XCVersionGroups (.xcdatamodeld bundles) to also be considered as potential parents

Closes https://github.com/CocoaPods/CocoaPods/issues/4187.

\c @kylef 