### PR TITLE
Use `__pthread_chdir` instead of `chdir`

### DIFF
--- a/lib/xcodeproj/plist/ffi/dev_tools_core.rb
+++ b/lib/xcodeproj/plist/ffi/dev_tools_core.rb
@@ -1,5 +1,35 @@
 require 'fiddle'
 
+# Since Xcode 8 beta 4, calling `PBXProject.projectWithFile` does break subsequent calls to
+# `chdir`. While sounding ridiculous, this is unfortunately true and debugging it from the
+# userland side showed no difference at all to successful calls to `chdir`, but the working
+# directory is simply not changed in the end. This workaround is even more absurd, monkey
+# patching all calls to `chdir` to use `__pthread_chdir` which does appear to work just fine.
+class Dir
+  def self.chdir(path)
+    old_dir = Dir.getwd
+    res = actually_chdir(path)
+
+    if block_given?
+      begin
+        return yield
+      ensure
+        actually_chdir(old_dir)
+      end
+    end
+
+    res
+  end
+
+  private
+
+  def self.actually_chdir(path)
+    libc = Fiddle.dlopen '/usr/lib/libc.dylib'
+    f = Fiddle::Function.new(libc['__pthread_chdir'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT)
+    f.call(path.to_s)
+  end
+end
+
 module Xcodeproj
   module Plist
     module FFI


### PR DESCRIPTION
:boom:

This fixes CocoaPods/CocoaPods#5661 — we should probably not merge it until it is confirmed that the final version of Xcode 8 exhibits the same weird behaviour.