### PR TITLE
Track .def files as headers

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -347,6 +347,6 @@ module Xcodeproj
 
     # @return [Array] The extensions which are associated with header files.
     #
-    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .tpp .hxx).freeze
+    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .tpp .hxx .def).freeze
   end
 end


### PR DESCRIPTION
@segiddins I apologize for this inconvenience.

My original PR here tracked these files as sources but it was a mistake. `.def` files are meant to be used as headers.

By adding them as source files we are now receiving warnings when xcode is trying to compile them.

Please accept this PR and I will revert the source file tracking from CocoaPods and update the CHANGELOG accordingly.