### PR TITLE
Add `XCScheme#save!` to save scheme in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   [Olivier Halligon](https://github.com/AliSoftware)
   [#307](https://github.com/CocoaPods/Xcodeproj/pull/307)
 
+* Adds `Xcodeproj::XCScheme#save!` to save in place when 
+  the `XCScheme` object was initialized from an existing file.  
+  [Olivier Halligon](https://github.com/AliSoftware)
+  [#308](https://github.com/CocoaPods/Xcodeproj/pull/308)
+
 ##### Bug Fixes
 
 * Allow opening and saving projects that have circular target dependencies.  

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -35,7 +35,6 @@ module Xcodeproj
 
         @scheme = @doc.elements['Scheme']
       else
-        @file_path = nil
         @doc = REXML::Document.new
         @doc.context[:attribute_quote] = :quote
         @doc << REXML::XMLDecl.new(REXML::XMLDecl::DEFAULT_VERSION, 'UTF-8')

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -29,11 +29,13 @@ module Xcodeproj
     #
     def initialize(file_path = nil)
       if file_path
+        @file_path = file_path
         @doc = REXML::Document.new(File.new(file_path))
         @doc.context[:attribute_quote] = :quote
 
         @scheme = @doc.elements['Scheme']
       else
+        @file_path = nil
         @doc = REXML::Document.new
         @doc.context[:attribute_quote] = :quote
         @doc << REXML::XMLDecl.new(REXML::XMLDecl::DEFAULT_VERSION, 'UTF-8')
@@ -307,6 +309,19 @@ module Xcodeproj
       scheme_folder_path.mkpath
       scheme_path = scheme_folder_path + "#{name}.xcscheme"
       File.open(scheme_path, 'w') do |f|
+        f.write(to_s)
+      end
+    end
+
+    # Serializes the current state of the object to the original ".xcscheme"
+    # file this XCScheme was created from, overriding the original file.
+    #
+    # Requires that the XCScheme object was initialized using a file path.
+    #
+    def save!
+      raise Informative, 'This XCScheme object was not initialized ' \
+        'using a file path. Use save_as instead.' unless @file_path
+      File.open(@file_path, 'w') do |f|
         f.write(to_s)
       end
     end


### PR DESCRIPTION
When initialized from an existing `*.xcscheme` file, this allows to modify the existing schemes and save them more easily — as in such cases, the `save_as` (taking the path to the `xcodeproj` + scheme name as separate parameters) is not the most appropriate:

```ruby
s = Xcodeproj::XCScheme.new(some_path)
# … play with s, modify stuff
s.save!
```