### PR TITLE
Add capabilities for detecting app extensions and host targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ##### Enhancements
 
+* Add helpers to `Project` for finding an extension target's host targets
+  and a host target's extension targets.  
+  [Ben Asher](https://github.com/benasher44)
+  [#382](https://github.com/CocoaPods/Xcodeproj/pull/382)
+
 * Add accessors for working with skipped tests inside TestAction  in `.xcscheme` files.  
   [Eduard Panasiuk](https://github.com/somedev)
   [#380](https://github.com/CocoaPods/Xcodeproj/pull/380)

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -526,10 +526,11 @@ module Xcodeproj
       root_object.targets.grep(PBXNativeTarget)
     end
 
-    def embedded_native_targets_for_native_target(target):
-      native_targets.select do |native_target|
-        (native_target.product_bundle_id != target.bundle_id &&
-         native_target.product_bundle_id.start_with? target.bundle_id)
+    def host_target_for_extension_target(extension_target)
+      raise "#{target} is not an extension" unless native_target.extension?
+      native_targets.find do |native_target|
+        ((extension_target.product_bundle_id != native_target.product_bundle_id) &&
+         (extension_target.product_bundle_id.start_with? native_target.product_bundle_id))
       end
     end
 

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -526,6 +526,13 @@ module Xcodeproj
       root_object.targets.grep(PBXNativeTarget)
     end
 
+    def embedded_native_targets_for_native_target(target):
+      native_targets.select do |native_target|
+        (native_target.product_bundle_id != target.bundle_id &&
+         native_target.product_bundle_id.start_with? target.bundle_id)
+      end
+    end
+
     # @return [PBXGroup] The group which holds the product file references.
     #
     def products_group

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -539,31 +539,24 @@ module Xcodeproj
       return [] if native_target.app_extension?
       native_targets.select do |target|
         next unless target.app_extension?
-        host_target_for_app_extension_target(target).product_bundle_id == native_target.product_bundle_id
+        host_targets_for_app_extension_target(target).map(&:uuid).include? native_target.uuid
       end
     end
 
     # Returns the native target, in which the extension target is embedded.
-    # This works by traversing the targets in descending order of the length
-    # of each one's product_bundle_id. The idea is that for a target's
-    # product_bundle_id com.org.app, the extension has the product_bundle_id
-    # com.org.app.extension. Therefore, the host target should be the nearest
-    # target (in the mentioned list order), where the product_bundle_id prefixes
-    # the extension target.
+    # This works by traversing the targets to find those where the extension
+    # target is a dependency.
     #
     # @param  [PBXNativeTarget] native target where target.app_extension?
     #                           is true
     #
-    # @return [PBXNativeTarget] the native target that hosts the extension
+    # @return [ObjectList<PBXNativeTarget>] the native targets that hosts the extension
     #
-    def host_target_for_app_extension_target(extension_target)
+    def host_targets_for_app_extension_target(extension_target)
       raise ArgumentError, "#{extension_target} is not an app extension" unless extension_target.app_extension?
-      sorted_targets = native_targets.sort do |target_a, target_b|
-        target_b.product_bundle_id.length <=> target_a.product_bundle_id.length
-      end
-      sorted_targets.find do |native_target|
-        ((extension_target.product_bundle_id != native_target.product_bundle_id) &&
-         (extension_target.product_bundle_id.start_with? native_target.product_bundle_id))
+      native_targets.find_all do |native_target|
+        ((extension_target.uuid != native_target.uuid) &&
+         (native_target.dependencies.map(&:target).map(&:uuid).include? extension_target.uuid))
       end
     end
 

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -526,6 +526,23 @@ module Xcodeproj
       root_object.targets.grep(PBXNativeTarget)
     end
 
+    # Checks the native target for any targets in the project that are
+    # app extensions of that target
+    #
+    # @param  [PBXNativeTarget] native target to check for app extensions
+    #
+    #
+    # @return [ObjectList<PBXNativeTarget>] A list of all targets that are
+    #         app extensions of the passed in target.
+    #
+    def app_extensions_for_native_target(native_target)
+      return [] if native_target.app_extension?
+      native_targets.select do |target|
+        next unless target.app_extension?
+        host_target_for_app_extension_target(target).product_bundle_id == native_target.product_bundle_id
+      end
+    end
+
     # Returns the native target, in which the extension target is embedded.
     # This works by traversing the targets in descending order of the length
     # of each one's product_bundle_id. The idea is that for a target's

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -543,14 +543,14 @@ module Xcodeproj
       end
     end
 
-    # Returns the native target, in which the extension target is embedded.
+    # Returns the native targets, in which the extension target are embedded.
     # This works by traversing the targets to find those where the extension
     # target is a dependency.
     #
     # @param  [PBXNativeTarget] native target where target.extension_target_type?
     #                           is true
     #
-    # @return [Array<PBXNativeTarget>] the native targets that hosts the extension
+    # @return [Array<PBXNativeTarget>] the native targets that host the extension
     #
     def host_targets_for_extension_target(extension_target)
       raise ArgumentError, "#{extension_target} is not an extension" unless extension_target.extension_target_type?

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -532,7 +532,7 @@ module Xcodeproj
     # @param  [PBXNativeTarget] native target to check for app extensions
     #
     #
-    # @return [ObjectList<PBXNativeTarget>] A list of all targets that are
+    # @return [Array<PBXNativeTarget>] A list of all targets that are
     #         app extensions of the passed in target.
     #
     def app_extensions_for_native_target(native_target)
@@ -550,11 +550,11 @@ module Xcodeproj
     # @param  [PBXNativeTarget] native target where target.app_extension?
     #                           is true
     #
-    # @return [ObjectList<PBXNativeTarget>] the native targets that hosts the extension
+    # @return [Array<PBXNativeTarget>] the native targets that hosts the extension
     #
     def host_targets_for_app_extension_target(extension_target)
       raise ArgumentError, "#{extension_target} is not an app extension" unless extension_target.app_extension?
-      native_targets.find_all do |native_target|
+      native_targets.select do |native_target|
         ((extension_target.uuid != native_target.uuid) &&
          (native_target.dependencies.map(&:target).map(&:uuid).include? extension_target.uuid))
       end

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -527,19 +527,19 @@ module Xcodeproj
     end
 
     # Checks the native target for any targets in the project that are
-    # app extensions of that target
+    # extensions of that target
     #
-    # @param  [PBXNativeTarget] native target to check for app extensions
+    # @param  [PBXNativeTarget] native target to check for extensions
     #
     #
     # @return [Array<PBXNativeTarget>] A list of all targets that are
-    #         app extensions of the passed in target.
+    #         extensions of the passed in target.
     #
-    def app_extensions_for_native_target(native_target)
-      return [] if native_target.app_extension?
+    def extensions_for_native_target(native_target)
+      return [] if native_target.extension_target_type?
       native_targets.select do |target|
-        next unless target.app_extension?
-        host_targets_for_app_extension_target(target).map(&:uuid).include? native_target.uuid
+        next unless target.extension_target_type?
+        host_targets_for_extension_target(target).map(&:uuid).include? native_target.uuid
       end
     end
 
@@ -547,13 +547,13 @@ module Xcodeproj
     # This works by traversing the targets to find those where the extension
     # target is a dependency.
     #
-    # @param  [PBXNativeTarget] native target where target.app_extension?
+    # @param  [PBXNativeTarget] native target where target.extension_target_type?
     #                           is true
     #
     # @return [Array<PBXNativeTarget>] the native targets that hosts the extension
     #
-    def host_targets_for_app_extension_target(extension_target)
-      raise ArgumentError, "#{extension_target} is not an app extension" unless extension_target.app_extension?
+    def host_targets_for_extension_target(extension_target)
+      raise ArgumentError, "#{extension_target} is not an extension" unless extension_target.extension_target_type?
       native_targets.select do |native_target|
         ((extension_target.uuid != native_target.uuid) &&
          (native_target.dependencies.map(&:target).map(&:uuid).include? extension_target.uuid))

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -80,12 +80,12 @@ module Xcodeproj
           end
         end
 
-        def bundle_id
-          resolved_build_setting('BUNDLE_IDENTIFIER')
+        def extension?
+          common_resolved_build_setting('PACKAGE_TYPE') == 'com.apple.package-type.app-extension'
         end
 
         def product_bundle_id
-          resolved_build_setting('PRODUCT_BUNDLE_IDENTIFIER')
+          common_resolved_build_setting('PRODUCT_BUNDLE_IDENTIFIER')
         end
 
         # @return [String] the SDK that the target should use.

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -416,19 +416,6 @@ module Xcodeproj
         # @!group Helpers
         #--------------------------------------#
 
-        # Checks product_type to determine whether or not the recevier is a
-        # an app extension
-        #
-        # @return True if the target would be an extension embedded in an
-        #         app target, otherwise false
-        #
-        # @note watchOS 2 extensions are extensions of a watch target, not
-        #       an app target, whereas this is not the case for watchOS 1
-        def app_extension?
-          extension_types = Set.new [:app_extension, :watch_extension]
-          extension_types.include? symbol_type
-        end
-
         # @return [Symbol] The type of the target expressed as a symbol.
         #
         def symbol_type

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -80,10 +80,6 @@ module Xcodeproj
           end
         end
 
-        def product_bundle_id
-          common_resolved_build_setting('PRODUCT_BUNDLE_IDENTIFIER')
-        end
-
         # @return [String] the SDK that the target should use.
         #
         def sdk

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -457,12 +457,6 @@ module Xcodeproj
           end
         end
 
-        # @return [String] The build setting equivalent of WRAPPER_NAME
-        #
-        def wrapper_name
-          product_reference.display_name
-        end
-
         # Adds source files to the target.
         #
         # @param  [Array<PBXFileReference>] file_references

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -80,20 +80,6 @@ module Xcodeproj
           end
         end
 
-        # Positively identifies the target as an app extension
-        # configurations or the value inheriting the value from the project
-        # ones if needed.
-        #
-        # @return True if the target would be an extension embedded in an
-        #         app target, otherwise false
-        #
-        # @note watchOS 2 extensions are extensions of a watch target, not
-        #       an app target, whereas this is not the case for watchOS 1
-        def app_extension?
-          extension_types = Set.new [:app_extension, :watch_extension]
-          extension_types.include? Constants::PRODUCT_TYPE_UTI.invert[product_type]
-        end
-
         def product_bundle_id
           common_resolved_build_setting('PRODUCT_BUNDLE_IDENTIFIER')
         end
@@ -434,6 +420,19 @@ module Xcodeproj
         # @!group Helpers
         #--------------------------------------#
 
+        # Checks product_type to determine whether or not the recevier is a
+        #  an app extension
+        #
+        # @return True if the target would be an extension embedded in an
+        #         app target, otherwise false
+        #
+        # @note watchOS 2 extensions are extensions of a watch target, not
+        #       an app target, whereas this is not the case for watchOS 1
+        def app_extension?
+          extension_types = Set.new [:app_extension, :watch_extension]
+          extension_types.include? symbold_type
+        end
+
         # @return [Symbol] The type of the target expressed as a symbol.
         #
         def symbol_type
@@ -460,6 +459,12 @@ module Xcodeproj
           else
             false
           end
+        end
+
+        # @return [String] The build setting equivalent of WRAPPER_NAME
+        #
+        def wrapper_name
+          product_reference.display_name
         end
 
         # Adds source files to the target.

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -80,6 +80,14 @@ module Xcodeproj
           end
         end
 
+        def bundle_id
+          resolved_build_setting('BUNDLE_IDENTIFIER')
+        end
+
+        def product_bundle_id
+          resolved_build_setting('PRODUCT_BUNDLE_IDENTIFIER')
+        end
+
         # @return [String] the SDK that the target should use.
         #
         def sdk

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -430,7 +430,7 @@ module Xcodeproj
         #       an app target, whereas this is not the case for watchOS 1
         def app_extension?
           extension_types = Set.new [:app_extension, :watch_extension]
-          extension_types.include? symbold_type
+          extension_types.include? symbol_type
         end
 
         # @return [Symbol] The type of the target expressed as a symbol.

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -417,7 +417,7 @@ module Xcodeproj
         #--------------------------------------#
 
         # Checks product_type to determine whether or not the recevier is a
-        #  an app extension
+        # an app extension
         #
         # @return True if the target would be an extension embedded in an
         #         app target, otherwise false

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -80,8 +80,18 @@ module Xcodeproj
           end
         end
 
-        def extension?
-          common_resolved_build_setting('PACKAGE_TYPE') == 'com.apple.package-type.app-extension'
+        # Positively identifies the target as an app extension
+        # configurations or the value inheriting the value from the project
+        # ones if needed.
+        #
+        # @return True if the target would be an extension embedded in an
+        #         app target, otherwise false
+        #
+        # @note watchOS 2 extensions are extensions of a watch target, not
+        #       an app target, whereas this is not the case for watchOS 1
+        def app_extension?
+          extension_types = Set.new [:app_extension, :watch_extension]
+          extension_types.include? Constants::PRODUCT_TYPE_UTI.invert[product_type]
         end
 
         def product_bundle_id

--- a/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,62 @@
+{
+  "images" : [
+    {
+      "size" : "24x24",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "27.5x27.5",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "44x44",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "longLook",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "86x86",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "98x98",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 App/Base.lproj/Interface.storyboard
+++ b/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 App/Base.lproj/Interface.storyboard
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6221" systemVersion="13E28" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6213"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="3733"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="aou-V4-d1y">
+            <objects>
+                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModuleProvider="target"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 App/Info.plist
+++ b/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 App/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Extensions</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>cocoapods.Extensions</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 Extension/Assets.xcassets/README__ignoredByTemplate__
+++ b/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 Extension/Assets.xcassets/README__ignoredByTemplate__
@@ -1,0 +1,1 @@
+Did you know that git does not support storing empty directories?

--- a/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 Extension/Info.plist
+++ b/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 Extension/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Extensions WatchKit 1 Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>cocoapods.Extensions.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+</dict>
+</plist>

--- a/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 Extension/InterfaceController.swift
+++ b/spec/fixtures/Sample Project/Extensions/Extensions WatchKit 1 Extension/InterfaceController.swift
@@ -1,0 +1,31 @@
+//
+//  InterfaceController.swift
+//  Extensions WatchKit 1 Extension
+//
+//  Created by Benjamin Asher on 4/9/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import WatchKit
+import Foundation
+
+
+class InterfaceController: WKInterfaceController {
+
+    override func awakeWithContext(context: AnyObject?) {
+        super.awakeWithContext(context)
+        
+        // Configure interface objects here.
+    }
+
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
+
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
+
+}

--- a/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/project.pbxproj
+++ b/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/project.pbxproj
@@ -1,0 +1,1008 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13185ECA1CB98E1900AED60A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13185EC91CB98E1900AED60A /* AppDelegate.swift */; };
+		13185ECC1CB98E1900AED60A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13185ECB1CB98E1900AED60A /* ViewController.swift */; };
+		13185ECF1CB98E1900AED60A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 13185ECD1CB98E1900AED60A /* Main.storyboard */; };
+		13185ED11CB98E1900AED60A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13185ED01CB98E1900AED60A /* Assets.xcassets */; };
+		13185ED41CB98E1900AED60A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 13185ED21CB98E1900AED60A /* LaunchScreen.storyboard */; };
+		13185EDF1CB98E1900AED60A /* ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13185EDE1CB98E1900AED60A /* ExtensionsTests.swift */; };
+		13185F161CB98E6500AED60A /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13185F151CB98E6500AED60A /* InterfaceController.swift */; };
+		13185F181CB98E6500AED60A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13185F171CB98E6500AED60A /* Assets.xcassets */; };
+		13185F1D1CB98E6600AED60A /* Extensions WatchKit 1 App.app in Resources */ = {isa = PBXBuildFile; fileRef = 13185F1C1CB98E6500AED60A /* Extensions WatchKit 1 App.app */; };
+		13185F231CB98E6600AED60A /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 13185F211CB98E6600AED60A /* Interface.storyboard */; };
+		13185F251CB98E6600AED60A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13185F241CB98E6600AED60A /* Assets.xcassets */; };
+		13185F291CB98E6600AED60A /* Extensions WatchKit 1 Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 13185F131CB98E6500AED60A /* Extensions WatchKit 1 Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		13185F361CB98E9200AED60A /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 13185F341CB98E9200AED60A /* Interface.storyboard */; };
+		13185F381CB98E9200AED60A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13185F371CB98E9200AED60A /* Assets.xcassets */; };
+		13185F3F1CB98E9200AED60A /* WatchOS 2 App Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 13185F3E1CB98E9200AED60A /* WatchOS 2 App Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		13185F441CB98E9200AED60A /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13185F431CB98E9200AED60A /* InterfaceController.swift */; };
+		13185F461CB98E9200AED60A /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13185F451CB98E9200AED60A /* ExtensionDelegate.swift */; };
+		13185F481CB98E9200AED60A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13185F471CB98E9200AED60A /* Assets.xcassets */; };
+		13185F4C1CB98E9200AED60A /* WatchOS 2 App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 13185F321CB98E9200AED60A /* WatchOS 2 App.app */; };
+		13185F5C1CB98EB300AED60A /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 13185F5B1CB98EB300AED60A /* NotificationCenter.framework */; };
+		13185F5F1CB98EB300AED60A /* TodayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13185F5E1CB98EB300AED60A /* TodayViewController.swift */; };
+		13185F621CB98EB300AED60A /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 13185F601CB98EB300AED60A /* MainInterface.storyboard */; };
+		13185F661CB98EB300AED60A /* Today.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 13185F591CB98EB300AED60A /* Today.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		13185EDB1CB98E1900AED60A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 13185EBE1CB98E1900AED60A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13185EC51CB98E1900AED60A;
+			remoteInfo = Extensions;
+		};
+		13185F1E1CB98E6600AED60A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 13185EBE1CB98E1900AED60A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13185F1B1CB98E6500AED60A;
+			remoteInfo = "Extensions WatchKit 1 App";
+		};
+		13185F271CB98E6600AED60A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 13185EBE1CB98E1900AED60A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13185F121CB98E6500AED60A;
+			remoteInfo = "Extensions WatchKit 1 Extension";
+		};
+		13185F401CB98E9200AED60A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 13185EBE1CB98E1900AED60A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13185F3D1CB98E9200AED60A;
+			remoteInfo = "WatchOS 2 App Extension";
+		};
+		13185F4A1CB98E9200AED60A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 13185EBE1CB98E1900AED60A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13185F311CB98E9200AED60A;
+			remoteInfo = "WatchOS 2 App";
+		};
+		13185F641CB98EB300AED60A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 13185EBE1CB98E1900AED60A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13185F581CB98EB300AED60A;
+			remoteInfo = Today;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		13185F0E1CB98E3000AED60A /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				13185F661CB98EB300AED60A /* Today.appex in Embed App Extensions */,
+				13185F291CB98E6600AED60A /* Extensions WatchKit 1 Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F501CB98E9200AED60A /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				13185F3F1CB98E9200AED60A /* WatchOS 2 App Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F541CB98E9200AED60A /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				13185F4C1CB98E9200AED60A /* WatchOS 2 App.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		13185EC61CB98E1900AED60A /* Extensions.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Extensions.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13185EC91CB98E1900AED60A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		13185ECB1CB98E1900AED60A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		13185ECE1CB98E1900AED60A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		13185ED01CB98E1900AED60A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		13185ED31CB98E1900AED60A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		13185ED51CB98E1900AED60A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		13185EDA1CB98E1900AED60A /* ExtensionsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExtensionsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		13185EDE1CB98E1900AED60A /* ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsTests.swift; sourceTree = "<group>"; };
+		13185EE01CB98E1900AED60A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		13185F131CB98E6500AED60A /* Extensions WatchKit 1 Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Extensions WatchKit 1 Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		13185F151CB98E6500AED60A /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
+		13185F171CB98E6500AED60A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		13185F191CB98E6500AED60A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		13185F1C1CB98E6500AED60A /* Extensions WatchKit 1 App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Extensions WatchKit 1 App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		13185F221CB98E6600AED60A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		13185F241CB98E6600AED60A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		13185F261CB98E6600AED60A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		13185F321CB98E9200AED60A /* WatchOS 2 App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WatchOS 2 App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		13185F351CB98E9200AED60A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		13185F371CB98E9200AED60A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		13185F391CB98E9200AED60A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		13185F3E1CB98E9200AED60A /* WatchOS 2 App Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "WatchOS 2 App Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		13185F431CB98E9200AED60A /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
+		13185F451CB98E9200AED60A /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		13185F471CB98E9200AED60A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		13185F491CB98E9200AED60A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		13185F591CB98EB300AED60A /* Today.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = Today.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		13185F5B1CB98EB300AED60A /* NotificationCenter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = NotificationCenter.framework; path = System/Library/Frameworks/NotificationCenter.framework; sourceTree = SDKROOT; };
+		13185F5E1CB98EB300AED60A /* TodayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewController.swift; sourceTree = "<group>"; };
+		13185F611CB98EB300AED60A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		13185F631CB98EB300AED60A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13185EC31CB98E1900AED60A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185ED71CB98E1900AED60A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F101CB98E6500AED60A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F3B1CB98E9200AED60A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F561CB98EB300AED60A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F5C1CB98EB300AED60A /* NotificationCenter.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13185EBD1CB98E1900AED60A = {
+			isa = PBXGroup;
+			children = (
+				13185EC81CB98E1900AED60A /* Extensions */,
+				13185EDD1CB98E1900AED60A /* ExtensionsTests */,
+				13185F141CB98E6500AED60A /* Extensions WatchKit 1 Extension */,
+				13185F201CB98E6600AED60A /* Extensions WatchKit 1 App */,
+				13185F331CB98E9200AED60A /* WatchOS 2 App */,
+				13185F421CB98E9200AED60A /* WatchOS 2 App Extension */,
+				13185F5D1CB98EB300AED60A /* Today */,
+				13185F5A1CB98EB300AED60A /* Frameworks */,
+				13185EC71CB98E1900AED60A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		13185EC71CB98E1900AED60A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13185EC61CB98E1900AED60A /* Extensions.app */,
+				13185EDA1CB98E1900AED60A /* ExtensionsTests.xctest */,
+				13185F131CB98E6500AED60A /* Extensions WatchKit 1 Extension.appex */,
+				13185F1C1CB98E6500AED60A /* Extensions WatchKit 1 App.app */,
+				13185F321CB98E9200AED60A /* WatchOS 2 App.app */,
+				13185F3E1CB98E9200AED60A /* WatchOS 2 App Extension.appex */,
+				13185F591CB98EB300AED60A /* Today.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		13185EC81CB98E1900AED60A /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				13185EC91CB98E1900AED60A /* AppDelegate.swift */,
+				13185ECB1CB98E1900AED60A /* ViewController.swift */,
+				13185ECD1CB98E1900AED60A /* Main.storyboard */,
+				13185ED01CB98E1900AED60A /* Assets.xcassets */,
+				13185ED21CB98E1900AED60A /* LaunchScreen.storyboard */,
+				13185ED51CB98E1900AED60A /* Info.plist */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		13185EDD1CB98E1900AED60A /* ExtensionsTests */ = {
+			isa = PBXGroup;
+			children = (
+				13185EDE1CB98E1900AED60A /* ExtensionsTests.swift */,
+				13185EE01CB98E1900AED60A /* Info.plist */,
+			);
+			path = ExtensionsTests;
+			sourceTree = "<group>";
+		};
+		13185F141CB98E6500AED60A /* Extensions WatchKit 1 Extension */ = {
+			isa = PBXGroup;
+			children = (
+				13185F151CB98E6500AED60A /* InterfaceController.swift */,
+				13185F171CB98E6500AED60A /* Assets.xcassets */,
+				13185F191CB98E6500AED60A /* Info.plist */,
+			);
+			path = "Extensions WatchKit 1 Extension";
+			sourceTree = "<group>";
+		};
+		13185F201CB98E6600AED60A /* Extensions WatchKit 1 App */ = {
+			isa = PBXGroup;
+			children = (
+				13185F211CB98E6600AED60A /* Interface.storyboard */,
+				13185F241CB98E6600AED60A /* Assets.xcassets */,
+				13185F261CB98E6600AED60A /* Info.plist */,
+			);
+			path = "Extensions WatchKit 1 App";
+			sourceTree = "<group>";
+		};
+		13185F331CB98E9200AED60A /* WatchOS 2 App */ = {
+			isa = PBXGroup;
+			children = (
+				13185F341CB98E9200AED60A /* Interface.storyboard */,
+				13185F371CB98E9200AED60A /* Assets.xcassets */,
+				13185F391CB98E9200AED60A /* Info.plist */,
+			);
+			path = "WatchOS 2 App";
+			sourceTree = "<group>";
+		};
+		13185F421CB98E9200AED60A /* WatchOS 2 App Extension */ = {
+			isa = PBXGroup;
+			children = (
+				13185F431CB98E9200AED60A /* InterfaceController.swift */,
+				13185F451CB98E9200AED60A /* ExtensionDelegate.swift */,
+				13185F471CB98E9200AED60A /* Assets.xcassets */,
+				13185F491CB98E9200AED60A /* Info.plist */,
+			);
+			path = "WatchOS 2 App Extension";
+			sourceTree = "<group>";
+		};
+		13185F5A1CB98EB300AED60A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				13185F5B1CB98EB300AED60A /* NotificationCenter.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		13185F5D1CB98EB300AED60A /* Today */ = {
+			isa = PBXGroup;
+			children = (
+				13185F5E1CB98EB300AED60A /* TodayViewController.swift */,
+				13185F601CB98EB300AED60A /* MainInterface.storyboard */,
+				13185F631CB98EB300AED60A /* Info.plist */,
+			);
+			path = Today;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13185EC51CB98E1900AED60A /* Extensions */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13185EE31CB98E1900AED60A /* Build configuration list for PBXNativeTarget "Extensions" */;
+			buildPhases = (
+				13185EC21CB98E1900AED60A /* Sources */,
+				13185EC31CB98E1900AED60A /* Frameworks */,
+				13185EC41CB98E1900AED60A /* Resources */,
+				13185F0E1CB98E3000AED60A /* Embed App Extensions */,
+				13185F541CB98E9200AED60A /* Embed Watch Content */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				13185F281CB98E6600AED60A /* PBXTargetDependency */,
+				13185F4B1CB98E9200AED60A /* PBXTargetDependency */,
+				13185F651CB98EB300AED60A /* PBXTargetDependency */,
+			);
+			name = Extensions;
+			productName = Extensions;
+			productReference = 13185EC61CB98E1900AED60A /* Extensions.app */;
+			productType = "com.apple.product-type.application";
+		};
+		13185ED91CB98E1900AED60A /* ExtensionsTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13185EE61CB98E1900AED60A /* Build configuration list for PBXNativeTarget "ExtensionsTests" */;
+			buildPhases = (
+				13185ED61CB98E1900AED60A /* Sources */,
+				13185ED71CB98E1900AED60A /* Frameworks */,
+				13185ED81CB98E1900AED60A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				13185EDC1CB98E1900AED60A /* PBXTargetDependency */,
+			);
+			name = ExtensionsTests;
+			productName = ExtensionsTests;
+			productReference = 13185EDA1CB98E1900AED60A /* ExtensionsTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		13185F121CB98E6500AED60A /* Extensions WatchKit 1 Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13185F2D1CB98E6600AED60A /* Build configuration list for PBXNativeTarget "Extensions WatchKit 1 Extension" */;
+			buildPhases = (
+				13185F0F1CB98E6500AED60A /* Sources */,
+				13185F101CB98E6500AED60A /* Frameworks */,
+				13185F111CB98E6500AED60A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				13185F1F1CB98E6600AED60A /* PBXTargetDependency */,
+			);
+			name = "Extensions WatchKit 1 Extension";
+			productName = "Extensions WatchKit 1 Extension";
+			productReference = 13185F131CB98E6500AED60A /* Extensions WatchKit 1 Extension.appex */;
+			productType = "com.apple.product-type.watchkit-extension";
+		};
+		13185F1B1CB98E6500AED60A /* Extensions WatchKit 1 App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13185F2A1CB98E6600AED60A /* Build configuration list for PBXNativeTarget "Extensions WatchKit 1 App" */;
+			buildPhases = (
+				13185F1A1CB98E6500AED60A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Extensions WatchKit 1 App";
+			productName = "Extensions WatchKit 1 App";
+			productReference = 13185F1C1CB98E6500AED60A /* Extensions WatchKit 1 App.app */;
+			productType = "com.apple.product-type.application.watchapp";
+		};
+		13185F311CB98E9200AED60A /* WatchOS 2 App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13185F511CB98E9200AED60A /* Build configuration list for PBXNativeTarget "WatchOS 2 App" */;
+			buildPhases = (
+				13185F301CB98E9200AED60A /* Resources */,
+				13185F501CB98E9200AED60A /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				13185F411CB98E9200AED60A /* PBXTargetDependency */,
+			);
+			name = "WatchOS 2 App";
+			productName = "WatchOS 2 App";
+			productReference = 13185F321CB98E9200AED60A /* WatchOS 2 App.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		13185F3D1CB98E9200AED60A /* WatchOS 2 App Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13185F4D1CB98E9200AED60A /* Build configuration list for PBXNativeTarget "WatchOS 2 App Extension" */;
+			buildPhases = (
+				13185F3A1CB98E9200AED60A /* Sources */,
+				13185F3B1CB98E9200AED60A /* Frameworks */,
+				13185F3C1CB98E9200AED60A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "WatchOS 2 App Extension";
+			productName = "WatchOS 2 App Extension";
+			productReference = 13185F3E1CB98E9200AED60A /* WatchOS 2 App Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
+		13185F581CB98EB300AED60A /* Today */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13185F671CB98EB300AED60A /* Build configuration list for PBXNativeTarget "Today" */;
+			buildPhases = (
+				13185F551CB98EB300AED60A /* Sources */,
+				13185F561CB98EB300AED60A /* Frameworks */,
+				13185F571CB98EB300AED60A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Today;
+			productName = Today;
+			productReference = 13185F591CB98EB300AED60A /* Today.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		13185EBE1CB98E1900AED60A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0730;
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = CocoaPods;
+				TargetAttributes = {
+					13185EC51CB98E1900AED60A = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					13185ED91CB98E1900AED60A = {
+						CreatedOnToolsVersion = 7.3;
+						TestTargetID = 13185EC51CB98E1900AED60A;
+					};
+					13185F121CB98E6500AED60A = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					13185F1B1CB98E6500AED60A = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					13185F311CB98E9200AED60A = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					13185F3D1CB98E9200AED60A = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					13185F581CB98EB300AED60A = {
+						CreatedOnToolsVersion = 7.3;
+					};
+				};
+			};
+			buildConfigurationList = 13185EC11CB98E1900AED60A /* Build configuration list for PBXProject "Extensions" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 13185EBD1CB98E1900AED60A;
+			productRefGroup = 13185EC71CB98E1900AED60A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13185EC51CB98E1900AED60A /* Extensions */,
+				13185ED91CB98E1900AED60A /* ExtensionsTests */,
+				13185F121CB98E6500AED60A /* Extensions WatchKit 1 Extension */,
+				13185F1B1CB98E6500AED60A /* Extensions WatchKit 1 App */,
+				13185F311CB98E9200AED60A /* WatchOS 2 App */,
+				13185F3D1CB98E9200AED60A /* WatchOS 2 App Extension */,
+				13185F581CB98EB300AED60A /* Today */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13185EC41CB98E1900AED60A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185ED41CB98E1900AED60A /* LaunchScreen.storyboard in Resources */,
+				13185ED11CB98E1900AED60A /* Assets.xcassets in Resources */,
+				13185ECF1CB98E1900AED60A /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185ED81CB98E1900AED60A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F111CB98E6500AED60A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F181CB98E6500AED60A /* Assets.xcassets in Resources */,
+				13185F1D1CB98E6600AED60A /* Extensions WatchKit 1 App.app in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F1A1CB98E6500AED60A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F251CB98E6600AED60A /* Assets.xcassets in Resources */,
+				13185F231CB98E6600AED60A /* Interface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F301CB98E9200AED60A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F381CB98E9200AED60A /* Assets.xcassets in Resources */,
+				13185F361CB98E9200AED60A /* Interface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F3C1CB98E9200AED60A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F481CB98E9200AED60A /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F571CB98EB300AED60A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F621CB98EB300AED60A /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13185EC21CB98E1900AED60A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185ECC1CB98E1900AED60A /* ViewController.swift in Sources */,
+				13185ECA1CB98E1900AED60A /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185ED61CB98E1900AED60A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185EDF1CB98E1900AED60A /* ExtensionsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F0F1CB98E6500AED60A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F161CB98E6500AED60A /* InterfaceController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F3A1CB98E9200AED60A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F461CB98E9200AED60A /* ExtensionDelegate.swift in Sources */,
+				13185F441CB98E9200AED60A /* InterfaceController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13185F551CB98EB300AED60A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				13185F5F1CB98EB300AED60A /* TodayViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		13185EDC1CB98E1900AED60A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 13185EC51CB98E1900AED60A /* Extensions */;
+			targetProxy = 13185EDB1CB98E1900AED60A /* PBXContainerItemProxy */;
+		};
+		13185F1F1CB98E6600AED60A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 13185F1B1CB98E6500AED60A /* Extensions WatchKit 1 App */;
+			targetProxy = 13185F1E1CB98E6600AED60A /* PBXContainerItemProxy */;
+		};
+		13185F281CB98E6600AED60A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 13185F121CB98E6500AED60A /* Extensions WatchKit 1 Extension */;
+			targetProxy = 13185F271CB98E6600AED60A /* PBXContainerItemProxy */;
+		};
+		13185F411CB98E9200AED60A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 13185F3D1CB98E9200AED60A /* WatchOS 2 App Extension */;
+			targetProxy = 13185F401CB98E9200AED60A /* PBXContainerItemProxy */;
+		};
+		13185F4B1CB98E9200AED60A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 13185F311CB98E9200AED60A /* WatchOS 2 App */;
+			targetProxy = 13185F4A1CB98E9200AED60A /* PBXContainerItemProxy */;
+		};
+		13185F651CB98EB300AED60A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 13185F581CB98EB300AED60A /* Today */;
+			targetProxy = 13185F641CB98EB300AED60A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		13185ECD1CB98E1900AED60A /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13185ECE1CB98E1900AED60A /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		13185ED21CB98E1900AED60A /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13185ED31CB98E1900AED60A /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		13185F211CB98E6600AED60A /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13185F221CB98E6600AED60A /* Base */,
+			);
+			name = Interface.storyboard;
+			sourceTree = "<group>";
+		};
+		13185F341CB98E9200AED60A /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13185F351CB98E9200AED60A /* Base */,
+			);
+			name = Interface.storyboard;
+			sourceTree = "<group>";
+		};
+		13185F601CB98EB300AED60A /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				13185F611CB98EB300AED60A /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		13185EE11CB98E1900AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		13185EE21CB98E1900AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		13185EE41CB98E1900AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = Extensions/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		13185EE51CB98E1900AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = Extensions/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		13185EE71CB98E1900AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = ExtensionsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.ExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Extensions.app/Extensions";
+			};
+			name = Debug;
+		};
+		13185EE81CB98E1900AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = ExtensionsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.ExtensionsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Extensions.app/Extensions";
+			};
+			name = Release;
+		};
+		13185F2B1CB98E6600AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				IBSC_MODULE = Extensions_WatchKit_1_Extension;
+				INFOPLIST_FILE = "Extensions WatchKit 1 App/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = "1,4";
+			};
+			name = Debug;
+		};
+		13185F2C1CB98E6600AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				IBSC_MODULE = Extensions_WatchKit_1_Extension;
+				INFOPLIST_FILE = "Extensions WatchKit 1 App/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				"TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]" = "1,4";
+			};
+			name = Release;
+		};
+		13185F2E1CB98E6600AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "Extensions WatchKit 1 Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		13185F2F1CB98E6600AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "Extensions WatchKit 1 Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		13185F4E1CB98E9200AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "WatchOS 2 App Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		13185F4F1CB98E9200AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "WatchOS 2 App Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
+		13185F521CB98E9200AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				IBSC_MODULE = WatchOS_2_App_Extension;
+				INFOPLIST_FILE = "WatchOS 2 App/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		13185F531CB98E9200AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				IBSC_MODULE = WatchOS_2_App_Extension;
+				INFOPLIST_FILE = "WatchOS 2 App/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
+		13185F681CB98EB300AED60A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = Today/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.Today;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		13185F691CB98EB300AED60A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = Today/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = cocoapods.Extensions.Today;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13185EC11CB98E1900AED60A /* Build configuration list for PBXProject "Extensions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185EE11CB98E1900AED60A /* Debug */,
+				13185EE21CB98E1900AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		13185EE31CB98E1900AED60A /* Build configuration list for PBXNativeTarget "Extensions" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185EE41CB98E1900AED60A /* Debug */,
+				13185EE51CB98E1900AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		13185EE61CB98E1900AED60A /* Build configuration list for PBXNativeTarget "ExtensionsTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185EE71CB98E1900AED60A /* Debug */,
+				13185EE81CB98E1900AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		13185F2A1CB98E6600AED60A /* Build configuration list for PBXNativeTarget "Extensions WatchKit 1 App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185F2B1CB98E6600AED60A /* Debug */,
+				13185F2C1CB98E6600AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		13185F2D1CB98E6600AED60A /* Build configuration list for PBXNativeTarget "Extensions WatchKit 1 Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185F2E1CB98E6600AED60A /* Debug */,
+				13185F2F1CB98E6600AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		13185F4D1CB98E9200AED60A /* Build configuration list for PBXNativeTarget "WatchOS 2 App Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185F4E1CB98E9200AED60A /* Debug */,
+				13185F4F1CB98E9200AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		13185F511CB98E9200AED60A /* Build configuration list for PBXNativeTarget "WatchOS 2 App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185F521CB98E9200AED60A /* Debug */,
+				13185F531CB98E9200AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		13185F671CB98EB300AED60A /* Build configuration list for PBXNativeTarget "Today" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13185F681CB98EB300AED60A /* Debug */,
+				13185F691CB98EB300AED60A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 13185EBE1CB98E1900AED60A /* Project object */;
+}

