### PR TITLE
#221 Fixed handling of xcdatamodeld packages in subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   [Danielle Tomlinson](https://github.com/dantoml)
   [#421](https://github.com/CocoaPods/Xcodeproj/pull/421)
 
+* Fixed handling of xcdatamodeld packages in subfolders.
+  [Simon Seyer](https://github.com/Eldorado234)
+  [#427](https://github.com/CocoaPods/Xcodeproj/pull/427)
 
 ## 1.3.1 (2016-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   [Danielle Tomlinson](https://github.com/dantoml)
   [#421](https://github.com/CocoaPods/Xcodeproj/pull/421)
 
-* Fixed handling of xcdatamodeld packages in subfolders.
+* Fixed handling of xcdatamodeld packages in subfolders.  
   [Simon Seyer](https://github.com/Eldorado234)
   [#427](https://github.com/CocoaPods/Xcodeproj/pull/427)
 

--- a/lib/xcodeproj/project/object/helpers/file_references_factory.rb
+++ b/lib/xcodeproj/project/object/helpers/file_references_factory.rb
@@ -132,13 +132,14 @@ module Xcodeproj
             GroupableHelper.set_path_with_source_tree(ref, path, source_tree)
             ref.version_group_type = 'wrapper.xcdatamodel'
 
+            real_path = group.real_path.join(path) 
             current_version_name = nil
-            if path.exist?
-              path.children.each do |child_path|
+            if real_path.exist?
+              real_path.children.each do |child_path|
                 if File.extname(child_path) == '.xcdatamodel'
                   new_file_reference(ref, child_path, :group)
                 elsif File.basename(child_path) == '.xccurrentversion'
-                  full_path = path + File.basename(child_path)
+                  full_path = real_path + File.basename(child_path)
                   xccurrentversion = Plist.read_from_path(full_path)
                   current_version_name = xccurrentversion['_XCCurrentVersionName']
                 end

--- a/lib/xcodeproj/project/object/helpers/file_references_factory.rb
+++ b/lib/xcodeproj/project/object/helpers/file_references_factory.rb
@@ -132,7 +132,7 @@ module Xcodeproj
             GroupableHelper.set_path_with_source_tree(ref, path, source_tree)
             ref.version_group_type = 'wrapper.xcdatamodel'
 
-            real_path = group.real_path.join(path) 
+            real_path = group.real_path.join(path)
             current_version_name = nil
             if real_path.exist?
               real_path.children.each do |child_path|

--- a/spec/project/object/helpers/file_references_factory_spec.rb
+++ b/spec/project/object/helpers/file_references_factory_spec.rb
@@ -170,6 +170,20 @@ module ProjectSpecs
         ref.current_version.source_tree.should == '<group>'
         @group.children.should.include(ref)
       end
+
+      it 'resolves path to models in subfolders' do
+        group_path = fixture_path('CoreData')
+        group = @group.new_group('CoreData', group_path)
+
+        path = 'VersionedModel.xcdatamodeld'
+        ref = @factory.send(:new_xcdatamodeld, group, path, :group)
+
+        ref.current_version.isa.should == 'PBXFileReference'
+        ref.current_version.path.should.include 'VersionedModel 2.xcdatamodel'
+        ref.current_version.last_known_file_type.should == 'wrapper.xcdatamodel'
+        ref.current_version.source_tree.should == '<group>'
+        group.children.should.include(ref)
+      end
     end
 
     #-------------------------------------------------------------------------#


### PR DESCRIPTION
This fixes issue #221.

The PR #291  from @adamhrz unfortunately only works when the model is one folder deep in the hierarchy. As soon as it is located on a deeper level (e.g. `Source/CoreData/Model.xcdatamodeld`), PR #291 leads to a crash.

The underlying issue was that the `path` is relative to the `group` but was handled as it would be absolute. I just joined the absolute/real path of the `group` with the `path` to create the correct `real_path`.
