### PR TITLE
Support multiple OTHER_CFLAGS/OTHER_LDFLAGS on 6.3 project

### DIFF
--- a/lib/xcodeproj/config/other_linker_flags_parser.rb
+++ b/lib/xcodeproj/config/other_linker_flags_parser.rb
@@ -8,7 +8,7 @@ module Xcodeproj
       # @return [Hash{Symbol, Array[String]}] Splits the given
       #         other linker flags value by type.
       #
-      # @param  [String] flags
+      # @param  [String, Array] flags
       #         The other linker flags value.
       #
       def self.parse(flags)
@@ -21,7 +21,10 @@ module Xcodeproj
         }
 
         key = nil
-        split(flags).each do |token|
+        if flags.is_a? String
+          flags = split(flags)
+        end
+        flags.each do |token|
           case token
           when '-framework'
             key = :frameworks

--- a/spec/config/other_linker_flags_parser_spec.rb
+++ b/spec/config/other_linker_flags_parser_spec.rb
@@ -133,5 +133,16 @@ describe Xcodeproj::Config::OtherLinkerFlagsParser do
         :force_load => [],
       }
     end
+
+    it 'handles Array flags' do
+      flags = %w(-Objc -all_load -lsqlite3 -lz)
+      @parser.parse(flags).should == {
+        :frameworks => [],
+        :weak_frameworks => [],
+        :libraries => [],
+        :simple => ['-Objc', '-all_load', '-lsqlite3', '-lz'],
+        :force_load => [],
+      }
+    end
   end
 end

--- a/spec/fixtures/Sample Project/6.3-format.xcodeproj/project.pbxproj
+++ b/spec/fixtures/Sample Project/6.3-format.xcodeproj/project.pbxproj
@@ -2610,7 +2610,14 @@
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_CFLAGS = (
+					"-DCONST1",
+					"-DCONST2",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lz",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
`xcodeproj config-dump` fails on some 6.3 style project which has multiple OTHER_LDFLAGS.

If the value count of OTHER_LDFLAGS is 1, it's stored as string.
```
OTHER_LDFLAGS = "-Objc"
```

Whereas if the value count of them is 2+, it's stored as array.
```
OTHER_LDFLAGS = (
  "-Objc",
  "-lz",
)
```

`Xcodeproj::Config::OtherLinkerFlagsParser.parse(flags)` always split the argument `flags`. This pull request changes it to split if needed.