### PR TITLE
Add support for command line arguments

### DIFF
--- a/lib/xcodeproj/scheme/abstract_scheme_action.rb
+++ b/lib/xcodeproj/scheme/abstract_scheme_action.rb
@@ -1,4 +1,6 @@
 require 'xcodeproj/scheme/xml_element_wrapper'
+require 'xcodeproj/scheme/environment_variables'
+require 'xcodeproj/scheme/command_line_arguments'
 
 module Xcodeproj
   class XCScheme

--- a/lib/xcodeproj/scheme/command_line_arguments.rb
+++ b/lib/xcodeproj/scheme/command_line_arguments.rb
@@ -40,10 +40,14 @@ module Xcodeproj
       #         The new set of command line arguments after addition
       #
       def assign_argument(argument)
-        env_var = argument.is_a?(CommandLineArgument) ? argument : CommandLineArgument.new(argument)
-        all_arguments.each { |existing_var| remove_argument(existing_var) if existing_var.argument == env_var.argument }
-        @xml_element.add_element(env_var.xml_element)
-        @all_arguments << env_var
+        command_line_arg = if argument.is_a?(CommandLineArgument)
+                             argument
+                           else
+                             CommandLineArgument.new(argument)
+                           end
+        all_arguments.each { |existing_var| remove_argument(existing_var) if existing_var.argument == command_line_arg.argument }
+        @xml_element.add_element(command_line_arg.xml_element)
+        @all_arguments << command_line_arg
       end
 
       # Removes a specified argument (by string or object) from the set of command line arguments
@@ -54,10 +58,14 @@ module Xcodeproj
       #         The new set of command line arguments after removal
       #
       def remove_argument(argument)
-        env_var = argument.is_a?(CommandLineArgument) ? argument : all_arguments.find { |var| var.argument == argument }
-        raise "Unexpected parameter type: #{env_var.class}" unless env_var.is_a?(CommandLineArgument)
-        @xml_element.delete_element(env_var.xml_element)
-        @all_arguments -= [env_var]
+        command_line_arg = if argument.is_a?(CommandLineArgument)
+                             argument
+                           else
+                             CommandLineArgument.new(argument)
+                           end
+        raise "Unexpected parameter type: #{command_line_arg.class}" unless command_line_arg.is_a?(CommandLineArgument)
+        @xml_element.delete_element(command_line_arg.xml_element)
+        @all_arguments -= [command_line_arg]
       end
 
       # @param [String] key
@@ -93,7 +101,7 @@ module Xcodeproj
 
     # This class wraps the CommandLineArgument node of a .xcscheme XML file.
     # Environment arguments are accessible via the NSDictionary returned from
-    # [[NSProcessInfo processInfo] environment] in your app code.
+    # [[NSProcessInfo processInfo] arguments] in your app code.
     #
     class CommandLineArgument < XMLElementWrapper
       # @param [nil,REXML::Element,Hash{Symbol => String,Bool}] node_or_argument