--- a/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Extensions.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/Extensions WatchKit 1 App.xcscheme
+++ b/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/Extensions WatchKit 1 App.xcscheme
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185F1B1CB98E6500AED60A"
+               BuildableName = "Extensions WatchKit 1 App.app"
+               BlueprintName = "Extensions WatchKit 1 App"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+               BuildableName = "Extensions.app"
+               BlueprintName = "Extensions"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185F121CB98E6500AED60A"
+               BuildableName = "Extensions WatchKit 1 Extension.appex"
+               BlueprintName = "Extensions WatchKit 1 Extension"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F1B1CB98E6500AED60A"
+            BuildableName = "Extensions WatchKit 1 App.app"
+            BlueprintName = "Extensions WatchKit 1 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.carousel"
+         RemotePath = "/Extensions">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F1B1CB98E6500AED60A"
+            BuildableName = "Extensions WatchKit 1 App.app"
+            BlueprintName = "Extensions WatchKit 1 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F1B1CB98E6500AED60A"
+            BuildableName = "Extensions WatchKit 1 App.app"
+            BlueprintName = "Extensions WatchKit 1 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.carousel"
+         RemotePath = "/Extensions">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F1B1CB98E6500AED60A"
+            BuildableName = "Extensions WatchKit 1 App.app"
+            BlueprintName = "Extensions WatchKit 1 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F1B1CB98E6500AED60A"
+            BuildableName = "Extensions WatchKit 1 App.app"
+            BlueprintName = "Extensions WatchKit 1 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/Extensions.xcscheme
+++ b/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/Extensions.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+               BuildableName = "Extensions.app"
+               BlueprintName = "Extensions"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185ED91CB98E1900AED60A"
+               BuildableName = "ExtensionsTests.xctest"
+               BlueprintName = "ExtensionsTests"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+            BuildableName = "Extensions.app"
+            BlueprintName = "Extensions"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+            BuildableName = "Extensions.app"
+            BlueprintName = "Extensions"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+            BuildableName = "Extensions.app"
+            BlueprintName = "Extensions"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/ExtensionsTests.xcscheme
+++ b/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/ExtensionsTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185ED91CB98E1900AED60A"
+               BuildableName = "ExtensionsTests.xctest"
+               BlueprintName = "ExtensionsTests"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/Today.xcscheme
+++ b/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/Today.xcscheme
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185F581CB98EB300AED60A"
+               BuildableName = "Today.appex"
+               BlueprintName = "Today"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+               BuildableName = "Extensions.app"
+               BlueprintName = "Extensions"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F581CB98EB300AED60A"
+            BuildableName = "Today.appex"
+            BlueprintName = "Today"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+            BuildableName = "Extensions.app"
+            BlueprintName = "Extensions"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+            BuildableName = "Extensions.app"
+            BlueprintName = "Extensions"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/WatchOS 2 App.xcscheme
+++ b/spec/fixtures/Sample Project/Extensions/Extensions.xcodeproj/xcshareddata/xcschemes/WatchOS 2 App.xcscheme
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185F311CB98E9200AED60A"
+               BuildableName = "WatchOS 2 App.app"
+               BlueprintName = "WatchOS 2 App"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185EC51CB98E1900AED60A"
+               BuildableName = "Extensions.app"
+               BlueprintName = "Extensions"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185F3D1CB98E9200AED60A"
+               BuildableName = "WatchOS 2 App Extension.appex"
+               BlueprintName = "WatchOS 2 App Extension"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13185F121CB98E6500AED60A"
+               BuildableName = "Extensions WatchKit 1 Extension.appex"
+               BlueprintName = "Extensions WatchKit 1 Extension"
+               ReferencedContainer = "container:Extensions.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F311CB98E9200AED60A"
+            BuildableName = "WatchOS 2 App.app"
+            BlueprintName = "WatchOS 2 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.carousel"
+         RemotePath = "/Extensions">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F311CB98E9200AED60A"
+            BuildableName = "WatchOS 2 App.app"
+            BlueprintName = "WatchOS 2 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F311CB98E9200AED60A"
+            BuildableName = "WatchOS 2 App.app"
+            BlueprintName = "WatchOS 2 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.carousel"
+         RemotePath = "/Extensions">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F311CB98E9200AED60A"
+            BuildableName = "WatchOS 2 App.app"
+            BlueprintName = "WatchOS 2 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "13185F311CB98E9200AED60A"
+            BuildableName = "WatchOS 2 App.app"
+            BlueprintName = "WatchOS 2 App"
+            ReferencedContainer = "container:Extensions.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Sample Project/Extensions/Extensions/AppDelegate.swift
+++ b/spec/fixtures/Sample Project/Extensions/Extensions/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  Extensions
+//
+//  Created by Benjamin Asher on 4/9/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  var window: UIWindow?
+
+
+  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
+
+  func applicationWillResignActive(application: UIApplication) {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+  }
+
+  func applicationDidEnterBackground(application: UIApplication) {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  }
+
+  func applicationWillEnterForeground(application: UIApplication) {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+  }
+
+  func applicationDidBecomeActive(application: UIApplication) {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+  }
+
+  func applicationWillTerminate(application: UIApplication) {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+  }
+
+
+}
+

