### PR TITLE
Add quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ by performing the following command:
 
     $ [sudo] gem install xcodeproj
 
+## Quickstart
+
+To begin editing an xcodeproj file start by opening it as an Xcodeproj with:
+```
+require 'xcodeproj'
+project_path = "/your_path/your_project.xcodeproj"
+project = Xcodeproj::Project.open(project_path)
+```
+
 ## Collaborate
 
 All Xcodeproj development happens on [GitHub][xcodeproj]. Contributing patches


### PR DESCRIPTION
Recently had a chance to use this gem and found it incredibly helpful. Thank you! 

It did, however, take me a little while to figure out how to actually open my .xcodeproj and start editing. I got pretty stuck trying to do `Xcodeproj::Project.new(path)` and the docs did not have much about how to get started. 

This quickstart would have been super helpful for my particular situation. I'm not sure that it is the most common use case though, so I would welcome feedback on what else should be included. Or maybe there's a better place to include this type of information. Wanted to get the conversation started though! 