--- a/lib/xcodeproj/scheme/command_line_arguments.rb
+++ b/lib/xcodeproj/scheme/command_line_arguments.rb
@@ -1,0 +1,154 @@
+require 'xcodeproj/scheme/xml_element_wrapper'
+
+module Xcodeproj
+  class XCScheme
+    COMMAND_LINE_ARGS_NODE = 'CommandLineArguments'.freeze
+    COMMAND_LINE_ARG_NODE = 'CommandLineArgument'.freeze
+
+    # This class wraps the CommandLineArguments node of a .xcscheme XML file. This
+    # is just a container of CommandLineArgument objects. It can either appear on a
+    # LaunchAction or TestAction scheme group.
+    #
+    class CommandLineArguments < XMLElementWrapper
+      # @param [nil,REXML::Element,Array<CommandLineArgument>,Array<Hash{Symbol => String,Bool}>] node_or_arguments
+      #        The 'CommandLineArguments' XML node, or list of command line arguments, that this object represents.
+      #          - If nil, an empty 'CommandLineArguments' XML node will be created
+      #          - If an REXML::Element, it must be named 'CommandLineArguments'
+      #          - If an Array of objects or Hashes, they'll each be passed to {#assign_argument}
+      #
+      def initialize(node_or_arguments = nil)
+        create_xml_element_with_fallback(node_or_arguments, COMMAND_LINE_ARGS_NODE) do
+          @all_arguments = []
+          node_or_arguments.each { |var| assign_argument(var) } unless node_or_arguments.nil?
+        end
+      end
+
+      # @return [Array<CommandLineArgument>]
+      #         The key value pairs currently set in @xml_element
+      #
+      def all_arguments
+        @all_arguments ||= @xml_element.get_elements(COMMAND_LINE_ARG_NODE).map { |argument| CommandLineArgument.new(argument) }
+      end
+
+      # Adds a given argument to the set of command line arguments, or replaces it if that key already exists
+      #
+      # @param [CommandLineArgument,Hash{Symbol => String,Bool}] argument
+      #        The argument to add or update, backed by an CommandLineArgument node.
+      #          - If an CommandLineArgument, the previous reference will still be valid
+      #          - If a Hash, must conform to {CommandLineArgument#initialize} requirements
+      # @return [Array<CommandLineArgument>]
+      #         The new set of command line arguments after addition
+      #
+      def assign_argument(argument)
+        env_var = argument.is_a?(CommandLineArgument) ? argument : CommandLineArgument.new(argument)
+        all_arguments.each { |existing_var| remove_argument(existing_var) if existing_var.argument == env_var.argument }
+        @xml_element.add_element(env_var.xml_element)
+        @all_arguments << env_var
+      end
+
+      # Removes a specified argument (by string or object) from the set of command line arguments
+      #
+      # @param [CommandLineArgument,String] argument
+      #        The argument to remove
+      # @return [Array<CommandLineArgument>]
+      #         The new set of command line arguments after removal
+      #
+      def remove_argument(argument)
+        env_var = argument.is_a?(CommandLineArgument) ? argument : all_arguments.find { |var| var.argument == argument }
+        raise "Unexpected parameter type: #{env_var.class}" unless env_var.is_a?(CommandLineArgument)
+        @xml_element.delete_element(env_var.xml_element)
+        @all_arguments -= [env_var]
+      end
+
+      # @param [String] key
+      #        The key to lookup
+      # @return [CommandLineArgument] argument
+      #         Returns the matching command line argument for a specified key
+      #
+      def [](argument)
+        all_arguments.find { |var| var.argument == argument }
+      end
+
+      # Assigns a value for a specified key
+      #
+      # @param [String] key
+      #        The key to update in the command line arguments
+      # @param [String] value
+      #        The value to lookup
+      # @return [CommandLineArgument] argument
+      #         The newly updated command line argument
+      #
+      def []=(argument, enabled)
+        assign_argument(:argument => argument, :enabled => enabled)
+        self[argument]
+      end
+
+      # @return [Array<Hash{Symbol => String,Bool}>]
+      #         The current command line arguments represented as an array
+      #
+      def to_a
+        all_arguments.map(&:to_h)
+      end
+    end
+
+    # This class wraps the CommandLineArgument node of a .xcscheme XML file.
+    # Environment arguments are accessible via the NSDictionary returned from
+    # [[NSProcessInfo processInfo] environment] in your app code.
+    #
+    class CommandLineArgument < XMLElementWrapper
+      # @param [nil,REXML::Element,Hash{Symbol => String,Bool}] node_or_argument
+      #        - If nil, it will create a default XML node to use
+      #        - If a REXML::Element, should be a <CommandLineArgument> XML node to wrap
+      #        - If a Hash, must contain keys :key and :value (Strings) and optionally :enabled (Boolean)
+      #
+      def initialize(node_or_argument)
+        create_xml_element_with_fallback(node_or_argument, COMMAND_LINE_ARG_NODE) do
+          raise "Must pass a Hash with 'argument' and 'enabled'!" unless node_or_argument.is_a?(Hash) &&
+              node_or_argument.key?(:argument) && node_or_argument.key?(:enabled)
+
+          @xml_element.attributes['argument'] = node_or_argument[:argument]
+          @xml_element.attributes['isEnabled'] = if node_or_argument.key?(:enabled)
+                                                   bool_to_string(node_or_argument[:enabled])
+                                                 else
+                                                   bool_to_string(false)
+                                                 end
+        end
+      end
+
+      # Returns the CommandLineArgument's key
+      # @return [String]
+      #
+      def argument
+        @xml_element.attributes['argument']
+      end
+
+      # Sets the CommandLineArgument's key
+      # @param [String] key
+      #
+      def argument=(argument)
+        @xml_element.attributes['argument'] = argument
+      end
+
+      # Returns the CommandLineArgument's enabled state
+      # @return [Bool]
+      #
+      def enabled
+        string_to_bool(@xml_element.attributes['isEnabled'])
+      end
+
+      # Sets the CommandLineArgument's enabled state
+      # @param [Bool] enabled
+      #
+      def enabled=(enabled)
+        @xml_element.attributes['isEnabled'] = bool_to_string(enabled)
+      end
+
+      # @return [Hash{:key => String, :value => String, :enabled => Bool}]
+      #         The command line argument XML node with attributes converted to a representative Hash
+      #
+      def to_h
+        { :argument => argument, :enabled => enabled }
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -79,6 +79,22 @@ module Xcodeproj
       end
 
       # @todo handle 'AdditionalOptions' tag
