### PR TITLE
Update last known OS constants to latest Apple OS releases

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -4,17 +4,17 @@ module Xcodeproj
   module Constants
     # @return [String] The last known iOS SDK (stable).
     #
-    LAST_KNOWN_IOS_SDK = '9.3'
+    LAST_KNOWN_IOS_SDK = '10.0'
 
     # @return [String] The last known OS X SDK (stable).
     #
-    LAST_KNOWN_OSX_SDK = '10.11'
+    LAST_KNOWN_OSX_SDK = '10.12'
 
     # @return [String] The last known tvOS SDK (stable).
-    LAST_KNOWN_TVOS_SDK = '9.2'
+    LAST_KNOWN_TVOS_SDK = '10.0'
 
     # @return [String] The last known watchOS SDK (stable).
-    LAST_KNOWN_WATCHOS_SDK = '2.2'
+    LAST_KNOWN_WATCHOS_SDK = '3.0'
 
     # @return [String] The last known archive version to Xcodeproj.
     #

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -391,7 +391,7 @@ module ProjectSpecs
         it 'adds a file reference for a system framework, in a dedicated subgroup of the Frameworks group' do
           @target.add_system_framework('QuartzCore')
           file = @project['Frameworks/iOS'].files.first
-          file.path.should == 'Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk/System/Library/Frameworks/QuartzCore.framework'
+          file.path.should == 'Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/QuartzCore.framework'
           file.source_tree.should == 'DEVELOPER_DIR'
         end
 

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -406,14 +406,14 @@ module ProjectSpecs
           @target.build_configuration_list.set_setting('SDKROOT', 'iphoneos')
           @target.add_system_framework('QuartzCore')
           file = @project['Frameworks/iOS'].files.first
-          file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_IOS_SDK
+          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_IOS_SDK
         end
 
         it 'uses the last known tvOS SDK version if none is specified in the target' do
           @target.build_configuration_list.set_setting('SDKROOT', 'appletvos')
           @target.add_system_framework('TVServices')
           file = @project['Frameworks/tvOS'].files.first
-          file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_TVOS_SDK
+          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_TVOS_SDK
         end
 
         it 'uses the last known watchOS SDK version if none is specified in the target' do


### PR DESCRIPTION
This revision updates the constants representing the last known iOS, tvOS, macOS, and watchOS to reflect the latest releases.  
