### PR TITLE
Support for UI test bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Support for UI test bundles.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#372](https://github.com/CocoaPods/Xcodeproj/pull/372)
 
 ##### Bug Fixes
 

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -113,6 +113,7 @@ module Xcodeproj
       :bundle            => 'com.apple.product-type.bundle',
       :octest_bundle     => 'com.apple.product-type.bundle',
       :unit_test_bundle  => 'com.apple.product-type.bundle.unit-test',
+      :ui_test_bundle    => 'com.apple.product-type.bundle.ui-testing',
       :app_extension     => 'com.apple.product-type.app-extension',
       :command_line_tool => 'com.apple.product-type.tool',
       :watch_app         => 'com.apple.product-type.application.watchapp',

--- a/lib/xcodeproj/scheme/build_action.rb
+++ b/lib/xcodeproj/scheme/build_action.rb
@@ -79,7 +79,9 @@ module Xcodeproj
             is_test_target = false
             is_app_target = false
             if target_or_node && target_or_node.is_a?(::Xcodeproj::Project::Object::PBXNativeTarget)
-              test_types = [Constants::PRODUCT_TYPE_UTI[:octest_bundle], Constants::PRODUCT_TYPE_UTI[:unit_test_bundle]]
+              test_types = [Constants::PRODUCT_TYPE_UTI[:octest_bundle],
+                            Constants::PRODUCT_TYPE_UTI[:unit_test_bundle],
+                            Constants::PRODUCT_TYPE_UTI[:ui_test_bundle]]
               app_types = [Constants::PRODUCT_TYPE_UTI[:application]]
               is_test_target = test_types.include?(target_or_node.product_type)
               is_app_target = app_types.include?(target_or_node.product_type)

--- a/spec/scheme/build_action_spec.rb
+++ b/spec/scheme/build_action_spec.rb
@@ -120,6 +120,16 @@ module Xcodeproj
           entry.build_for_archiving?.should == false
           entry.build_for_analyzing?.should == true
         end
+
+        it 'Use proper defaults for UI test target' do
+          target = @project.new_target(:ui_test_bundle, 'FooUITests', :ios)
+          entry = Xcodeproj::XCScheme::BuildAction::Entry.new(target)
+          entry.build_for_testing?.should == true
+          entry.build_for_running?.should == false
+          entry.build_for_profiling?.should == false
+          entry.build_for_archiving?.should == false
+          entry.build_for_analyzing?.should == true
+        end
       end
 
       describe 'Map attributes to XML' do


### PR DESCRIPTION
They have their own `productType` and need to be correctly marked as test targets.

Preparation for fixing CocoaPods/CocoaPods#5250