### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 
 Xcodeproj lets you create and modify Xcode projects from [Ruby][ruby].
 Script boring management tasks or build Xcode-friendly libraries. Also includes
-support for Xcode workspaces (.xcworkspace) and configuration files (.xcconfig).
+support for Xcode workspaces (`.xcworkspace`), configuration files (`.xcconfig`) and
+Xcode Scheme files (`.xcscheme`).
 
 It is used in [CocoaPods](https://github.com/CocoaPods/CocoaPods) to create a
-static library from scratch, for both iOS and OSX.
+a collection of supplemental libraries or frameworks, for all platforms Xcode supports.
 
-The documentation can be found [here](http://docs.cocoapods.org/xcodeproj/index.html).
+The API reference can be found [here](http://www.rubydoc.info/gems/xcodeproj).
 
 ## Installing Xcodeproj
 
@@ -23,11 +24,54 @@ by performing the following command:
 ## Quickstart
 
 To begin editing an xcodeproj file start by opening it as an Xcodeproj with:
-```
+
+```ruby
 require 'xcodeproj'
-project_path = "/your_path/your_project.xcodeproj"
+project_path = '/your_path/your_project.xcodeproj'
 project = Xcodeproj::Project.open(project_path)
 ```
+
+#### Some Small Examples To Get You Started
+
+> Look through all targets
+
+```ruby
+project.targets.each do |target|
+  puts target.name
+end
+```
+
+> Get all source files for a target
+
+```ruby
+target = project.targets.first
+files = target.source_build_phase.files.to_a.map do |pbx_build_file|
+	pbx_build_file.file_ref.real_path.to_s
+
+end.select do |path|
+  path.end_with?(".m", ".mm", ".swift")
+
+end.select do |path|
+  File.exists?(path)
+end
+```
+
+> Set a specific build configuration to all targets
+
+```ruby
+project.targets.each do |target|
+  target.build_configurations.each do |config|
+    config.build_settings['MY_CUSTOM_FLAG'] ||= 'TRUE'
+  end
+end
+```
+
+## Command Line Tool
+
+Installing the Xcodeproj gem will also install a command-line tool `xcodeproj` which you can
+use to generate project diffs, target diffs, output all configurations and show a YAML representation.
+
+For more information consult `xcodeproj --help`.
 
 ## Collaborate
 


### PR DESCRIPTION
Thanks @samjohn - re: https://github.com/CocoaPods/Xcodeproj/pull/391

This adds some examples ( I've taken them from Artsy's Podfile, and CocoaDoc's Testing Investigator ) open to more examples. 

Updated the types of Xcode things it can handle, and removed the direct reference to platforms now there's 2 new ones per year ;)

Added a ref about the `xcodeproj` tool too