### PR TITLE
Load DVTServices and DVTPortal frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Xcodeproj Changelog
 
+## Master
+
+##### Bug Fixes
+
+* Fix ASCII .xcodeproj serialization with Xcode 7.3.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#356](https://github.com/CocoaPods/Xcodeproj/pull/356)
+
+
 ## 1.0.0.beta.2 (2015-12-30)
 
 ##### Bug Fixes

--- a/lib/xcodeproj/plist/ffi/dev_tools_core.rb
+++ b/lib/xcodeproj/plist/ffi/dev_tools_core.rb
@@ -72,6 +72,8 @@ module Xcodeproj
         def self.load_xcode_frameworks
           DevToolsCore.silence_stderr do
             load_xcode_framework('SharedFrameworks/DVTFoundation.framework/DVTFoundation')
+            load_xcode_framework('SharedFrameworks/DVTServices.framework/DVTServices')
+            load_xcode_framework('SharedFrameworks/DVTPortal.framework/DVTPortal')
             load_xcode_framework('SharedFrameworks/DVTSourceControl.framework/DVTSourceControl')
             load_xcode_framework('SharedFrameworks/CSServiceClient.framework/CSServiceClient')
             load_xcode_framework('Frameworks/IBFoundation.framework/IBFoundation')


### PR DESCRIPTION
IDEFoundation depends on them in Xcode 7.3

cc @segiddins 