### PR TITLE
Add product type constant for XPC services

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -4,17 +4,17 @@ module Xcodeproj
   module Constants
     # @return [String] The last known iOS SDK (stable).
     #
-    LAST_KNOWN_IOS_SDK = '9.3'
+    LAST_KNOWN_IOS_SDK = '10.0'
 
     # @return [String] The last known OS X SDK (stable).
     #
-    LAST_KNOWN_OSX_SDK = '10.11'
+    LAST_KNOWN_OSX_SDK = '10.12'
 
     # @return [String] The last known tvOS SDK (stable).
-    LAST_KNOWN_TVOS_SDK = '9.2'
+    LAST_KNOWN_TVOS_SDK = '10.0'
 
     # @return [String] The last known watchOS SDK (stable).
-    LAST_KNOWN_WATCHOS_SDK = '2.2'
+    LAST_KNOWN_WATCHOS_SDK = '3.0'
 
     # @return [String] The last known archive version to Xcodeproj.
     #
@@ -124,6 +124,7 @@ module Xcodeproj
       :messages_application => 'com.apple.product-type.application.messages',
       :messages_extension   => 'com.apple.product-type.app-extension.messages',
       :sticker_pack         => 'com.apple.product-type.app-extension.messages-sticker-pack',
+      :xpc_service          => 'com.apple.product-type.xpc-service',
     }.freeze
 
     # @return [Hash] The extensions or the various product UTIs.

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -26,9 +26,9 @@ module ProjectSpecs
 
       it 'uses default Release build configuration build settings for custom build configurations when adding a target' do
         @project.add_build_configuration('App Store', :release)
-        target = @project.new_target(:static_library, 'Pods', :ios, '9.0', @project.products_group)
+        target = @project.new_target(:static_library, 'Pods', :ios, '10.0', @project.products_group)
 
-        release_settings = Xcodeproj::Project::ProjectHelper.common_build_settings(:release, :ios, '9.0', :static_library)
+        release_settings = Xcodeproj::Project::ProjectHelper.common_build_settings(:release, :ios, '10.0', :static_library)
         target.build_settings('App Store').should == release_settings
       end
     end
@@ -391,7 +391,7 @@ module ProjectSpecs
         it 'adds a file reference for a system framework, in a dedicated subgroup of the Frameworks group' do
           @target.add_system_framework('QuartzCore')
           file = @project['Frameworks/iOS'].files.first
-          file.path.should == 'Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.3.sdk/System/Library/Frameworks/QuartzCore.framework'
+          file.path.should == 'Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/QuartzCore.framework'
           file.source_tree.should == 'DEVELOPER_DIR'
         end
 
@@ -406,14 +406,14 @@ module ProjectSpecs
           @target.build_configuration_list.set_setting('SDKROOT', 'iphoneos')
           @target.add_system_framework('QuartzCore')
           file = @project['Frameworks/iOS'].files.first
-          file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_IOS_SDK
+          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_IOS_SDK
         end
 
         it 'uses the last known tvOS SDK version if none is specified in the target' do
           @target.build_configuration_list.set_setting('SDKROOT', 'appletvos')
           @target.add_system_framework('TVServices')
           file = @project['Frameworks/tvOS'].files.first
-          file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_TVOS_SDK
+          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_TVOS_SDK
         end
 
         it 'uses the last known watchOS SDK version if none is specified in the target' do


### PR DESCRIPTION
XPC services might need to be added to CocoaPods's list of product types that require a host target. Otherwise, the Swift runtime is included multiple times, for example.