--- a/spec/fixtures/Sample Project/Extensions/Extensions/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/spec/fixtures/Sample Project/Extensions/Extensions/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/spec/fixtures/Sample Project/Extensions/Extensions/Base.lproj/LaunchScreen.storyboard
+++ b/spec/fixtures/Sample Project/Extensions/Extensions/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8150" systemVersion="15A204g" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8122"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <animations/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/spec/fixtures/Sample Project/Extensions/Extensions/Base.lproj/Main.storyboard
+++ b/spec/fixtures/Sample Project/Extensions/Extensions/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/spec/fixtures/Sample Project/Extensions/Extensions/Info.plist
+++ b/spec/fixtures/Sample Project/Extensions/Extensions/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/spec/fixtures/Sample Project/Extensions/Extensions/ViewController.swift
+++ b/spec/fixtures/Sample Project/Extensions/Extensions/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  Extensions
+//
+//  Created by Benjamin Asher on 4/9/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    // Do any additional setup after loading the view, typically from a nib.
+  }
+
+  override func didReceiveMemoryWarning() {
+    super.didReceiveMemoryWarning()
+    // Dispose of any resources that can be recreated.
+  }
+
+
+}
+

--- a/spec/fixtures/Sample Project/Extensions/ExtensionsTests/ExtensionsTests.swift
+++ b/spec/fixtures/Sample Project/Extensions/ExtensionsTests/ExtensionsTests.swift
@@ -1,0 +1,36 @@
+//
+//  ExtensionsTests.swift
+//  ExtensionsTests
+//
+//  Created by Benjamin Asher on 4/9/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import Extensions
+
+class ExtensionsTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/spec/fixtures/Sample Project/Extensions/ExtensionsTests/Info.plist
+++ b/spec/fixtures/Sample Project/Extensions/ExtensionsTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/spec/fixtures/Sample Project/Extensions/Today/Base.lproj/MainInterface.storyboard
+++ b/spec/fixtures/Sample Project/Extensions/Today/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="M4Y-Lb-cyx">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--Today View Controller-->
+        <scene sceneID="cwh-vc-ff4">
+            <objects>
+                <viewController id="M4Y-Lb-cyx" customClass="TodayViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Ft6-oW-KC0"/>
+                        <viewControllerLayoutGuide type="bottom" id="FKl-LY-JtV"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" simulatedAppContext="notificationCenter" id="S3S-Oj-5AN">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="37"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Hello World" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="280" translatesAutoresizingMaskIntoConstraints="NO" id="GcN-lo-r42">
+                                <rect key="frame" x="20" y="8" width="280" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" cocoaTouchSystemColor="lightTextColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="FKl-LY-JtV" firstAttribute="top" secondItem="GcN-lo-r42" secondAttribute="bottom" constant="20" symbolic="YES" id="0Q0-KW-PJ6"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="leading" secondItem="S3S-Oj-5AN" secondAttribute="leading" constant="20" symbolic="YES" id="6Vq-gs-PHe"/>
+                            <constraint firstAttribute="trailing" secondItem="GcN-lo-r42" secondAttribute="trailing" constant="20" symbolic="YES" id="L8K-9R-egU"/>
+                            <constraint firstItem="GcN-lo-r42" firstAttribute="top" secondItem="Ft6-oW-KC0" secondAttribute="bottom" constant="20" symbolic="YES" id="mYS-Cv-VNx"/>
+                        </constraints>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <nil key="simulatedStatusBarMetrics"/>
+                    <nil key="simulatedTopBarMetrics"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+                    <size key="freeformSize" width="320" height="37"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="vXp-U4-Rya" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="516" y="285"/>
+        </scene>
+    </scenes>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4"/>
+    </simulatedMetricsContainer>
+</document>

