### PR TITLE
[FFI] Default to overriding chdir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ rvm:
 before_install:
   # There is a bug in travis. When using system ruby, bundler is not installed
   # and causes the default install action to fail.
-  - sudo gem install bundler
+  - sudo gem install bundler -v '1.12.5'
   # RubyGems 2.0.14 isn't a fun time on system ruby
   - if [ $TRAVIS_RUBY_VERSION = "system" ]; then sudo gem update --system; fi
 

--- a/lib/xcodeproj/plist/ffi.rb
+++ b/lib/xcodeproj/plist/ffi.rb
@@ -68,7 +68,7 @@ module Xcodeproj
 
           path = File.expand_path(path)
 
-          should_fork = ENV['FORK_XCODE_WRITING'] == true
+          should_fork = ENV['FORK_XCODE_WRITING']
           success = ruby_hash_write_xcode(hash, path, should_fork)
 
           unless success

--- a/lib/xcodeproj/plist/ffi.rb
+++ b/lib/xcodeproj/plist/ffi.rb
@@ -1,11 +1,11 @@
 module Xcodeproj
   module Plist
     module Extensions
-      # Since Xcode 8 beta 4, calling `PBXProject.projectWithFile` does break subsequent calls to
+      # Since Xcode 8 beta 4, calling `PBXProject.projectWithFile` breaks subsequent calls to
       # `chdir`. While sounding ridiculous, this is unfortunately true and debugging it from the
       # userland side showed no difference at all to successful calls to `chdir`, but the working
       # directory is simply not changed in the end. This workaround is even more absurd, monkey
-      # patching all calls to `chdir` to use `__pthread_chdir` which does appear to work just fine.
+      # patching all calls to `chdir` to use `__pthread_chdir` which appears to work.
       module Dir
         def self.chdir(path)
           old_dir = Dir.getwd

--- a/lib/xcodeproj/plist/ffi.rb
+++ b/lib/xcodeproj/plist/ffi.rb
@@ -171,7 +171,7 @@ module Xcodeproj
         end
 
         def monkey_patch_chdir
-          Dir.include Extensions::Dir
+          Dir.send(:include, Extensions::Dir)
         end
       end
     end


### PR DESCRIPTION
Because running Xcode via `open3` is so slow, default to the `chdir` override,  but allow users to opt for `open3` via an env var.