### PR TITLE
Adding .hxx to the list of recognized header file extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   [Boris Bügling](https://github.com/neonichu)
   [Xcodeproj#318](https://github.com/CocoaPods/Xcodeproj/pull/318)
 
+* Added .hxx to the list of recognized header file extensions.  
+  [Jason Vasquez](https://github.com/jasonvasquez)
+  [Xcodeproj#320](https://github.com/CocoaPods/Xcodeproj/pull/320)
 
 ## 0.28.2 (2015-10-09)
 

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -314,6 +314,6 @@ module Xcodeproj
 
     # @return [Array] The extensions which are associated with header files.
     #
-    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .tpp).freeze
+    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .tpp .hxx).freeze
   end
 end


### PR DESCRIPTION
I've run into a few cases with some third party open source libraries I'm wrapping in Cocoapods, where they use `.hxx` as a header extension in C++ projects.  I have .podspec `prepare_command`'s to actually rename all the files and update references to them, otherwise, we generate build rules for all the `.hxx` files.  That is obviously not optimal.  Xcode recognizes these as headers already, we just need to slot them in the right build phase.