### PR TITLE
Avoid use of `activesupport` version 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Avoid use of `activesupport` version 5 to stay compatible with macOS system Ruby.  
+  [Boris Bügling](https://github.com/neonichu)
+  [#393](https://github.com/CocoaPods/Xcodeproj/pull/393)
 
 
 ## 1.1.0 (2016-06-01)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
   remote: .
   specs:
     xcodeproj (1.1.0)
-      activesupport (>= 3)
+      activesupport (>= 3, < 5)
       claide (>= 1.0.0, < 2.0)
       colored (~> 1.2)
 
@@ -92,4 +92,4 @@ DEPENDENCIES
   xcodeproj!
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = %w{ xcodeproj }
   s.require_paths = %w{ lib }
 
-  s.add_runtime_dependency 'activesupport', '>= 3'
+  s.add_runtime_dependency 'activesupport', '>= 3', '< 5'
   s.add_runtime_dependency 'colored',       '~> 1.2'
   s.add_runtime_dependency 'claide',        '>= 1.0.0', '< 2.0'
 


### PR DESCRIPTION
Version 5 of `activesupport` requires Ruby version >= 2.2.2 which breaks fresh installations using system Ruby, which is still 2.0, even on macOS 10.12.