--- a/spec/fixtures/Sample Project/Extensions/Today/Info.plist
+++ b/spec/fixtures/Sample Project/Extensions/Today/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Today</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widget-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/spec/fixtures/Sample Project/Extensions/Today/TodayViewController.swift
+++ b/spec/fixtures/Sample Project/Extensions/Today/TodayViewController.swift
@@ -1,0 +1,34 @@
+//
+//  TodayViewController.swift
+//  Today
+//
+//  Created by Benjamin Asher on 4/9/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import UIKit
+import NotificationCenter
+
+class TodayViewController: UIViewController, NCWidgetProviding {
+        
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view from its nib.
+    }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    func widgetPerformUpdateWithCompletionHandler(completionHandler: ((NCUpdateResult) -> Void)) {
+        // Perform any setup necessary in order to update the view.
+
+        // If an error is encountered, use NCUpdateResult.Failed
+        // If there's no update required, use NCUpdateResult.NoData
+        // If there's an update, use NCUpdateResult.NewData
+
+        completionHandler(NCUpdateResult.NewData)
+    }
+    
+}

--- a/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/Assets.xcassets/README__ignoredByTemplate__
+++ b/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/Assets.xcassets/README__ignoredByTemplate__
@@ -1,0 +1,1 @@
+Did you know that git does not support storing empty directories?

