### PR TITLE
Xcode 8 devtoolscore workaround subprocess exec

### DIFF
--- a/lib/xcodeproj/plist/ffi/dev_tools_core.rb
+++ b/lib/xcodeproj/plist/ffi/dev_tools_core.rb
@@ -5,14 +5,11 @@ module Xcodeproj
     module FFI
       module DevToolsCore
         def self.silence_stderr
-          #begin
-          #  orig_stderr = $stderr.clone
-          #  $stderr.reopen File.new('/dev/null', 'w')
-            retval = yield
-          #ensure
-          #  $stderr.reopen orig_stderr
-          #end
-          retval
+          orig_stderr = $stderr.clone
+          $stderr.reopen File.new('/dev/null', 'w')
+          yield
+        ensure
+          $stderr.reopen orig_stderr
         end
 
         # rubocop:disable Style/MethodName

--- a/lib/xcodeproj/plist/ffi/dev_tools_core.rb
+++ b/lib/xcodeproj/plist/ffi/dev_tools_core.rb
@@ -5,13 +5,13 @@ module Xcodeproj
     module FFI
       module DevToolsCore
         def self.silence_stderr
-          begin
-            orig_stderr = $stderr.clone
-            $stderr.reopen File.new('/dev/null', 'w')
+          #begin
+          #  orig_stderr = $stderr.clone
+          #  $stderr.reopen File.new('/dev/null', 'w')
             retval = yield
-          ensure
-            $stderr.reopen orig_stderr
-          end
+          #ensure
+          #  $stderr.reopen orig_stderr
+          #end
           retval
         end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -208,7 +208,7 @@ module ProjectSpecs
       end
 
       it 'escapes non ASCII characters in the project' do
-        Plist::FFI::DevToolsCore.stubs(:load_xcode_frameworks).returns(nil)
+        Plist::FFI.stubs(:ruby_hash_write_xcode).returns(false)
 
         file_ref = @project.new_file('わくわく')
         file_ref.name = 'わくわく'


### PR DESCRIPTION
An alternative to @neonichu's recent work ¯\\\_(ツ)\_/¯ 