+
+      # @return [CommandLineArguments]
+      #         Returns the CommandLineArguments that will be passed at app launch
+      #
+      def command_line_arguments
+        CommandLineArguments.new(@xml_element.elements[XCScheme::COMMAND_LINE_ARGS_NODE])
+      end
+
+      # @return [CommandLineArguments] arguments
+      #         Sets the CommandLineArguments that will be passed at app launch
+      #
+      def command_line_arguments=(arguments)
+        @xml_element.delete_element(XCScheme::COMMAND_LINE_ARGS_NODE)
+        @xml_element.add_element(arguments.xml_element) if arguments
+        arguments
+      end
     end
   end
 end

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -1,5 +1,4 @@
 require 'xcodeproj/scheme/abstract_scheme_action'
-require 'xcodeproj/scheme/environment_variables'
 
 module Xcodeproj
   class XCScheme

--- a/spec/scheme/launch_action_spec.rb
+++ b/spec/scheme/launch_action_spec.rb
@@ -56,6 +56,63 @@ module Xcodeproj
         end
       end
 
+      describe '#command_line_arguments' do
+        vars_node_name = XCScheme::COMMAND_LINE_ARGS_NODE
+        var_node_name = XCScheme::COMMAND_LINE_ARG_NODE
+
+        it 'starts as nil if no xml exists' do
+          @sut.xml_element.elements[vars_node_name].should.equal nil
+          @sut.command_line_arguments.to_a.should.equal []
+        end
+
+        it 'picks up an existing node if exists in the XML' do
+          env_vars_xml = @sut.xml_element.add_element(vars_node_name)
+          env_vars_xml.add_element(var_node_name, 'isEnabled' => 'NO', 'argument' => '-com.foo.bar 1')
+          env_vars_xml.add_element(var_node_name, 'isEnabled' => 'YES', 'argument' => '-org.foo.bar 1')
+
+          # Reload content from XML
+          @sut = XCScheme::LaunchAction.new(@sut.xml_element)
+
+          @sut.command_line_arguments.to_a.should == [{ :argument => '-com.foo.bar 1', :enabled => false },
+                                                      { :argument => '-org.foo.bar 1', :enabled => true }]
+        end
+
+        it 'reflects direct changes to xml' do
+          @sut.command_line_arguments = XCScheme::CommandLineArguments.new([{ :argument => '-com.foo.bar 1', :enabled => false },
+                                                                            { :argument => '-org.foo.bar 1', :enabled => true }])
+          node_to_delete = @sut.command_line_arguments.xml_element.elements["#{var_node_name}[@argument='-com.foo.bar 1']"]
+          @sut.command_line_arguments.xml_element.delete(node_to_delete)
+          @sut.command_line_arguments.to_a.should == [{ :argument => '-org.foo.bar 1', :enabled => true }]
+        end
+
+        it 'can be assigned nil' do
+          @sut.xml_element.get_elements(vars_node_name).count.should == 0
+
+          @sut.command_line_arguments = XCScheme::CommandLineArguments.new
+          @sut.command_line_arguments.should.not.equal nil
+          @sut.xml_element.get_elements(vars_node_name).count.should == 1
+
+          @sut.command_line_arguments = nil
+          @sut.command_line_arguments.to_a.should.equal []
+          @sut.xml_element.elements[vars_node_name].should.be.nil
+        end
+
+        it 'assigning an CommandLineArguments object updates the xml' do
+          cl_arg = XCScheme::CommandLineArguments.new([{ :argument => '-com.foo.bar 1', :enabled => false }])
+          cl_arg.xml_element.elements.count.should == 1
+
+          @sut.command_line_arguments = cl_arg
+          @sut.command_line_arguments.to_a.should == [{ :argument => '-com.foo.bar 1', :enabled => false }]
+          @sut.command_line_arguments.xml_element.should == cl_arg.xml_element
+
+          xml_out = ''
+          xml_formatter = REXML::Formatters::Pretty.new(0)
+          xml_formatter.compact = true
+          xml_formatter.write(@sut.command_line_arguments.xml_element, xml_out)
+          xml_out.should == "<CommandLineArguments>\n<CommandLineArgument argument='-com.foo.bar 1' isEnabled='NO'/>\n</CommandLineArguments>"
+        end
+      end
+
       describe '#environment_variables' do
         vars_node_name = XCScheme::VARIABLES_NODE
         var_node_name = XCScheme::VARIABLE_NODE


### PR DESCRIPTION
I would like to be able to use `Xcodeproj` to manage the "Arguments Passed On Launch" within a projects Schemes. This adds support for getting and setting the `CommandLineArguments` (as the xcscheme format calls them internally).

I've added specs and based the implementation off of the `EnvironmentVariables` implementation that was in use for the `XCScheme::LaunchAction`.

![example-setting](https://cloud.githubusercontent.com/assets/20668/18736646/e009ccbc-803d-11e6-862c-97657191dbe4.png)

Which Xcode converts in the `xcscheme` to:

![xcscheme-sample](https://cloud.githubusercontent.com/assets/20668/18736678/26982476-803e-11e6-9d3f-742ab99db550.png)

I've also moved the `require` for `EnvironmentVariables` from `TestAction` to `AbstractSchemeAction`. 

Please let me know if anything should be updated/improved.

Thanks!