### PR TITLE
Escape XML entities in workspace file reference nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
   [Samuel Giddins](https://github.com/segiddins)
   [CocoaPods#3652](https://github.com/CocoaPods/CocoaPods/issues/3652)
 
+* Escape XML entities in project names when writing workspace
+  [Caesar Wirth](https://github.com/cjwirth)
+  [CocoaPods#4446](https://github.com/CocoaPods/CocoaPods/issues/4446)
 
 ## 0.28.2 (2015-10-09)
 

--- a/lib/xcodeproj/workspace.rb
+++ b/lib/xcodeproj/workspace.rb
@@ -240,7 +240,7 @@ DOC
                    end
       contents = "<#{elem.name}"
       indent = '   ' * depth
-      attributes.each { |name| contents += "\n   #{name} = \"#{elem.attribute(name).value}\"" }
+      attributes.each { |name| contents += "\n   #{name} = \"#{elem.attribute(name)}\"" }
       contents.split("\n").map { |line| "#{indent}#{line}" }.join("\n") + ">\n"
     end
 

--- a/lib/xcodeproj/workspace/file_reference.rb
+++ b/lib/xcodeproj/workspace/file_reference.rb
@@ -54,7 +54,8 @@ module Xcodeproj
       #
       def to_node
         REXML::Element.new('FileRef').tap do |element|
-          element.add_attribute('location', "#{type}:#{path}")
+          cleaned_path = CGI.escapeHTML(path)
+          element.add_attribute('location', "#{type}:#{cleaned_path}")
         end
       end
 

--- a/lib/xcodeproj/workspace/file_reference.rb
+++ b/lib/xcodeproj/workspace/file_reference.rb
@@ -54,8 +54,7 @@ module Xcodeproj
       #
       def to_node
         REXML::Element.new('FileRef').tap do |element|
-          cleaned_path = CGI.escapeHTML(path)
-          element.add_attribute('location', "#{type}:#{cleaned_path}")
+          element.add_attribute('location', "#{type}:#{path}")
         end
       end
 

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -37,7 +37,7 @@ describe Xcodeproj::Workspace do
   describe 'converted to XML' do
     before do
       pods_project_file_reference = Xcodeproj::Workspace::FileReference.new('Pods/Pods.xcodeproj')
-      project_file_reference = Xcodeproj::Workspace::FileReference.new('App.xcodeproj')
+      project_file_reference = Xcodeproj::Workspace::FileReference.new('App&<>\'.xcodeproj')
       @workspace = Xcodeproj::Workspace.new(pods_project_file_reference, project_file_reference)
 
       file_reference_in_group = Xcodeproj::Workspace::FileReference.new('ProjectInGroup.xcodeproj')
@@ -55,7 +55,7 @@ describe Xcodeproj::Workspace do
     it 'refers to the projects in xml' do
       @doc.root.get_elements('/Workspace//FileRef').map do |node|
         node.attributes['location']
-      end.sort.should == ['group:App.xcodeproj', 'group:Pods/Pods.xcodeproj', 'group:ProjectInGroup.xcodeproj']
+      end.sort.should == ['group:App&<>\'.xcodeproj', 'group:Pods/Pods.xcodeproj', 'group:ProjectInGroup.xcodeproj']
     end
 
     it 'formats the XML consistently with Xcode' do
@@ -67,7 +67,7 @@ describe Xcodeproj::Workspace do
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:App.xcodeproj">
+      location = "group:App&amp;&lt;&gt;&apos;.xcodeproj">
    </FileRef>
    <Group
       location = "container:"


### PR DESCRIPTION
Closes https://github.com/CocoaPods/CocoaPods/issues/4446.

This is my first time contributing to the base project, so if this isn't where this logic should go, let me know (or if I'm just simply doing it wrong).

This is meant to fix the issue ["Can't use '&' in Xcode project's name."](https://github.com/CocoaPods/CocoaPods/issues/4446) in the main repository. 

I tried doing the same thing with < and >, and it seemed like HTML entities need to be escaped, so I added it in. That's all. 