### PR TITLE
Disable codesigning for iOS targets

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -194,7 +194,7 @@ module Xcodeproj
       }.freeze,
       [:ios, :framework] => {
         'LD_RUNPATH_SEARCH_PATHS'           => ['$(inherited)', '@executable_path/Frameworks', '@loader_path/Frameworks'],
-        'CODE_SIGN_IDENTITY[sdk=iphoneos*]' => 'iPhone Developer',
+        'CODE_SIGN_IDENTITY[sdk=iphoneos*]' => '',
         'TARGETED_DEVICE_FAMILY'            => '1,2',
       }.freeze,
       [:osx, :framework] => {


### PR DESCRIPTION
Xcode 8 validates code-signing things as the first step when this setting is configured at all. Since we want to not codesign for the Pods project, we'll turn it off.

@segiddins we should probably do this inside CocoaPods instead and only for Pod targets, but I couldn't figure out the syntax :grin:

```ruby
build_configuration.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]']
= ''
```

did not work for me.