### PR TITLE
Silence `dyld` warnings appearing on OS X 10.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [Samuel Giddins](https://github.com/)
   [CocoaPods#4291](https://github.com/CocoaPods/CocoaPods/issues/4291)
 
+* Silence `dyld` warnings appearing on OS X 10.11.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#312](https://github.com/CocoaPods/Xcodeproj/pull/312)
+
 
 ## 0.28.0 (2015-10-01)
 

--- a/lib/xcodeproj/plist_helper.rb
+++ b/lib/xcodeproj/plist_helper.rb
@@ -645,13 +645,15 @@ module DevToolsCore
   # @note The IB frameworks only seem to be necessary on Xcode 7+
   #
   def self.load_xcode_frameworks
-    load_xcode_framework('SharedFrameworks/DVTFoundation.framework/DVTFoundation')
-    load_xcode_framework('SharedFrameworks/DVTSourceControl.framework/DVTSourceControl')
-    load_xcode_framework('SharedFrameworks/CSServiceClient.framework/CSServiceClient')
-    load_xcode_framework('Frameworks/IBFoundation.framework/IBFoundation')
-    load_xcode_framework('Frameworks/IBAutolayoutFoundation.framework/IBAutolayoutFoundation')
-    load_xcode_framework('Frameworks/IDEFoundation.framework/IDEFoundation')
-    load_xcode_framework('PlugIns/Xcode3Core.ideplugin/Contents/MacOS/Xcode3Core')
+    DevToolsCore.silence_stderr do
+      load_xcode_framework('SharedFrameworks/DVTFoundation.framework/DVTFoundation')
+      load_xcode_framework('SharedFrameworks/DVTSourceControl.framework/DVTSourceControl')
+      load_xcode_framework('SharedFrameworks/CSServiceClient.framework/CSServiceClient')
+      load_xcode_framework('Frameworks/IBFoundation.framework/IBFoundation')
+      load_xcode_framework('Frameworks/IBAutolayoutFoundation.framework/IBAutolayoutFoundation')
+      load_xcode_framework('Frameworks/IDEFoundation.framework/IDEFoundation')
+      load_xcode_framework('PlugIns/Xcode3Core.ideplugin/Contents/MacOS/Xcode3Core')
+    end
   end
 
   class CFDictionary < NSObject


### PR DESCRIPTION
cc @segiddins 