### PR TITLE
Expand extension<->host relationship identification methods to all embeded targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ##### Enhancements
 
+* Expand `Project` helpers for finding a target's extension targets
+  and their hosts to include all embedded targets  
+  [Ben Asher](https://github.com/benasher44)
+  [#385](https://github.com/CocoaPods/Xcodeproj/pull/385)
+
 * Add helpers to `Project` for finding an extension target's host targets
   and a host target's extension targets.  
   [Ben Asher](https://github.com/benasher44)

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -526,37 +526,37 @@ module Xcodeproj
       root_object.targets.grep(PBXNativeTarget)
     end
 
-    # Checks the native target for any targets in the project that are
-    # extensions of that target
+    # Checks the native target for any targets in the project
+    # that are dependent on the native target and would be
+    # embedded in it at build time
     #
-    # @param  [PBXNativeTarget] native target to check for extensions
+    # @param  [PBXNativeTarget] native target to check for
+    #         embedded targets
     #
     #
-    # @return [Array<PBXNativeTarget>] A list of all targets that are
-    #         extensions of the passed in target.
+    # @return [Array<PBXNativeTarget>] A list of all targets that
+    #         are embedded in the passed in target
     #
-    def extensions_for_native_target(native_target)
-      return [] if native_target.extension_target_type?
+    def embedded_targets_in_native_target(native_target)
       native_targets.select do |target|
-        next unless target.extension_target_type?
-        host_targets_for_extension_target(target).map(&:uuid).include? native_target.uuid
+        host_targets_for_embedded_target(target).map(&:uuid).include? native_target.uuid
       end
     end
 
-    # Returns the native targets, in which the extension target are embedded.
-    # This works by traversing the targets to find those where the extension
-    # target is a dependency.
+    # Returns the native targets, in which the embedded target is
+    # embedded. This works by traversing the targets to find those
+    # where the target is a dependency.
     #
-    # @param  [PBXNativeTarget] native target where target.extension_target_type?
-    #                           is true
+    # @param  [PBXNativeTarget] native target that might be embedded
+    #         in another target
     #
-    # @return [Array<PBXNativeTarget>] the native targets that host the extension
+    # @return [Array<PBXNativeTarget>] the native targets that host the
+    #         embedded target
     #
-    def host_targets_for_extension_target(extension_target)
-      raise ArgumentError, "#{extension_target} is not an extension" unless extension_target.extension_target_type?
+    def host_targets_for_embedded_target(embedded_target)
       native_targets.select do |native_target|
-        ((extension_target.uuid != native_target.uuid) &&
-         (native_target.dependencies.map(&:target).map(&:uuid).include? extension_target.uuid))
+        ((embedded_target.uuid != native_target.uuid) &&
+         (native_target.dependencies.map(&:target).map(&:uuid).include? embedded_target.uuid))
       end
     end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -608,7 +608,7 @@ module ProjectSpecs
 
     #-------------------------------------------------------------------------#
 
-    describe 'Extension target relationships' do
+    describe 'Embedded target relationships' do
       before do
         dir = Pathname(fixture_path('Sample Project'))
         path = dir + 'Extensions/Extensions.xcodeproj'
@@ -623,32 +623,20 @@ module ProjectSpecs
 
       it 'identifies host of watch extension' do
         watch_extension = target_for_target_name('Extensions WatchKit 1 Extension')
-        @project.host_targets_for_extension_target(watch_extension).map(&:name).should == ['Extensions']
+        @project.host_targets_for_embedded_target(watch_extension).map(&:name).should == ['Extensions']
       end
 
       it 'identifies host of extension' do
         today_extension = target_for_target_name('Today')
-        @project.host_targets_for_extension_target(today_extension).map(&:name).should == ['Extensions']
+        @project.host_targets_for_embedded_target(today_extension).map(&:name).should == ['Extensions']
       end
 
-      it 'rejects identifying the host of targets that are not extensions' do
-        watch_app = target_for_target_name('Extensions WatchKit 1 App')
-        should.raise ArgumentError do
-          @project.host_targets_for_extension_target(watch_app)
-        end.message.should.equal "#{watch_app} is not an extension"
-      end
-
-      it 'identifies list of extensions given a host target' do
+      it 'identifies list of embedded targets given a host target' do
         main_app_target = target_for_target_name('Extensions')
-        extension_bundle_ids = @project.extensions_for_native_target(main_app_target).map(&:name)
+        extension_bundle_ids = @project.embedded_targets_in_native_target(main_app_target).map(&:name)
         extension_bundle_ids.should == ['Extensions WatchKit 1 Extension',
+                                        'WatchOS 2 App',
                                         'Today']
-      end
-
-      it 'returns an empty list extensions given an extension target' do
-        watch_extension = target_for_target_name('Extensions WatchKit 1 Extension')
-        extension_bundle_ids = @project.extensions_for_native_target(watch_extension).map(&:name)
-        extension_bundle_ids.should == []
       end
     end
 


### PR DESCRIPTION
This will allow CocoaPods/CocoaPods#5502 to handle both extension and framework targets