### PR TITLE
Set TARGETED_DEVICE_FAMILY to include iPhone and iPad device families…

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -270,6 +270,7 @@ module Xcodeproj
       }.freeze,
       [:ios, :bundle] => {
         'SDKROOT'                           => 'iphoneos',
+        'TARGETED_DEVICE_FAMILY'            => '1,2',
       }.freeze,
       [:osx, :bundle] => {
         'CODE_SIGN_IDENTITY'                => '-',


### PR DESCRIPTION
We found that the TARGETED_DEVICE_FAMILY is not set correctly for resource bundles configured in a podspec. The application using the resource bundle from the pod did not compile assets for iPad because this value was defaulted to "1" (iPhone only). Now, it correctly configures the pod resource bundle target to include both iPhone and iPad