--- a/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/ExtensionDelegate.swift
+++ b/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/ExtensionDelegate.swift
@@ -1,0 +1,26 @@
+//
+//  ExtensionDelegate.swift
+//  WatchOS 2 App Extension
+//
+//  Created by Benjamin Asher on 4/9/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import WatchKit
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
+
+    func applicationDidFinishLaunching() {
+        // Perform any final initialization of your application.
+    }
+
+    func applicationDidBecomeActive() {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillResignActive() {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, etc.
+    }
+
+}

--- a/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/Info.plist
+++ b/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>WatchOS 2 App Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>cocoapods.Extensions.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>WKExtensionDelegateClassName</key>
+	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
+</dict>
+</plist>

--- a/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/InterfaceController.swift
+++ b/spec/fixtures/Sample Project/Extensions/WatchOS 2 App Extension/InterfaceController.swift
@@ -1,0 +1,31 @@
+//
+//  InterfaceController.swift
+//  WatchOS 2 App Extension
+//
+//  Created by Benjamin Asher on 4/9/16.
+//  Copyright © 2016 CocoaPods. All rights reserved.
+//
+
+import WatchKit
+import Foundation
+
+
+class InterfaceController: WKInterfaceController {
+
+    override func awakeWithContext(context: AnyObject?) {
+        super.awakeWithContext(context)
+        
+        // Configure interface objects here.
+    }
+
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
+
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
+
+}

