### PR TITLE
[XCScheme] Add support for code_coverage_enabled setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Add `tvos` as a new platform.  
   [Boris Bügling](https://github.com/neonichu)
   [Xcodeproj#301](https://github.com/CocoaPods/Xcodeproj/pull/301)
+* Allow accessing the new Xcode 7's Clang code coverage setting on XCSchemes ("Gather Code Coverage" checkbox).  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#307](https://github.com/CocoaPods/Xcodeproj/pull/307)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 * Add `tvos` as a new platform.  
   [Boris Bügling](https://github.com/neonichu)
   [Xcodeproj#301](https://github.com/CocoaPods/Xcodeproj/pull/301)
-* Allow accessing the new Xcode 7's Clang code coverage setting on XCSchemes ("Gather Code Coverage" checkbox).  
+* Allow accessing the new Xcode 7's Clang code coverage setting on XCSchemes
+  ("Gather Code Coverage" checkbox).  
   [Olivier Halligon](https://github.com/AliSoftware)
   [#307](https://github.com/CocoaPods/Xcodeproj/pull/307)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `tvos` as a new platform.  
   [Boris Bügling](https://github.com/neonichu)
   [Xcodeproj#301](https://github.com/CocoaPods/Xcodeproj/pull/301)
+
 * Allow accessing the new Xcode 7's Clang code coverage setting on XCSchemes
   ("Gather Code Coverage" checkbox).  
   [Olivier Halligon](https://github.com/AliSoftware)

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -36,14 +36,14 @@ module Xcodeproj
       end
 
       # @return [Bool]
-      #         Whether Xcode7's Clang Code Coverage is enabled ('Gather coverage data' turned ON)
+      #         Whether Clang Code Coverage is enabled ('Gather coverage data' turned ON)
       #
       def code_coverage_enabled?
         string_to_bool(@xml_element.attributes['codeCoverageEnabled'])
       end
 
       # @rparam [Bool] flag
-      #         Set whether Xcode7's Clang Code Coverage is enabled ('Gather coverage data' turned ON)
+      #         Set whether Clang Code Coverage is enabled ('Gather coverage data' turned ON)
       #
       def code_coverage_enabled=(flag)
         @xml_element.attributes['codeCoverageEnabled'] = bool_to_string(flag)

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -28,11 +28,25 @@ module Xcodeproj
       end
 
       # @param [Bool] flag
-      #        Set Whether this Test Action should use the same arguments and environment variables
+      #        Set whether this Test Action should use the same arguments and environment variables
       #        as the Launch Action.
       #
       def should_use_launch_scheme_args_env=(flag)
         @xml_element.attributes['shouldUseLaunchSchemeArgsEnv'] = bool_to_string(flag)
+      end
+
+      # @return [Bool]
+      #         Whether Xcode7's Clang Code Coverage is enabled ('Gather coverage data' turned ON)
+      #
+      def code_coverage_enabled?
+        string_to_bool(@xml_element.attributes['codeCoverageEnabled'])
+      end
+
+      # @rparam [Bool] flag
+      #         Set whether Xcode7's Clang Code Coverage is enabled ('Gather coverage data' turned ON)
+      #
+      def code_coverage_enabled=(flag)
+        @xml_element.attributes['codeCoverageEnabled'] = bool_to_string(flag)
       end
 
       # @return [Array<TestableReference>]

--- a/spec/scheme/test_action_spec.rb
+++ b/spec/scheme/test_action_spec.rb
@@ -27,6 +27,7 @@ module Xcodeproj
 
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:should_use_launch_scheme_args_env => 'shouldUseLaunchSchemeArgsEnv')
+      specs_for_bool_attr(:code_coverage_enabled => 'codeCoverageEnabled')
 
       it '#testables' do
         project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')


### PR DESCRIPTION
That new Xcode 7 "Gather Code Coverage" setting in your scheme's Test Action.

Will be useful for venmo/slather#99