### PR TITLE
[PlistHelper] Ensure a UTF-8 encoding when trying to create a CFString

### DIFF
--- a/lib/xcodeproj/plist_helper.rb
+++ b/lib/xcodeproj/plist_helper.rb
@@ -531,7 +531,7 @@ module CoreFoundation
 
   def self.RubyStringToCFString(string)
     CFStringCreateWithCString(NULL,
-                              Fiddle::Pointer[string],
+                              Fiddle::Pointer[string.encode('UTF-8')],
                               KCFStringEncodingUTF8)
   end
 


### PR DESCRIPTION
Potentially closes https://github.com/CocoaPods/CocoaPods/issues/4520.

\c @neonichu @floere @alloy 