--- a/spec/fixtures/Sample Project/Extensions/WatchOS 2 App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/spec/fixtures/Sample Project/Extensions/WatchOS 2 App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,55 @@
+{
+  "images" : [
+    {
+      "size" : "24x24",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "27.5x27.5",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "86x86",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "98x98",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/spec/fixtures/Sample Project/Extensions/WatchOS 2 App/Base.lproj/Interface.storyboard
+++ b/spec/fixtures/Sample Project/Extensions/WatchOS 2 App/Base.lproj/Interface.storyboard
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="6221" systemVersion="13E28" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6213"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="3733"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="aou-V4-d1y">
+            <objects>
+                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModuleProvider="target"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/spec/fixtures/Sample Project/Extensions/WatchOS 2 App/Info.plist
+++ b/spec/fixtures/Sample Project/Extensions/WatchOS 2 App/Info.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Extensions</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>cocoapods.Extensions</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -672,24 +672,6 @@ module ProjectSpecs
         build_files = @target.resources_build_phase.files
         build_files.count.should == 1
       end
-
-      it 'positively identifies app extension targets' do
-        [:app_extension, :watch_extension].each do |type|
-          type_str = Xcodeproj::Constants::PRODUCT_TYPE_UTI[type]
-          @target.stubs(:product_type => type_str)
-          @target.app_extension?.should == true
-        end
-      end
-
-      it 'negatively identifies targets that are not app extensions' do
-        non_app_extension_type_strs = Xcodeproj::Constants::PRODUCT_TYPE_UTI.select do |key, _|
-          ![:app_extension, :watch_extension].include? key
-        end.values
-        non_app_extension_type_strs.each do |type_str|
-          @target.stubs(:product_type => type_str)
-          @target.app_extension?.should == false
-        end
-      end
     end
   end
 

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -672,6 +672,24 @@ module ProjectSpecs
         build_files = @target.resources_build_phase.files
         build_files.count.should == 1
       end
+
+      it 'positively identifies app extension targets' do
+        [:app_extension, :watch_extension].each do |type|
+          type_str = Xcodeproj::Constants::PRODUCT_TYPE_UTI[type]
+          @target.stubs(:product_type => type_str)
+          @target.app_extension?.should == true
+        end
+      end
+
+      it 'negatively identifies targets that are not app extensions' do
+        non_app_extension_type_strs = Xcodeproj::Constants::PRODUCT_TYPE_UTI.select do |key, _|
+          ![:app_extension, :watch_extension].include? key
+        end.values
+        non_app_extension_type_strs.each do |type_str|
+          @target.stubs(:product_type => type_str)
+          @target.app_extension?.should == false
+        end
+      end
     end
   end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -615,7 +615,27 @@ module ProjectSpecs
         @project = Xcodeproj::Project.open(path)
       end
 
-      it 'identifies hosts of extension targets' do
+      def target_for_product_bundle_id(product_bundle_id)
+        @project.native_targets.find do |target|
+          target.product_bundle_id == product_bundle_id
+        end
+      end
+
+      it 'identifies host of watch extension' do
+        watch_extension = target_for_product_bundle_id('cocoapods.Extensions.watchkitextension')
+        @project.host_target_for_app_extension_target(watch_extension).product_bundle_id.should == 'cocoapods.Extensions'
+      end
+
+      it 'identifies host of app extension' do
+        today_extension = target_for_product_bundle_id('cocoapods.Extensions.Today')
+        @project.host_target_for_app_extension_target(today_extension).product_bundle_id.should == 'cocoapods.Extensions'
+      end
+
+      it 'rejects identifying the host of targets that are not app extensions' do
+        watch_app = target_for_product_bundle_id('cocoapods.Extensions.watchkitapp')
+        should.raise ArgumentError do
+          @project.host_target_for_app_extension_target(watch_app)
+        end.message.should.equal "#{watch_app} is not an app extension"
       end
     end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -607,5 +607,18 @@ module ProjectSpecs
     end
 
     #-------------------------------------------------------------------------#
+
+    describe 'Extension target relationships' do
+      before do
+        dir = Pathname(fixture_path('Sample Project'))
+        path = dir + 'Extensions/Extensions.xcodeproj'
+        @project = Xcodeproj::Project.open(path)
+      end
+
+      it 'identifies hosts of extension targets' do
+      end
+    end
+
+    #-------------------------------------------------------------------------#
   end
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -637,6 +637,19 @@ module ProjectSpecs
           @project.host_target_for_app_extension_target(watch_app)
         end.message.should.equal "#{watch_app} is not an app extension"
       end
+
+      it 'identifies list of app extensions given a host target' do
+        main_app_target = target_for_product_bundle_id('cocoapods.Extensions')
+        app_extension_bundle_ids = @project.app_extensions_for_native_target(main_app_target).map(&:product_bundle_id)
+        app_extension_bundle_ids.should == ['cocoapods.Extensions.watchkitextension',
+                                            'cocoapods.Extensions.Today']
+      end
+
+      it 'returns an empty list app extensions given an app extension target' do
+        watch_extension = target_for_product_bundle_id('cocoapods.Extensions.watchkitextension')
+        app_extension_bundle_ids = @project.app_extensions_for_native_target(watch_extension).map(&:product_bundle_id)
+        app_extension_bundle_ids.should == []
+      end
     end
 
     #-------------------------------------------------------------------------#

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -615,39 +615,39 @@ module ProjectSpecs
         @project = Xcodeproj::Project.open(path)
       end
 
-      def target_for_product_bundle_id(product_bundle_id)
+      def target_for_target_name(name)
         @project.native_targets.find do |target|
-          target.product_bundle_id == product_bundle_id
+          target.name == name
         end
       end
 
       it 'identifies host of watch extension' do
-        watch_extension = target_for_product_bundle_id('cocoapods.Extensions.watchkitextension')
-        @project.host_target_for_app_extension_target(watch_extension).product_bundle_id.should == 'cocoapods.Extensions'
+        watch_extension = target_for_target_name('Extensions WatchKit 1 Extension')
+        @project.host_targets_for_app_extension_target(watch_extension).map(&:name).should == ['Extensions']
       end
 
       it 'identifies host of app extension' do
-        today_extension = target_for_product_bundle_id('cocoapods.Extensions.Today')
-        @project.host_target_for_app_extension_target(today_extension).product_bundle_id.should == 'cocoapods.Extensions'
+        today_extension = target_for_target_name('Today')
+        @project.host_targets_for_app_extension_target(today_extension).map(&:name).should == ['Extensions']
       end
 
       it 'rejects identifying the host of targets that are not app extensions' do
-        watch_app = target_for_product_bundle_id('cocoapods.Extensions.watchkitapp')
+        watch_app = target_for_target_name('Extensions WatchKit 1 App')
         should.raise ArgumentError do
-          @project.host_target_for_app_extension_target(watch_app)
+          @project.host_targets_for_app_extension_target(watch_app)
         end.message.should.equal "#{watch_app} is not an app extension"
       end
 
       it 'identifies list of app extensions given a host target' do
-        main_app_target = target_for_product_bundle_id('cocoapods.Extensions')
-        app_extension_bundle_ids = @project.app_extensions_for_native_target(main_app_target).map(&:product_bundle_id)
-        app_extension_bundle_ids.should == ['cocoapods.Extensions.watchkitextension',
-                                            'cocoapods.Extensions.Today']
+        main_app_target = target_for_target_name('Extensions')
+        app_extension_bundle_ids = @project.app_extensions_for_native_target(main_app_target).map(&:name)
+        app_extension_bundle_ids.should == ['Extensions WatchKit 1 Extension',
+                                            'Today']
       end
 
       it 'returns an empty list app extensions given an app extension target' do
-        watch_extension = target_for_product_bundle_id('cocoapods.Extensions.watchkitextension')
-        app_extension_bundle_ids = @project.app_extensions_for_native_target(watch_extension).map(&:product_bundle_id)
+        watch_extension = target_for_target_name('Extensions WatchKit 1 Extension')
+        app_extension_bundle_ids = @project.app_extensions_for_native_target(watch_extension).map(&:name)
         app_extension_bundle_ids.should == []
       end
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -623,32 +623,32 @@ module ProjectSpecs
 
       it 'identifies host of watch extension' do
         watch_extension = target_for_target_name('Extensions WatchKit 1 Extension')
-        @project.host_targets_for_app_extension_target(watch_extension).map(&:name).should == ['Extensions']
+        @project.host_targets_for_extension_target(watch_extension).map(&:name).should == ['Extensions']
       end
 
-      it 'identifies host of app extension' do
+      it 'identifies host of extension' do
         today_extension = target_for_target_name('Today')
-        @project.host_targets_for_app_extension_target(today_extension).map(&:name).should == ['Extensions']
+        @project.host_targets_for_extension_target(today_extension).map(&:name).should == ['Extensions']
       end
 
-      it 'rejects identifying the host of targets that are not app extensions' do
+      it 'rejects identifying the host of targets that are not extensions' do
         watch_app = target_for_target_name('Extensions WatchKit 1 App')
         should.raise ArgumentError do
-          @project.host_targets_for_app_extension_target(watch_app)
-        end.message.should.equal "#{watch_app} is not an app extension"
+          @project.host_targets_for_extension_target(watch_app)
+        end.message.should.equal "#{watch_app} is not an extension"
       end
 
-      it 'identifies list of app extensions given a host target' do
+      it 'identifies list of extensions given a host target' do
         main_app_target = target_for_target_name('Extensions')
-        app_extension_bundle_ids = @project.app_extensions_for_native_target(main_app_target).map(&:name)
-        app_extension_bundle_ids.should == ['Extensions WatchKit 1 Extension',
-                                            'Today']
+        extension_bundle_ids = @project.extensions_for_native_target(main_app_target).map(&:name)
+        extension_bundle_ids.should == ['Extensions WatchKit 1 Extension',
+                                        'Today']
       end
 
-      it 'returns an empty list app extensions given an app extension target' do
+      it 'returns an empty list extensions given an extension target' do
         watch_extension = target_for_target_name('Extensions WatchKit 1 Extension')
-        app_extension_bundle_ids = @project.app_extensions_for_native_target(watch_extension).map(&:name)
-        app_extension_bundle_ids.should == []
+        extension_bundle_ids = @project.extensions_for_native_target(watch_extension).map(&:name)
+        extension_bundle_ids.should == []
       end
     end
 


### PR DESCRIPTION
This is step 1 towards fixing CocoaPods/CocoaPods#4203. This provides a few new bits of functionality:

- Ability to determine if a target extends an app target
- Ability to determine which targets an app extension target extension
- Ability to determine a host target's app extension targets