### PR TITLE
Make FFI fail fast if the shared libraries it relies on are not available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ group :development do
   gem 'codeclimate-test-reporter', :require => nil
   gem 'simplecov'
   gem 'rubocop'
+
+  gem 'plist'
 end
 
 group :debugging do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     notify (0.5.2)
     parser (2.3.0.6)
       ast (~> 2.2)
+    plist (3.2.0)
     powerpack (0.1.1)
     prettybacon (0.0.2)
       bacon (~> 1.2)
@@ -91,6 +92,7 @@ DEPENDENCIES
   kicker
   mocha
   mocha-on-bacon
+  plist
   prettybacon
   rake
   rubocop

--- a/lib/xcodeproj/plist/ffi.rb
+++ b/lib/xcodeproj/plist/ffi.rb
@@ -17,7 +17,16 @@ module Xcodeproj
           return @attempt_to_load if defined?(@attempt_to_load)
           @attempt_to_load = begin
             require 'fiddle'
-            nil
+            begin
+              if DevToolsCore.load_xcode_frameworks
+                return nil
+              elsif CoreFoundation.image
+                return nil
+              end
+            rescue Fiddle::DLError
+              'Xcodeproj::Plist::FFI relies on a Xcode and  and CoreFoundation' \
+              'to read and write Xcode project files.'
+            end
           rescue LoadError
             'Xcodeproj relies on a library called `fiddle` to read and write ' \
             'Xcode project files. Ensure your Ruby installation includes ' \

--- a/lib/xcodeproj/plist/ffi.rb
+++ b/lib/xcodeproj/plist/ffi.rb
@@ -24,6 +24,8 @@ module Xcodeproj
                 return nil
               end
             rescue Fiddle::DLError
+              'Fallthrough to error which would happen if above methods' \
+              'returned nil instead of raising DLError'
             end
             'Xcodeproj::Plist::FFI relies on Xcode and/or CoreFoundation' \
             'to read and write Xcode project files.'

--- a/lib/xcodeproj/plist/ffi.rb
+++ b/lib/xcodeproj/plist/ffi.rb
@@ -24,9 +24,9 @@ module Xcodeproj
                 return nil
               end
             rescue Fiddle::DLError
-              'Xcodeproj::Plist::FFI relies on a Xcode and  and CoreFoundation' \
-              'to read and write Xcode project files.'
             end
+            'Xcodeproj::Plist::FFI relies on Xcode and/or CoreFoundation' \
+            'to read and write Xcode project files.'
           rescue LoadError
             'Xcodeproj relies on a library called `fiddle` to read and write ' \
             'Xcode project files. Ensure your Ruby installation includes ' \

--- a/spec/plist_helper_spec.rb
+++ b/spec/plist_helper_spec.rb
@@ -227,8 +227,11 @@ EOS
       extend SpecHelper::TemporaryDirectory
 
       before do
-        Plist.implementation = nil
         @plist = temporary_directory + 'plist'
+      end
+
+      after do
+        Plist.implementation = Plist::FFI
       end
 
       def write_and_read_xml_plist
@@ -240,6 +243,7 @@ EOS
       end
 
       it 'will fallback to Plist implementation in abscence of Xcode and CF' do
+        Plist.implementation = nil
         Plist::FFI::DevToolsCore.stubs(:load_xcode_frameworks).returns(nil)
         Plist::FFI::CoreFoundation.stubs(:image).returns(nil)
         Plist.implementation.should == Plist::PlistGem
@@ -247,6 +251,7 @@ EOS
       end
 
       it 'will fallback to Plist implementation in if shared lib load fails' do
+        Plist.implementation = nil
         Plist::FFI::DevToolsCore.stubs(:load_xcode_frameworks) { raise Fiddle::DLError }
         Plist::FFI::CoreFoundation.stubs(:image) { raise Fiddle::DLError }
         Plist.implementation.should == Plist::PlistGem


### PR DESCRIPTION
The enables the fallback Plist gem implementation to be used. As it stands FFI is selected based only on the presence of 'fiddle' and and then fails later when actually attempting to read/write a project/plist.