### PR TITLE
Fix Encoding::UndefinedConversionError

### DIFF
--- a/lib/xcodeproj/plist/ffi.rb
+++ b/lib/xcodeproj/plist/ffi.rb
@@ -103,7 +103,7 @@ module Xcodeproj
           return false unless path.end_with?('pbxproj')
           if should_fork
             require 'open3'
-            _output, status = Open3.capture2e(Gem.ruby, '-e', <<-RUBY, path, :stdin_data => Marshal.dump(hash))
+            _output, status = Open3.capture2e(Gem.ruby, '-e', <<-RUBY, path, :stdin_data => Marshal.dump(hash), :binmode => true)
             $LOAD_PATH.replace #{$LOAD_PATH}
             path = ARGV.first
             hash = Marshal.load(STDIN)


### PR DESCRIPTION
Fix #418 

Can't write a simple case to reproduce the problem, just encoding marshaled data to base64.