### PR TITLE
Fix regression resulting in projects existing product refs being altered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 
 ##### Bug Fixes
 
-* Fix regression resulting in projecs existing product ref groups being altered
+* Fix regression resulting in projects existing product ref groups being altered  
   [Rashin Arab](https://github.com/rasharab)
   [#429](https://github.com/CocoaPods/Xcodeproj/pull/429)
+
 
 ## 1.3.2 (2016-10-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Fix regression resulting in projecs existing product ref groups being altered
+  [Rashin Arab](https://github.com/rasharab)
+  [#429](https://github.com/CocoaPods/Xcodeproj/pull/429)
 
 ## 1.3.2 (2016-10-10)
 

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -216,7 +216,11 @@ module Xcodeproj
       if object_version.to_i > Constants::LAST_KNOWN_OBJECT_VERSION
         raise '[Xcodeproj] Unknown object version.'
       end
-      root_object.product_ref_group = root_object.main_group['Products'] || root_object.main_group.new_group('Products')
+
+      # Projects can have product_ref_groups that are not listed in the main_groups["Products"]
+      if root_object.product_ref_group.nil?
+        root_object.product_ref_group = root_object.main_group['Products'] || root_object.main_group.new_group('Products')
+      end
     end
 
     public

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -218,9 +218,7 @@ module Xcodeproj
       end
 
       # Projects can have product_ref_groups that are not listed in the main_groups["Products"]
-      if root_object.product_ref_group.nil?
-        root_object.product_ref_group = root_object.main_group['Products'] || root_object.main_group.new_group('Products')
-      end
+      root_object.product_ref_group ||= root_object.main_group['Products'] || root_object.main_group.new_group('Products')
     end
 
     public

--- a/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/project.pbxproj
+++ b/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/project.pbxproj
@@ -1,0 +1,4013 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 45;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		E550D6AA16371AF600A003E9 /* Aggregate */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = E550D6AB16371AF600A003E9 /* Build configuration list for PBXAggregateTarget "Aggregate" */;
+			buildPhases = (
+				E550D8F8163733DE00A003E9 /* CopyFiles */,
+				E550D8F9163733DF00A003E9 /* ShellScript */,
+			);
+			dependencies = (
+				E550D6AF16371AFC00A003E9 /* PBXTargetDependency */,
+			);
+			name = Aggregate;
+			productName = Aggregate;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		806F6FB717EFAF46001051EE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		806F6FBC17EFAF46001051EE /* iOS_staticLibrary.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 806F6FBB17EFAF46001051EE /* iOS_staticLibrary.h */; };
+		806F6FBE17EFAF46001051EE /* iOS_staticLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = 806F6FBD17EFAF46001051EE /* iOS_staticLibrary.m */; };
+		806F6FC517EFAF47001051EE /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 806F6FC417EFAF47001051EE /* XCTest.framework */; };
+		806F6FC617EFAF47001051EE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		806F6FC717EFAF47001051EE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523F616245AB20012E2BA /* UIKit.framework */; };
+		806F6FCA17EFAF47001051EE /* libiOS staticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */; };
+		806F6FD017EFAF47001051EE /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 806F6FCE17EFAF47001051EE /* InfoPlist.strings */; };
+		806F6FD217EFAF47001051EE /* iOS_staticLibraryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */; };
+		E525239116245A900012E2BA /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E525239B16245A900012E2BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E525239916245A900012E2BA /* InfoPlist.strings */; };
+		E525239D16245A900012E2BA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E525239C16245A900012E2BA /* main.m */; };
+		E52523A116245A900012E2BA /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = E525239F16245A900012E2BA /* Credits.rtf */; };
+		E52523A416245A900012E2BA /* CPDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = E52523A316245A900012E2BA /* CPDocument.m */; };
+		E52523A716245A900012E2BA /* CPDocument.xib in Resources */ = {isa = PBXBuildFile; fileRef = E52523A516245A900012E2BA /* CPDocument.xib */; };
+		E52523AA16245A910012E2BA /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = E52523A816245A910012E2BA /* MainMenu.xib */; };
+		E52523AD16245A910012E2BA /* CPDocument.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E52523AB16245A910012E2BA /* CPDocument.xcdatamodeld */; };
+		E52523B516245A910012E2BA /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523B416245A910012E2BA /* SenTestingKit.framework */; };
+		E52523B616245A910012E2BA /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E52523BE16245A910012E2BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E52523BC16245A910012E2BA /* InfoPlist.strings */; };
+		E52523C116245A910012E2BA /* Cocoa_ApplicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E52523C016245A910012E2BA /* Cocoa_ApplicationTests.m */; };
+		E52523C916245A910012E2BA /* Cocoa ApplicationImporter.mdimporter in Resources */ = {isa = PBXBuildFile; fileRef = E52523C616245A910012E2BA /* Cocoa ApplicationImporter.mdimporter */; };
+		E52523CB16245A910012E2BA /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CA16245A910012E2BA /* CoreServices.framework */; };
+		E52523CD16245A910012E2BA /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E52523CF16245A910012E2BA /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CE16245A910012E2BA /* CoreData.framework */; };
+		E52523D116245A910012E2BA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E52523D716245A910012E2BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E52523D516245A910012E2BA /* InfoPlist.strings */; };
+		E52523D916245A910012E2BA /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = E52523D816245A910012E2BA /* main.c */; };
+		E52523DB16245A910012E2BA /* GetMetadataForFile.m in Sources */ = {isa = PBXBuildFile; fileRef = E52523DA16245A910012E2BA /* GetMetadataForFile.m */; };
+		E52523DE16245A910012E2BA /* MySpotlightImporter.m in Sources */ = {isa = PBXBuildFile; fileRef = E52523DD16245A910012E2BA /* MySpotlightImporter.m */; };
+		E52523F716245AB20012E2BA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523F616245AB20012E2BA /* UIKit.framework */; };
+		E52523F816245AB20012E2BA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E52523FA16245AB20012E2BA /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523F916245AB20012E2BA /* CoreGraphics.framework */; };
+		E52523FB16245AB20012E2BA /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CE16245A910012E2BA /* CoreData.framework */; };
+		E525240116245AB20012E2BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E52523FF16245AB20012E2BA /* InfoPlist.strings */; };
+		E525240316245AB20012E2BA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E525240216245AB20012E2BA /* main.m */; };
+		E525240716245AB20012E2BA /* CPAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E525240616245AB20012E2BA /* CPAppDelegate.m */; };
+		E525240916245AB20012E2BA /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = E525240816245AB20012E2BA /* Default.png */; };
+		E525240B16245AB20012E2BA /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E525240A16245AB20012E2BA /* Default@2x.png */; };
+		E525240D16245AB20012E2BA /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = E525240C16245AB20012E2BA /* Default-568h@2x.png */; };
+		E525241016245AB20012E2BA /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E525240E16245AB20012E2BA /* MainStoryboard.storyboard */; };
+		E525241316245AB20012E2BA /* iOS_application.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E525241116245AB20012E2BA /* iOS_application.xcdatamodeld */; };
+		E525241616245AB20012E2BA /* CPMasterViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E525241516245AB20012E2BA /* CPMasterViewController.m */; };
+		E525241916245AB20012E2BA /* CPDetailViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E525241816245AB20012E2BA /* CPDetailViewController.m */; };
+		E525242016245AB20012E2BA /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523B416245A910012E2BA /* SenTestingKit.framework */; };
+		E525242116245AB20012E2BA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523F616245AB20012E2BA /* UIKit.framework */; };
+		E525242216245AB20012E2BA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E525242316245AB20012E2BA /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CE16245A910012E2BA /* CoreData.framework */; };
+		E525242B16245AB20012E2BA /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E525242916245AB20012E2BA /* InfoPlist.strings */; };
+		E525242E16245AB20012E2BA /* iOS_applicationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E525242D16245AB20012E2BA /* iOS_applicationTests.m */; };
+		E525243C16245AE10012E2BA /* Linked Folder in Resources */ = {isa = PBXBuildFile; fileRef = E525243B16245AE10012E2BA /* Linked Folder */; };
+		E550D6BA16371B1A00A003E9 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523B416245A910012E2BA /* SenTestingKit.framework */; };
+		E550D6BB16371B1A00A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D6D716371B3300A003E9 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E550D70416371B4400A003E9 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D70316371B4400A003E9 /* ApplicationServices.framework */; };
+		E550D70516371B4400A003E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E550D70716371B4400A003E9 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D70616371B4400A003E9 /* QuartzCore.framework */; };
+		E550D70816371B4400A003E9 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E550D73D16371B5A00A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D73F16371B5A00A003E9 /* PreferencePanes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D73E16371B5A00A003E9 /* PreferencePanes.framework */; };
+		E550D74116371B5A00A003E9 /* MacRuby.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D74016371B5A00A003E9 /* MacRuby.framework */; };
+		E550D75F16371B6300A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D76016371B6300A003E9 /* PreferencePanes.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D73E16371B5A00A003E9 /* PreferencePanes.framework */; };
+		E550D77B16371B6A00A003E9 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D77A16371B6A00A003E9 /* QuickLook.framework */; };
+		E550D77C16371B6A00A003E9 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D70316371B4400A003E9 /* ApplicationServices.framework */; };
+		E550D77D16371B6A00A003E9 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CA16245A910012E2BA /* CoreServices.framework */; };
+		E550D77E16371B6A00A003E9 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E550D79616371B7100A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D79816371B7100A003E9 /* ScreenSaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D79716371B7100A003E9 /* ScreenSaver.framework */; };
+		E550D7AB16371B7A00A003E9 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CA16245A910012E2BA /* CoreServices.framework */; };
+		E550D7AC16371B7A00A003E9 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E550D7AD16371B7A00A003E9 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CE16245A910012E2BA /* CoreData.framework */; };
+		E550D7AE16371B7A00A003E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E550D7C816371B9000A003E9 /* Automator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D7C716371B9000A003E9 /* Automator.framework */; };
+		E550D7C916371B9000A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D7E016371B9800A003E9 /* AddressBook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D7DF16371B9800A003E9 /* AddressBook.framework */; };
+		E550D7E116371B9800A003E9 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E550D7F316371BA500A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D7F516371BA500A003E9 /* InstallerPlugins.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D7F416371BA500A003E9 /* InstallerPlugins.framework */; };
+		E550D81116371BAF00A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D81316371BAF00A003E9 /* Quartz.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D81216371BAF00A003E9 /* Quartz.framework */; };
+		E550D82916371BC400A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D83C16371BCA00A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D84B16371BD000A003E9 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E550D85B16371BD600A003E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E550D88716371C0600A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D88916371C0600A003E9 /* AppleScriptObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D88816371C0600A003E9 /* AppleScriptObjC.framework */; };
+		E550D8A716371C0F00A003E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E550D8B816371C1700A003E9 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E525239016245A900012E2BA /* Cocoa.framework */; };
+		E550D8B916371C1700A003E9 /* MacRuby.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E550D74016371B5A00A003E9 /* MacRuby.framework */; };
+		E550D8DB16371C1800A003E9 /* MacRubyApplicationImporter.mdimporter in Resources */ = {isa = PBXBuildFile; fileRef = E550D8D816371C1800A003E9 /* MacRubyApplicationImporter.mdimporter */; };
+		E550D8DC16371C1800A003E9 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CA16245A910012E2BA /* CoreServices.framework */; };
+		E550D8DD16371C1800A003E9 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CC16245A910012E2BA /* CoreFoundation.framework */; };
+		E550D8DE16371C1800A003E9 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523CE16245A910012E2BA /* CoreData.framework */; };
+		E550D8DF16371C1800A003E9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E52523D016245A910012E2BA /* Foundation.framework */; };
+		E5D46499163577B5006A4730 /* Relative_to_group in Resources */ = {isa = PBXBuildFile; fileRef = E5D46498163577B5006A4730 /* Relative_to_group */; };
+		E5D4649B163577D2006A4730 /* Absolute_path in Resources */ = {isa = PBXBuildFile; fileRef = E5D4649A163577D2006A4730 /* Absolute_path */; };
+		E5D4649D163577E7006A4730 /* Relative_to_project in Resources */ = {isa = PBXBuildFile; fileRef = E5D4649C163577E7006A4730 /* Relative_to_project */; };
+		E5D4649F163577FB006A4730 /* Relative_to_developer_direcotry in Resources */ = {isa = PBXBuildFile; fileRef = E5D4649E163577FB006A4730 /* Relative_to_developer_direcotry */; };
+		E5D464A116357816006A4730 /* Relative_to_build_products in Resources */ = {isa = PBXBuildFile; fileRef = E5D464A016357816006A4730 /* Relative_to_build_products */; };
+		E5D464A316357833006A4730 /* Relative_to_SDK in Resources */ = {isa = PBXBuildFile; fileRef = E5D464A216357833006A4730 /* Relative_to_SDK */; };
+		E5D464A616357841006A4730 /* Localized in Resources */ = {isa = PBXBuildFile; fileRef = E5D464A816357841006A4730 /* Localized */; };
+		E5D464AA16357867006A4730 /* Text_settings in Resources */ = {isa = PBXBuildFile; fileRef = E5D464A916357867006A4730 /* Text_settings */; };
+		E5D464AD163578AC006A4730 /* Tools_version.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E5D464AB163578AC006A4730 /* Tools_version.xcdatamodeld */; };
+		E5D464B0163578C7006A4730 /* Deployment_target.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E5D464AE163578C7006A4730 /* Deployment_target.xcdatamodeld */; };
+		E5D464B416357954006A4730 /* Version_identifier.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = E5D464B216357954006A4730 /* Version_identifier.xcdatamodeld */; };
+		E5FBB2D116357C16009E96B0 /* sample.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = E5FBB2D016357C16009E96B0 /* sample.xcconfig */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXBuildRule section */
+		E525244116245B280012E2BA /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			fileType = pattern.proxy;
+			isEditable = 1;
+			outputFiles = (
+			);
+		};
+		E552E0F716263967003ED1FE /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = com.apple.compilers.proxy.script;
+			filePatterns = "*.css";
+			fileType = pattern.proxy;
+			isEditable = 1;
+			outputFiles = (
+				"${INPUT_FILE_BASE}.css.c",
+			);
+			script = "test
+";
+		};
+		E552E0F916263968003ED1FE /* PBXBuildRule */ = {
+			isa = PBXBuildRule;
+			compilerSpec = "com.apple.build-tasks.copy-strings-file";
+			fileType = wrapper.xcclassmodel;
+			isEditable = 1;
+			outputFiles = (
+			);
+		};
+/* End PBXBuildRule section */
+
+/* Begin PBXContainerItemProxy section */
+		5138059B16499F4C001D82AD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = E5FBB2E41635ED34009E96B0;
+			remoteInfo = ReferencedProject;
+		};
+		806F6FC817EFAF47001051EE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 806F6FB517EFAF46001051EE;
+			remoteInfo = "iOS staticLibrary";
+		};
+		806F6FDB17EFB0E7001051EE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E52523F316245AB20012E2BA;
+			remoteInfo = "iOS application";
+		};
+		E52523B716245A910012E2BA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E525238B16245A900012E2BA;
+			remoteInfo = "Cocoa Application";
+		};
+		E52523C716245A910012E2BA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E52523C516245A910012E2BA;
+			remoteInfo = "Cocoa ApplicationImporter";
+		};
+		E525242416245AB20012E2BA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E52523F316245AB20012E2BA;
+			remoteInfo = "iOS application";
+		};
+		E550D6AE16371AFC00A003E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E52523B216245A910012E2BA;
+			remoteInfo = "Cocoa ApplicationTests";
+		};
+		E550D8BB16371C1700A003E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E550D8B516371C1700A003E9;
+			remoteInfo = MacRubyApplication;
+		};
+		E550D8D916371C1800A003E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E525238316245A900012E2BA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E550D8D716371C1800A003E9;
+			remoteInfo = MacRubyApplicationImporter;
+		};
+		E5FBB34B1635ED36009E96B0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E5FBB2E51635ED34009E96B0;
+			remoteInfo = ReferencedProject;
+		};
+		E5FBB34D1635ED36009E96B0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E5FBB30C1635ED35009E96B0;
+			remoteInfo = ReferencedProjectTests;
+		};
+		E5FBB34F1635ED36009E96B0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = E5FBB31F1635ED35009E96B0;
+			remoteInfo = ReferencedProjectImporter;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		806F6FB417EFAF46001051EE /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				806F6FBC17EFAF46001051EE /* iOS_staticLibrary.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E525243E16245B1A0012E2BA /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8A316371C0F00A003E9 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
+		E550D8F8163733DE00A003E9 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5DCFBDB16285429002C6803 /* Custom name copy */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+			);
+			name = "Custom name copy";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libiOS staticLibrary.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		806F6FBA17EFAF46001051EE /* iOS staticLibrary-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOS staticLibrary-Prefix.pch"; sourceTree = "<group>"; };
+		806F6FBB17EFAF46001051EE /* iOS_staticLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOS_staticLibrary.h; sourceTree = "<group>"; };
+		806F6FBD17EFAF46001051EE /* iOS_staticLibrary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOS_staticLibrary.m; sourceTree = "<group>"; };
+		806F6FC317EFAF47001051EE /* iOS staticLibraryTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS staticLibraryTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		806F6FC417EFAF47001051EE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		806F6FCD17EFAF47001051EE /* iOS staticLibraryTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "iOS staticLibraryTests-Info.plist"; sourceTree = "<group>"; };
+		806F6FCF17EFAF47001051EE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOS_staticLibraryTests.m; sourceTree = "<group>"; };
+		E525238C16245A900012E2BA /* Cocoa Application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Cocoa Application.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E525239016245A900012E2BA /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
+		E525239316245A900012E2BA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
+		E525239416245A900012E2BA /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		E525239516245A900012E2BA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		E525239816245A900012E2BA /* Cocoa Application-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Cocoa Application-Info.plist"; sourceTree = "<group>"; };
+		E525239A16245A900012E2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E525239C16245A900012E2BA /* main.m */ = {isa = PBXFileReference; comments = "I must comment a lot!"; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		E525239E16245A900012E2BA /* Cocoa Application-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Cocoa Application-Prefix.pch"; sourceTree = "<group>"; };
+		E52523A016245A900012E2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = en; path = en.lproj/Credits.rtf; sourceTree = "<group>"; };
+		E52523A216245A900012E2BA /* CPDocument.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPDocument.h; sourceTree = "<group>"; };
+		E52523A316245A900012E2BA /* CPDocument.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPDocument.m; sourceTree = "<group>"; };
+		E52523AC16245A910012E2BA /* CPDocument.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = CPDocument.xcdatamodel; sourceTree = "<group>"; };
+		E52523B316245A910012E2BA /* Cocoa ApplicationTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cocoa ApplicationTests.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E52523B416245A910012E2BA /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		E52523BB16245A910012E2BA /* Cocoa ApplicationTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Cocoa ApplicationTests-Info.plist"; sourceTree = "<group>"; };
+		E52523BD16245A910012E2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E52523BF16245A910012E2BA /* Cocoa_ApplicationTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Cocoa_ApplicationTests.h; sourceTree = "<group>"; };
+		E52523C016245A910012E2BA /* Cocoa_ApplicationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Cocoa_ApplicationTests.m; sourceTree = "<group>"; };
+		E52523C616245A910012E2BA /* Cocoa ApplicationImporter.mdimporter */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cocoa ApplicationImporter.mdimporter"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E52523CA16245A910012E2BA /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
+		E52523CC16245A910012E2BA /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		E52523CE16245A910012E2BA /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
+		E52523D016245A910012E2BA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		E52523D416245A910012E2BA /* Cocoa ApplicationImporter-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Cocoa ApplicationImporter-Info.plist"; sourceTree = "<group>"; };
+		E52523D616245A910012E2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E52523D816245A910012E2BA /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		E52523DA16245A910012E2BA /* GetMetadataForFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GetMetadataForFile.m; sourceTree = "<group>"; };
+		E52523DC16245A910012E2BA /* MySpotlightImporter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MySpotlightImporter.h; sourceTree = "<group>"; };
+		E52523DD16245A910012E2BA /* MySpotlightImporter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MySpotlightImporter.m; sourceTree = "<group>"; };
+		E52523DF16245A910012E2BA /* Importer Read Me.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Importer Read Me.txt"; sourceTree = "<group>"; };
+		E52523E016245A910012E2BA /* Cocoa ApplicationImporter-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Cocoa ApplicationImporter-Prefix.pch"; sourceTree = "<group>"; };
+		E52523F416245AB20012E2BA /* iOS application.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS application.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E52523F616245AB20012E2BA /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		E52523F916245AB20012E2BA /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		E52523FE16245AB20012E2BA /* iOS application-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "iOS application-Info.plist"; sourceTree = "<group>"; };
+		E525240016245AB20012E2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E525240216245AB20012E2BA /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		E525240416245AB20012E2BA /* iOS application-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOS application-Prefix.pch"; sourceTree = "<group>"; };
+		E525240516245AB20012E2BA /* CPAppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPAppDelegate.h; sourceTree = "<group>"; };
+		E525240616245AB20012E2BA /* CPAppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPAppDelegate.m; sourceTree = "<group>"; };
+		E525240816245AB20012E2BA /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
+		E525240A16245AB20012E2BA /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
+		E525240C16245AB20012E2BA /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		E525240F16245AB20012E2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/MainStoryboard.storyboard; sourceTree = "<group>"; };
+		E525241216245AB20012E2BA /* iOS_application.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = iOS_application.xcdatamodel; sourceTree = "<group>"; };
+		E525241416245AB20012E2BA /* CPMasterViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPMasterViewController.h; sourceTree = "<group>"; };
+		E525241516245AB20012E2BA /* CPMasterViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPMasterViewController.m; sourceTree = "<group>"; };
+		E525241716245AB20012E2BA /* CPDetailViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CPDetailViewController.h; sourceTree = "<group>"; };
+		E525241816245AB20012E2BA /* CPDetailViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CPDetailViewController.m; sourceTree = "<group>"; };
+		E525241F16245AB20012E2BA /* iOS applicationTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS applicationTests.octest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E525242816245AB20012E2BA /* iOS applicationTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "iOS applicationTests-Info.plist"; sourceTree = "<group>"; };
+		E525242A16245AB20012E2BA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		E525242C16245AB20012E2BA /* iOS_applicationTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = iOS_applicationTests.h; sourceTree = "<group>"; };
+		E525242D16245AB20012E2BA /* iOS_applicationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iOS_applicationTests.m; sourceTree = "<group>"; };
+		E525243B16245AE10012E2BA /* Linked Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "Linked Folder"; sourceTree = "<group>"; };
+		E550D6B916371B1A00A003E9 /* UnitTestingBundle.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTestingBundle.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D6CB16371B2800A003E9 /* InAppPurchaseContent */ = {isa = PBXFileReference; explicitFileType = folder; includeInIndex = 0; path = InAppPurchaseContent; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D6D616371B3300A003E9 /* PlugIn.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PlugIn.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D6EE16371B3B00A003E9 /* KernelExtension.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KernelExtension.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D6EF16371B3B00A003E9 /* Kernel.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Kernel.framework; path = System/Library/Frameworks/Kernel.framework; sourceTree = SDKROOT; };
+		E550D70216371B4400A003E9 /* ImageUnitPlugIn.plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ImageUnitPlugIn.plugin; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D70316371B4400A003E9 /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
+		E550D70616371B4400A003E9 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		E550D72816371B4E00A003E9 /* IOKitDriver.kext */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IOKitDriver.kext; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D73C16371B5A00A003E9 /* MacRubyPrefPanel.prefPane */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacRubyPrefPanel.prefPane; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D73E16371B5A00A003E9 /* PreferencePanes.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PreferencePanes.framework; path = System/Library/Frameworks/PreferencePanes.framework; sourceTree = SDKROOT; };
+		E550D74016371B5A00A003E9 /* MacRuby.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MacRuby.framework; path = Library/Frameworks/MacRuby.framework; sourceTree = DEVELOPER_DIR; };
+		E550D75E16371B6300A003E9 /* PreferencePanel.prefPane */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PreferencePanel.prefPane; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D77916371B6A00A003E9 /* QuickLook.qlgenerator */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QuickLook.qlgenerator; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D77A16371B6A00A003E9 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = System/Library/Frameworks/QuickLook.framework; sourceTree = SDKROOT; };
+		E550D79516371B7100A003E9 /* ScreenSaver.saver */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScreenSaver.saver; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D79716371B7100A003E9 /* ScreenSaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScreenSaver.framework; path = System/Library/Frameworks/ScreenSaver.framework; sourceTree = SDKROOT; };
+		E550D7AA16371B7A00A003E9 /* SpotLightImporter.mdimporter */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpotLightImporter.mdimporter; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D7C616371B8F00A003E9 /* AutomatorAction.action */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AutomatorAction.action; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D7C716371B9000A003E9 /* Automator.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Automator.framework; path = System/Library/Frameworks/Automator.framework; sourceTree = SDKROOT; };
+		E550D7DE16371B9800A003E9 /* AddressBookPlugIn.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AddressBookPlugIn.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D7DF16371B9800A003E9 /* AddressBook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AddressBook.framework; path = System/Library/Frameworks/AddressBook.framework; sourceTree = SDKROOT; };
+		E550D7F216371BA500A003E9 /* InstallerPlugIn.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = InstallerPlugIn.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D7F416371BA500A003E9 /* InstallerPlugins.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = InstallerPlugins.framework; path = System/Library/Frameworks/InstallerPlugins.framework; sourceTree = SDKROOT; };
+		E550D81016371BAF00A003E9 /* QuartzComposerPlugIn.plugin */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = QuartzComposerPlugIn.plugin; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D81216371BAF00A003E9 /* Quartz.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quartz.framework; path = System/Library/Frameworks/Quartz.framework; sourceTree = SDKROOT; };
+		E550D82816371BC400A003E9 /* CocoaFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D83B16371BCA00A003E9 /* Library.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = Library.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D84A16371BD000A003E9 /* Bundle.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Bundle.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D85A16371BD600A003E9 /* org.cocoapods.XPCServic.xpc */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = org.cocoapods.XPCServic.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D86C16371BE100A003E9 /* libC/C++ Library.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "libC/C++ Library.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D87416371BEE00A003E9 /* STL C++ Library.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "STL C++ Library.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D88516371C0600A003E9 /* CocoaAppleScriptApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CocoaAppleScriptApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D88816371C0600A003E9 /* AppleScriptObjC.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppleScriptObjC.framework; path = System/Library/Frameworks/AppleScriptObjC.framework; sourceTree = SDKROOT; };
+		E550D8A516371C0F00A003E9 /* CommandLineTool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = CommandLineTool; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D8B616371C1700A003E9 /* MacRubyApplication.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MacRubyApplication.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E550D8D816371C1800A003E9 /* MacRubyApplicationImporter.mdimporter */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MacRubyApplicationImporter.mdimporter; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5D46498163577B5006A4730 /* Relative_to_group */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Relative_to_group; path = "Cocoa Application/Relative_to_group"; sourceTree = "<group>"; };
+		E5D4649A163577D2006A4730 /* Absolute_path */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Absolute_path; path = "/Users/fabio/Documents/GitHub/CP/Xcodeproj/spec/fixtures/Sample Project/Cocoa Application/Absolute_path"; sourceTree = "<absolute>"; };
+		E5D4649C163577E7006A4730 /* Relative_to_project */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Relative_to_project; path = "Cocoa Application/Relative_to_project"; sourceTree = SOURCE_ROOT; };
+		E5D4649E163577FB006A4730 /* Relative_to_developer_direcotry */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Relative_to_developer_direcotry; path = "../../../../Users/fabio/Documents/GitHub/CP/Xcodeproj/spec/fixtures/Sample Project/Cocoa Application/Relative_to_developer_direcotry"; sourceTree = DEVELOPER_DIR; };
+		E5D464A016357816006A4730 /* Relative_to_build_products */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Relative_to_build_products; path = "../../../../../../../../Documents/GitHub/CP/Xcodeproj/spec/fixtures/Sample Project/Cocoa Application/Relative_to_build_products"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E5D464A216357833006A4730 /* Relative_to_SDK */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Relative_to_SDK; path = "Cocoa Application/Relative_to_SDK"; sourceTree = "<group>"; };
+		E5D464A716357841006A4730 /* en */ = {isa = PBXFileReference; lastKnownFileType = text; name = en; path = en.lproj/Localized; sourceTree = "<group>"; };
+		E5D464A916357867006A4730 /* Text_settings */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = text; name = Text_settings; path = "Cocoa Application/Text_settings"; sourceTree = "<group>"; tabWidth = 4; usesTabs = 1; wrapsLines = 1; };
+		E5D464AC163578AC006A4730 /* Tools_version.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Tools_version.xcdatamodel; sourceTree = "<group>"; };
+		E5D464AF163578C7006A4730 /* Deployment_target.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Deployment_target.xcdatamodel; sourceTree = "<group>"; };
+		E5D464B316357954006A4730 /* Version_identifier.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Version_identifier.xcdatamodel; sourceTree = "<group>"; };
+		E5FBB2D016357C16009E96B0 /* sample.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = sample.xcconfig; path = ../sample.xcconfig; sourceTree = "<group>"; };
+		E5FBB2D216357C70009E96B0 /* Cocoa Application.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = "Cocoa Application.entitlements"; sourceTree = "<group>"; };
+		E5FBB2D316357C93009E96B0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/CPDocument.xib; sourceTree = "<group>"; };
+		E5FBB2D416357C93009E96B0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ReferencedProject.xcodeproj; path = ReferencedProject/ReferencedProject.xcodeproj; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		806F6FB317EFAF46001051EE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FB717EFAF46001051EE /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		806F6FC017EFAF47001051EE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FCA17EFAF47001051EE /* libiOS staticLibrary.a in Frameworks */,
+				806F6FC517EFAF47001051EE /* XCTest.framework in Frameworks */,
+				806F6FC717EFAF47001051EE /* UIKit.framework in Frameworks */,
+				806F6FC617EFAF47001051EE /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E525238916245A900012E2BA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525239116245A900012E2BA /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523AF16245A910012E2BA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E52523B516245A910012E2BA /* SenTestingKit.framework in Frameworks */,
+				E52523B616245A910012E2BA /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523C316245A910012E2BA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E52523CB16245A910012E2BA /* CoreServices.framework in Frameworks */,
+				E52523CD16245A910012E2BA /* CoreFoundation.framework in Frameworks */,
+				E52523CF16245A910012E2BA /* CoreData.framework in Frameworks */,
+				E52523D116245A910012E2BA /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523F116245AB20012E2BA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E52523F716245AB20012E2BA /* UIKit.framework in Frameworks */,
+				E52523F816245AB20012E2BA /* Foundation.framework in Frameworks */,
+				E52523FA16245AB20012E2BA /* CoreGraphics.framework in Frameworks */,
+				E52523FB16245AB20012E2BA /* CoreData.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E525241B16245AB20012E2BA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525242016245AB20012E2BA /* SenTestingKit.framework in Frameworks */,
+				E525242116245AB20012E2BA /* UIKit.framework in Frameworks */,
+				E525242216245AB20012E2BA /* Foundation.framework in Frameworks */,
+				E525242316245AB20012E2BA /* CoreData.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6B516371B1A00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D6BA16371B1A00A003E9 /* SenTestingKit.framework in Frameworks */,
+				E550D6BB16371B1A00A003E9 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6D316371B3300A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D6D716371B3300A003E9 /* CoreFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6E916371B3B00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6FD16371B4400A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D70416371B4400A003E9 /* ApplicationServices.framework in Frameworks */,
+				E550D70516371B4400A003E9 /* Foundation.framework in Frameworks */,
+				E550D70716371B4400A003E9 /* QuartzCore.framework in Frameworks */,
+				E550D70816371B4400A003E9 /* CoreFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D72316371B4E00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D73716371B5A00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D73D16371B5A00A003E9 /* Cocoa.framework in Frameworks */,
+				E550D73F16371B5A00A003E9 /* PreferencePanes.framework in Frameworks */,
+				E550D74116371B5A00A003E9 /* MacRuby.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D75916371B6300A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D75F16371B6300A003E9 /* Cocoa.framework in Frameworks */,
+				E550D76016371B6300A003E9 /* PreferencePanes.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D77416371B6A00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D77B16371B6A00A003E9 /* QuickLook.framework in Frameworks */,
+				E550D77C16371B6A00A003E9 /* ApplicationServices.framework in Frameworks */,
+				E550D77D16371B6A00A003E9 /* CoreServices.framework in Frameworks */,
+				E550D77E16371B6A00A003E9 /* CoreFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D79016371B7100A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D79616371B7100A003E9 /* Cocoa.framework in Frameworks */,
+				E550D79816371B7100A003E9 /* ScreenSaver.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7A716371B7A00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D7AB16371B7A00A003E9 /* CoreServices.framework in Frameworks */,
+				E550D7AC16371B7A00A003E9 /* CoreFoundation.framework in Frameworks */,
+				E550D7AD16371B7A00A003E9 /* CoreData.framework in Frameworks */,
+				E550D7AE16371B7A00A003E9 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7C216371B8F00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D7C816371B9000A003E9 /* Automator.framework in Frameworks */,
+				E550D7C916371B9000A003E9 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7DB16371B9800A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D7E016371B9800A003E9 /* AddressBook.framework in Frameworks */,
+				E550D7E116371B9800A003E9 /* CoreFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7EF16371BA500A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D7F316371BA500A003E9 /* Cocoa.framework in Frameworks */,
+				E550D7F516371BA500A003E9 /* InstallerPlugins.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D80C16371BAF00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D81116371BAF00A003E9 /* Cocoa.framework in Frameworks */,
+				E550D81316371BAF00A003E9 /* Quartz.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D82416371BC400A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D82916371BC400A003E9 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D83816371BCA00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D83C16371BCA00A003E9 /* Cocoa.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D84716371BD000A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D84B16371BD000A003E9 /* CoreFoundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D85716371BD600A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D85B16371BD600A003E9 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D86916371BE100A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D87116371BEE00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D88216371C0600A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D88716371C0600A003E9 /* Cocoa.framework in Frameworks */,
+				E550D88916371C0600A003E9 /* AppleScriptObjC.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8A216371C0F00A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D8A716371C0F00A003E9 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8B316371C1700A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D8B816371C1700A003E9 /* Cocoa.framework in Frameworks */,
+				E550D8B916371C1700A003E9 /* MacRuby.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8D516371C1800A003E9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D8DC16371C1800A003E9 /* CoreServices.framework in Frameworks */,
+				E550D8DD16371C1800A003E9 /* CoreFoundation.framework in Frameworks */,
+				E550D8DE16371C1800A003E9 /* CoreData.framework in Frameworks */,
+				E550D8DF16371C1800A003E9 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		806F6FB817EFAF46001051EE /* iOS staticLibrary */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FBB17EFAF46001051EE /* iOS_staticLibrary.h */,
+				806F6FBD17EFAF46001051EE /* iOS_staticLibrary.m */,
+				806F6FB917EFAF46001051EE /* Supporting Files */,
+			);
+			path = "iOS staticLibrary";
+			sourceTree = "<group>";
+		};
+		806F6FB917EFAF46001051EE /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FBA17EFAF46001051EE /* iOS staticLibrary-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		806F6FCB17EFAF47001051EE /* iOS staticLibraryTests */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FD117EFAF47001051EE /* iOS_staticLibraryTests.m */,
+				806F6FCC17EFAF47001051EE /* Supporting Files */,
+			);
+			path = "iOS staticLibraryTests";
+			sourceTree = "<group>";
+		};
+		806F6FCC17EFAF47001051EE /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				806F6FCD17EFAF47001051EE /* iOS staticLibraryTests-Info.plist */,
+				806F6FCE17EFAF47001051EE /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E525238116245A900012E2BA = {
+			isa = PBXGroup;
+			children = (
+				E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */,
+				E5FBB2D016357C16009E96B0 /* sample.xcconfig */,
+				E52523AB16245A910012E2BA /* CPDocument.xcdatamodeld */,
+				E5D464AB163578AC006A4730 /* Tools_version.xcdatamodeld */,
+				E5D464AE163578C7006A4730 /* Deployment_target.xcdatamodeld */,
+				E5D464B216357954006A4730 /* Version_identifier.xcdatamodeld */,
+				E5D46498163577B5006A4730 /* Relative_to_group */,
+				E5D4649A163577D2006A4730 /* Absolute_path */,
+				E5D4649C163577E7006A4730 /* Relative_to_project */,
+				E5D4649E163577FB006A4730 /* Relative_to_developer_direcotry */,
+				E5D464A016357816006A4730 /* Relative_to_build_products */,
+				E5D464A216357833006A4730 /* Relative_to_SDK */,
+				E5D464A816357841006A4730 /* Localized */,
+				E5D464A916357867006A4730 /* Text_settings */,
+				E5D464B516357987006A4730 /* Absolute_path */,
+				E5D464B1163578DB006A4730 /* Text_settings */,
+				E525239616245A900012E2BA /* Cocoa Application */,
+				E52523B916245A910012E2BA /* Cocoa ApplicationTests */,
+				E52523D216245A910012E2BA /* Cocoa ApplicationImporter */,
+				E52523FC16245AB20012E2BA /* iOS application */,
+				E525242616245AB20012E2BA /* iOS applicationTests */,
+				806F6FB817EFAF46001051EE /* iOS staticLibrary */,
+				806F6FCB17EFAF47001051EE /* iOS staticLibraryTests */,
+				E525238F16245A900012E2BA /* Frameworks */,
+				E525238D16245A900012E2BA /* Products */,
+				E525243B16245AE10012E2BA /* Linked Folder */,
+			);
+			sourceTree = "<group>";
+			usesTabs = 0;
+		};
+		E525238D16245A900012E2BA /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E525238C16245A900012E2BA /* Cocoa Application.app */,
+				E52523B316245A910012E2BA /* Cocoa ApplicationTests.octest */,
+				E52523C616245A910012E2BA /* Cocoa ApplicationImporter.mdimporter */,
+				E52523F416245AB20012E2BA /* iOS application.app */,
+				E525241F16245AB20012E2BA /* iOS applicationTests.octest */,
+				E550D6B916371B1A00A003E9 /* UnitTestingBundle.octest */,
+				E550D6CB16371B2800A003E9 /* InAppPurchaseContent */,
+				E550D6D616371B3300A003E9 /* PlugIn.bundle */,
+				E550D6EE16371B3B00A003E9 /* KernelExtension.kext */,
+				E550D70216371B4400A003E9 /* ImageUnitPlugIn.plugin */,
+				E550D72816371B4E00A003E9 /* IOKitDriver.kext */,
+				E550D73C16371B5A00A003E9 /* MacRubyPrefPanel.prefPane */,
+				E550D75E16371B6300A003E9 /* PreferencePanel.prefPane */,
+				E550D77916371B6A00A003E9 /* QuickLook.qlgenerator */,
+				E550D79516371B7100A003E9 /* ScreenSaver.saver */,
+				E550D7AA16371B7A00A003E9 /* SpotLightImporter.mdimporter */,
+				E550D7C616371B8F00A003E9 /* AutomatorAction.action */,
+				E550D7DE16371B9800A003E9 /* AddressBookPlugIn.bundle */,
+				E550D7F216371BA500A003E9 /* InstallerPlugIn.bundle */,
+				E550D81016371BAF00A003E9 /* QuartzComposerPlugIn.plugin */,
+				E550D82816371BC400A003E9 /* CocoaFramework.framework */,
+				E550D83B16371BCA00A003E9 /* Library.dylib */,
+				E550D84A16371BD000A003E9 /* Bundle.bundle */,
+				E550D85A16371BD600A003E9 /* org.cocoapods.XPCServic.xpc */,
+				E550D86C16371BE100A003E9 /* libC/C++ Library.dylib */,
+				E550D87416371BEE00A003E9 /* STL C++ Library.dylib */,
+				E550D88516371C0600A003E9 /* CocoaAppleScriptApp.app */,
+				E550D8A516371C0F00A003E9 /* CommandLineTool */,
+				E550D8B616371C1700A003E9 /* MacRubyApplication.app */,
+				E550D8D816371C1800A003E9 /* MacRubyApplicationImporter.mdimporter */,
+				806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */,
+				806F6FC317EFAF47001051EE /* iOS staticLibraryTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E525238F16245A900012E2BA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E525239016245A900012E2BA /* Cocoa.framework */,
+				E52523B416245A910012E2BA /* SenTestingKit.framework */,
+				E52523CA16245A910012E2BA /* CoreServices.framework */,
+				E52523CC16245A910012E2BA /* CoreFoundation.framework */,
+				E52523CE16245A910012E2BA /* CoreData.framework */,
+				E52523D016245A910012E2BA /* Foundation.framework */,
+				E52523F616245AB20012E2BA /* UIKit.framework */,
+				E52523F916245AB20012E2BA /* CoreGraphics.framework */,
+				E550D70316371B4400A003E9 /* ApplicationServices.framework */,
+				E550D70616371B4400A003E9 /* QuartzCore.framework */,
+				E550D73E16371B5A00A003E9 /* PreferencePanes.framework */,
+				E550D74016371B5A00A003E9 /* MacRuby.framework */,
+				E550D77A16371B6A00A003E9 /* QuickLook.framework */,
+				E550D79716371B7100A003E9 /* ScreenSaver.framework */,
+				E550D7C716371B9000A003E9 /* Automator.framework */,
+				E550D7DF16371B9800A003E9 /* AddressBook.framework */,
+				E550D7F416371BA500A003E9 /* InstallerPlugins.framework */,
+				E550D81216371BAF00A003E9 /* Quartz.framework */,
+				E550D88816371C0600A003E9 /* AppleScriptObjC.framework */,
+				806F6FC417EFAF47001051EE /* XCTest.framework */,
+				E525239216245A900012E2BA /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E525239216245A900012E2BA /* Other Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E525239316245A900012E2BA /* AppKit.framework */,
+				E525239416245A900012E2BA /* CoreData.framework */,
+				E525239516245A900012E2BA /* Foundation.framework */,
+				E550D6EF16371B3B00A003E9 /* Kernel.framework */,
+			);
+			name = "Other Frameworks";
+			sourceTree = "<group>";
+		};
+		E525239616245A900012E2BA /* Cocoa Application */ = {
+			isa = PBXGroup;
+			children = (
+				E5FBB2D216357C70009E96B0 /* Cocoa Application.entitlements */,
+				E525239716245A900012E2BA /* Supporting Files */,
+				E52523A216245A900012E2BA /* CPDocument.h */,
+				E52523A316245A900012E2BA /* CPDocument.m */,
+				E52523A516245A900012E2BA /* CPDocument.xib */,
+				E52523A816245A910012E2BA /* MainMenu.xib */,
+			);
+			path = "Cocoa Application";
+			sourceTree = "<group>";
+		};
+		E525239716245A900012E2BA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E525239816245A900012E2BA /* Cocoa Application-Info.plist */,
+				E525239916245A900012E2BA /* InfoPlist.strings */,
+				E525239C16245A900012E2BA /* main.m */,
+				E525239E16245A900012E2BA /* Cocoa Application-Prefix.pch */,
+				E525239F16245A900012E2BA /* Credits.rtf */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E52523B916245A910012E2BA /* Cocoa ApplicationTests */ = {
+			isa = PBXGroup;
+			children = (
+				E52523BF16245A910012E2BA /* Cocoa_ApplicationTests.h */,
+				E52523C016245A910012E2BA /* Cocoa_ApplicationTests.m */,
+				E52523BA16245A910012E2BA /* Supporting Files */,
+			);
+			path = "Cocoa ApplicationTests";
+			sourceTree = "<group>";
+		};
+		E52523BA16245A910012E2BA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E52523BB16245A910012E2BA /* Cocoa ApplicationTests-Info.plist */,
+				E52523BC16245A910012E2BA /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E52523D216245A910012E2BA /* Cocoa ApplicationImporter */ = {
+			isa = PBXGroup;
+			children = (
+				E52523DA16245A910012E2BA /* GetMetadataForFile.m */,
+				E52523DC16245A910012E2BA /* MySpotlightImporter.h */,
+				E52523DD16245A910012E2BA /* MySpotlightImporter.m */,
+				E52523DF16245A910012E2BA /* Importer Read Me.txt */,
+				E52523D316245A910012E2BA /* Supporting Files */,
+			);
+			path = "Cocoa ApplicationImporter";
+			sourceTree = "<group>";
+		};
+		E52523D316245A910012E2BA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E52523D416245A910012E2BA /* Cocoa ApplicationImporter-Info.plist */,
+				E52523D516245A910012E2BA /* InfoPlist.strings */,
+				E52523D816245A910012E2BA /* main.c */,
+				E52523E016245A910012E2BA /* Cocoa ApplicationImporter-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E52523FC16245AB20012E2BA /* iOS application */ = {
+			isa = PBXGroup;
+			children = (
+				E525240516245AB20012E2BA /* CPAppDelegate.h */,
+				E525240616245AB20012E2BA /* CPAppDelegate.m */,
+				E525240E16245AB20012E2BA /* MainStoryboard.storyboard */,
+				E525241416245AB20012E2BA /* CPMasterViewController.h */,
+				E525241516245AB20012E2BA /* CPMasterViewController.m */,
+				E525241716245AB20012E2BA /* CPDetailViewController.h */,
+				E525241816245AB20012E2BA /* CPDetailViewController.m */,
+				E525241116245AB20012E2BA /* iOS_application.xcdatamodeld */,
+				E52523FD16245AB20012E2BA /* Supporting Files */,
+			);
+			path = "iOS application";
+			sourceTree = "<group>";
+		};
+		E52523FD16245AB20012E2BA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E52523FE16245AB20012E2BA /* iOS application-Info.plist */,
+				E52523FF16245AB20012E2BA /* InfoPlist.strings */,
+				E525240216245AB20012E2BA /* main.m */,
+				E525240416245AB20012E2BA /* iOS application-Prefix.pch */,
+				E525240816245AB20012E2BA /* Default.png */,
+				E525240A16245AB20012E2BA /* Default@2x.png */,
+				E525240C16245AB20012E2BA /* Default-568h@2x.png */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E525242616245AB20012E2BA /* iOS applicationTests */ = {
+			isa = PBXGroup;
+			children = (
+				E525242C16245AB20012E2BA /* iOS_applicationTests.h */,
+				E525242D16245AB20012E2BA /* iOS_applicationTests.m */,
+				E525242716245AB20012E2BA /* Supporting Files */,
+			);
+			path = "iOS applicationTests";
+			sourceTree = "<group>";
+		};
+		E525242716245AB20012E2BA /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				E525242816245AB20012E2BA /* iOS applicationTests-Info.plist */,
+				E525242916245AB20012E2BA /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E5D464B1163578DB006A4730 /* Text_settings */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			indentWidth = 4;
+			name = Text_settings;
+			path = "Cocoa Application";
+			sourceTree = "<group>";
+			tabWidth = 4;
+			usesTabs = 1;
+			wrapsLines = 1;
+		};
+		E5D464B516357987006A4730 /* Absolute_path */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Absolute_path;
+			path = "/Users/fabio/Documents/GitHub/CP/Xcodeproj/spec/fixtures/Sample Project/Cocoa Application";
+			sourceTree = "<absolute>";
+		};
+		E5FBB3461635ED35009E96B0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E5FBB34C1635ED36009E96B0 /* ReferencedProject.app */,
+				E5FBB34E1635ED36009E96B0 /* ReferencedProjectTests.octest */,
+				E5FBB3501635ED36009E96B0 /* ReferencedProjectImporter.mdimporter */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		 D5DE4A8C17D611E20001B687 = {
+            isa = PBXGroup;
+            children = (
+                E5FBB34C1635ED36009E96B0 /* ReferencedProject.app */,
+            	E5FBB34E1635ED36009E96B0 /* ReferencedProjectTests.octest */,
+                E5FBB3501635ED36009E96B0 /* ReferencedProjectImporter.mdimporter */,
+            );
+            sourceTree = "<group>";
+        };
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		E525244016245B230012E2BA /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6D416371B3300A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6EA16371B3B00A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6FE16371B4400A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D72416371B4E00A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D73816371B5A00A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D75A16371B6300A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D77516371B6A00A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D79116371B7100A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D82516371BC400A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D83916371BCA00A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D86A16371BE100A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D87216371BEE00A003E9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E5DCFBD916285415002C6803 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXLegacyTarget section */
+		E550D6B016371B0600A003E9 /* External */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "$(ACTION)";
+			buildConfigurationList = E550D6B116371B0600A003E9 /* Build configuration list for PBXLegacyTarget "External" */;
+			buildPhases = (
+			);
+			buildToolPath = /usr/bin/make;
+			buildWorkingDirectory = Dir;
+			dependencies = (
+			);
+			name = External;
+			passBuildSettingsInEnvironment = 1;
+			productName = External;
+		};
+		E550D8BA16371C1700A003E9 /* Deployment */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "--compile --embed";
+			buildConfigurationList = E550D8F516371C1800A003E9 /* Build configuration list for PBXLegacyTarget "Deployment" */;
+			buildPhases = (
+			);
+			buildToolPath = /usr/local/bin/macruby_deploy;
+			dependencies = (
+				E550D8BC16371C1700A003E9 /* PBXTargetDependency */,
+			);
+			name = Deployment;
+			passBuildSettingsInEnvironment = 1;
+			productName = Deployment;
+		};
+/* End PBXLegacyTarget section */
+
+/* Begin PBXNativeTarget section */
+		806F6FB517EFAF46001051EE /* iOS staticLibrary */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 806F6FD917EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibrary" */;
+			buildPhases = (
+				806F6FB217EFAF46001051EE /* Sources */,
+				806F6FB317EFAF46001051EE /* Frameworks */,
+				806F6FB417EFAF46001051EE /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "iOS staticLibrary";
+			productName = "iOS staticLibrary";
+			productReference = 806F6FB617EFAF46001051EE /* libiOS staticLibrary.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		806F6FC217EFAF47001051EE /* iOS staticLibraryTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 806F6FDA17EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibraryTests" */;
+			buildPhases = (
+				806F6FBF17EFAF47001051EE /* Sources */,
+				806F6FC017EFAF47001051EE /* Frameworks */,
+				806F6FC117EFAF47001051EE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				806F6FDC17EFB0E7001051EE /* PBXTargetDependency */,
+				806F6FC917EFAF47001051EE /* PBXTargetDependency */,
+			);
+			name = "iOS staticLibraryTests";
+			productName = "iOS staticLibraryTests";
+			productReference = 806F6FC317EFAF47001051EE /* iOS staticLibraryTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		E525238B16245A900012E2BA /* Cocoa Application */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E52523E616245A910012E2BA /* Build configuration list for PBXNativeTarget "Cocoa Application" */;
+			buildPhases = (
+				E525238816245A900012E2BA /* Sources */,
+				E525238916245A900012E2BA /* Frameworks */,
+				E525238A16245A900012E2BA /* Resources */,
+				E5DCFBD916285415002C6803 /* Headers */,
+				E5DCFBDB16285429002C6803 /* Custom name copy */,
+				E5DCFBDC16285431002C6803 /* Custom name */,
+			);
+			buildRules = (
+				E552E0F916263968003ED1FE /* PBXBuildRule */,
+				E552E0F716263967003ED1FE /* PBXBuildRule */,
+			);
+			dependencies = (
+				E52523C816245A910012E2BA /* PBXTargetDependency */,
+			);
+			name = "Cocoa Application";
+			productName = "Cocoa Application";
+			productReference = E525238C16245A900012E2BA /* Cocoa Application.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E52523B216245A910012E2BA /* Cocoa ApplicationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E52523E916245A910012E2BA /* Build configuration list for PBXNativeTarget "Cocoa ApplicationTests" */;
+			buildPhases = (
+				E52523AE16245A910012E2BA /* Sources */,
+				E52523AF16245A910012E2BA /* Frameworks */,
+				E52523B016245A910012E2BA /* Resources */,
+				E52523B116245A910012E2BA /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5138059C16499F4C001D82AD /* PBXTargetDependency */,
+				E52523B816245A910012E2BA /* PBXTargetDependency */,
+			);
+			name = "Cocoa ApplicationTests";
+			productName = "Cocoa ApplicationTests";
+			productReference = E52523B316245A910012E2BA /* Cocoa ApplicationTests.octest */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E52523C516245A910012E2BA /* Cocoa ApplicationImporter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E52523E316245A910012E2BA /* Build configuration list for PBXNativeTarget "Cocoa ApplicationImporter" */;
+			buildPhases = (
+				E52523C216245A910012E2BA /* Sources */,
+				E52523C316245A910012E2BA /* Frameworks */,
+				E52523C416245A910012E2BA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Cocoa ApplicationImporter";
+			productName = "Cocoa ApplicationImporter";
+			productReference = E52523C616245A910012E2BA /* Cocoa ApplicationImporter.mdimporter */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E52523F316245AB20012E2BA /* iOS application */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E525243316245AB20012E2BA /* Build configuration list for PBXNativeTarget "iOS application" */;
+			buildPhases = (
+				E52523F016245AB20012E2BA /* Sources */,
+				E52523F116245AB20012E2BA /* Frameworks */,
+				E52523F216245AB20012E2BA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "iOS application";
+			productName = "iOS application";
+			productReference = E52523F416245AB20012E2BA /* iOS application.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E525241E16245AB20012E2BA /* iOS applicationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E525243416245AB20012E2BA /* Build configuration list for PBXNativeTarget "iOS applicationTests" */;
+			buildPhases = (
+				E525241A16245AB20012E2BA /* Sources */,
+				E525241B16245AB20012E2BA /* Frameworks */,
+				E525241C16245AB20012E2BA /* Resources */,
+				E525241D16245AB20012E2BA /* ShellScript */,
+				E525243E16245B1A0012E2BA /* CopyFiles */,
+				E525243F16245B1D0012E2BA /* ShellScript */,
+				E525244016245B230012E2BA /* Headers */,
+			);
+			buildRules = (
+				E525244116245B280012E2BA /* PBXBuildRule */,
+			);
+			dependencies = (
+				E525242516245AB20012E2BA /* PBXTargetDependency */,
+			);
+			name = "iOS applicationTests";
+			productName = "iOS applicationTests";
+			productReference = E525241F16245AB20012E2BA /* iOS applicationTests.octest */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D6B816371B1A00A003E9 /* UnitTestingBundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D6C616371B1A00A003E9 /* Build configuration list for PBXNativeTarget "UnitTestingBundle" */;
+			buildPhases = (
+				E550D6B416371B1A00A003E9 /* Sources */,
+				E550D6B516371B1A00A003E9 /* Frameworks */,
+				E550D6B616371B1A00A003E9 /* Resources */,
+				E550D6B716371B1A00A003E9 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UnitTestingBundle;
+			productName = UnitTestingBundle;
+			productReference = E550D6B916371B1A00A003E9 /* UnitTestingBundle.octest */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D6CA16371B2800A003E9 /* InAppPurchaseContent */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D6CF16371B2800A003E9 /* Build configuration list for PBXNativeTarget "InAppPurchaseContent" */;
+			buildPhases = (
+				E550D6C916371B2800A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InAppPurchaseContent;
+			productName = InAppPurchaseContent;
+			productReference = E550D6CB16371B2800A003E9 /* InAppPurchaseContent */;
+			productType = "com.apple.product-type.in-app-purchase-content";
+		};
+		E550D6D516371B3300A003E9 /* PlugIn */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D6E516371B3300A003E9 /* Build configuration list for PBXNativeTarget "PlugIn" */;
+			buildPhases = (
+				E550D6D216371B3300A003E9 /* Sources */,
+				E550D6D316371B3300A003E9 /* Frameworks */,
+				E550D6D416371B3300A003E9 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PlugIn;
+			productName = PlugIn;
+			productReference = E550D6D616371B3300A003E9 /* PlugIn.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D6ED16371B3B00A003E9 /* KernelExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D6F916371B3B00A003E9 /* Build configuration list for PBXNativeTarget "KernelExtension" */;
+			buildPhases = (
+				E550D6E816371B3B00A003E9 /* Sources */,
+				E550D6E916371B3B00A003E9 /* Frameworks */,
+				E550D6EA16371B3B00A003E9 /* Headers */,
+				E550D6EB16371B3B00A003E9 /* Resources */,
+				E550D6EC16371B3B00A003E9 /* Rez */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = KernelExtension;
+			productName = KernelExtension;
+			productReference = E550D6EE16371B3B00A003E9 /* KernelExtension.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+		E550D70116371B4400A003E9 /* ImageUnitPlugIn */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D71F16371B4400A003E9 /* Build configuration list for PBXNativeTarget "ImageUnitPlugIn" */;
+			buildPhases = (
+				E550D6FC16371B4400A003E9 /* Sources */,
+				E550D6FD16371B4400A003E9 /* Frameworks */,
+				E550D6FE16371B4400A003E9 /* Headers */,
+				E550D6FF16371B4400A003E9 /* Resources */,
+				E550D70016371B4400A003E9 /* Rez */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ImageUnitPlugIn;
+			productName = ImageUnitPlugIn;
+			productReference = E550D70216371B4400A003E9 /* ImageUnitPlugIn.plugin */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D72716371B4E00A003E9 /* IOKitDriver */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D73316371B4E00A003E9 /* Build configuration list for PBXNativeTarget "IOKitDriver" */;
+			buildPhases = (
+				E550D72216371B4E00A003E9 /* Sources */,
+				E550D72316371B4E00A003E9 /* Frameworks */,
+				E550D72416371B4E00A003E9 /* Headers */,
+				E550D72516371B4E00A003E9 /* Resources */,
+				E550D72616371B4E00A003E9 /* Rez */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = IOKitDriver;
+			productName = IOKitDriver;
+			productReference = E550D72816371B4E00A003E9 /* IOKitDriver.kext */;
+			productType = "com.apple.product-type.kernel-extension";
+		};
+		E550D73B16371B5A00A003E9 /* MacRubyPrefPanel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D75516371B5A00A003E9 /* Build configuration list for PBXNativeTarget "MacRubyPrefPanel" */;
+			buildPhases = (
+				E550D73616371B5A00A003E9 /* Sources */,
+				E550D73716371B5A00A003E9 /* Frameworks */,
+				E550D73816371B5A00A003E9 /* Headers */,
+				E550D73916371B5A00A003E9 /* Resources */,
+				E550D73A16371B5A00A003E9 /* Rez */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MacRubyPrefPanel;
+			productName = MacRubyPrefPanel;
+			productReference = E550D73C16371B5A00A003E9 /* MacRubyPrefPanel.prefPane */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D75D16371B6300A003E9 /* PreferencePanel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D77016371B6300A003E9 /* Build configuration list for PBXNativeTarget "PreferencePanel" */;
+			buildPhases = (
+				E550D75816371B6300A003E9 /* Sources */,
+				E550D75916371B6300A003E9 /* Frameworks */,
+				E550D75A16371B6300A003E9 /* Headers */,
+				E550D75B16371B6300A003E9 /* Resources */,
+				E550D75C16371B6300A003E9 /* Rez */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = PreferencePanel;
+			productName = PreferencePanel;
+			productReference = E550D75E16371B6300A003E9 /* PreferencePanel.prefPane */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D77816371B6A00A003E9 /* QuickLook */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D78C16371B6A00A003E9 /* Build configuration list for PBXNativeTarget "QuickLook" */;
+			buildPhases = (
+				E550D77316371B6A00A003E9 /* Sources */,
+				E550D77416371B6A00A003E9 /* Frameworks */,
+				E550D77516371B6A00A003E9 /* Headers */,
+				E550D77616371B6A00A003E9 /* Resources */,
+				E550D77716371B6A00A003E9 /* Rez */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QuickLook;
+			productName = QuickLook;
+			productReference = E550D77916371B6A00A003E9 /* QuickLook.qlgenerator */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D79416371B7100A003E9 /* ScreenSaver */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D7A316371B7100A003E9 /* Build configuration list for PBXNativeTarget "ScreenSaver" */;
+			buildPhases = (
+				E550D78F16371B7100A003E9 /* Sources */,
+				E550D79016371B7100A003E9 /* Frameworks */,
+				E550D79116371B7100A003E9 /* Headers */,
+				E550D79216371B7100A003E9 /* Resources */,
+				E550D79316371B7100A003E9 /* Rez */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ScreenSaver;
+			productName = ScreenSaver;
+			productReference = E550D79516371B7100A003E9 /* ScreenSaver.saver */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D7A916371B7A00A003E9 /* SpotLightImporter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D7BE16371B7A00A003E9 /* Build configuration list for PBXNativeTarget "SpotLightImporter" */;
+			buildPhases = (
+				E550D7A616371B7A00A003E9 /* Sources */,
+				E550D7A716371B7A00A003E9 /* Frameworks */,
+				E550D7A816371B7A00A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SpotLightImporter;
+			productName = SpotLightImporter;
+			productReference = E550D7AA16371B7A00A003E9 /* SpotLightImporter.mdimporter */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D7C516371B8F00A003E9 /* AutomatorAction */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D7D716371B9000A003E9 /* Build configuration list for PBXNativeTarget "AutomatorAction" */;
+			buildPhases = (
+				E550D7C116371B8F00A003E9 /* Sources */,
+				E550D7C216371B8F00A003E9 /* Frameworks */,
+				E550D7C316371B8F00A003E9 /* Resources */,
+				E550D7C416371B8F00A003E9 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AutomatorAction;
+			productName = AutomatorAction;
+			productReference = E550D7C616371B8F00A003E9 /* AutomatorAction.action */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D7DD16371B9800A003E9 /* AddressBookPlugIn */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D7EB16371B9800A003E9 /* Build configuration list for PBXNativeTarget "AddressBookPlugIn" */;
+			buildPhases = (
+				E550D7DA16371B9800A003E9 /* Sources */,
+				E550D7DB16371B9800A003E9 /* Frameworks */,
+				E550D7DC16371B9800A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AddressBookPlugIn;
+			productName = AddressBookPlugIn;
+			productReference = E550D7DE16371B9800A003E9 /* AddressBookPlugIn.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D7F116371BA500A003E9 /* InstallerPlugIn */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D80816371BA500A003E9 /* Build configuration list for PBXNativeTarget "InstallerPlugIn" */;
+			buildPhases = (
+				E550D7EE16371BA500A003E9 /* Sources */,
+				E550D7EF16371BA500A003E9 /* Frameworks */,
+				E550D7F016371BA500A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = InstallerPlugIn;
+			productName = InstallerPlugIn;
+			productReference = E550D7F216371BA500A003E9 /* InstallerPlugIn.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D80F16371BAF00A003E9 /* QuartzComposerPlugIn */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D82016371BAF00A003E9 /* Build configuration list for PBXNativeTarget "QuartzComposerPlugIn" */;
+			buildPhases = (
+				E550D80B16371BAF00A003E9 /* Sources */,
+				E550D80C16371BAF00A003E9 /* Frameworks */,
+				E550D80D16371BAF00A003E9 /* Resources */,
+				E550D80E16371BAF00A003E9 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = QuartzComposerPlugIn;
+			productName = QuartzComposerPlugIn;
+			productReference = E550D81016371BAF00A003E9 /* QuartzComposerPlugIn.plugin */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D82716371BC400A003E9 /* CocoaFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D83416371BC500A003E9 /* Build configuration list for PBXNativeTarget "CocoaFramework" */;
+			buildPhases = (
+				E550D82316371BC400A003E9 /* Sources */,
+				E550D82416371BC400A003E9 /* Frameworks */,
+				E550D82516371BC400A003E9 /* Headers */,
+				E550D82616371BC400A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CocoaFramework;
+			productName = CocoaFramework;
+			productReference = E550D82816371BC400A003E9 /* CocoaFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E550D83A16371BCA00A003E9 /* Library */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D84316371BCA00A003E9 /* Build configuration list for PBXNativeTarget "Library" */;
+			buildPhases = (
+				E550D83716371BCA00A003E9 /* Sources */,
+				E550D83816371BCA00A003E9 /* Frameworks */,
+				E550D83916371BCA00A003E9 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Library;
+			productName = Library;
+			productReference = E550D83B16371BCA00A003E9 /* Library.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		E550D84916371BD000A003E9 /* Bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D85316371BD000A003E9 /* Build configuration list for PBXNativeTarget "Bundle" */;
+			buildPhases = (
+				E550D84616371BD000A003E9 /* Sources */,
+				E550D84716371BD000A003E9 /* Frameworks */,
+				E550D84816371BD000A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Bundle;
+			productName = Bundle;
+			productReference = E550D84A16371BD000A003E9 /* Bundle.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D85916371BD600A003E9 /* XPCServic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D86516371BD700A003E9 /* Build configuration list for PBXNativeTarget "XPCServic" */;
+			buildPhases = (
+				E550D85616371BD600A003E9 /* Sources */,
+				E550D85716371BD600A003E9 /* Frameworks */,
+				E550D85816371BD600A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = XPCServic;
+			productName = XPCServic;
+			productReference = E550D85A16371BD600A003E9 /* org.cocoapods.XPCServic.xpc */;
+			productType = "com.apple.product-type.bundle";
+		};
+		E550D86B16371BE100A003E9 /* C/C++ Library */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D86D16371BE100A003E9 /* Build configuration list for PBXNativeTarget "C/C++ Library" */;
+			buildPhases = (
+				E550D86816371BE100A003E9 /* Sources */,
+				E550D86916371BE100A003E9 /* Frameworks */,
+				E550D86A16371BE100A003E9 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "C/C++ Library";
+			productName = "C/C++ Library";
+			productReference = E550D86C16371BE100A003E9 /* libC/C++ Library.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		E550D87316371BEE00A003E9 /* STL C++ Library */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D87E16371BEE00A003E9 /* Build configuration list for PBXNativeTarget "STL C++ Library" */;
+			buildPhases = (
+				E550D87016371BEE00A003E9 /* Sources */,
+				E550D87116371BEE00A003E9 /* Frameworks */,
+				E550D87216371BEE00A003E9 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "STL C++ Library";
+			productName = "STL C++ Library";
+			productReference = E550D87416371BEE00A003E9 /* STL C++ Library.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		E550D88416371C0600A003E9 /* CocoaAppleScriptApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D89E16371C0700A003E9 /* Build configuration list for PBXNativeTarget "CocoaAppleScriptApp" */;
+			buildPhases = (
+				E550D88116371C0600A003E9 /* Sources */,
+				E550D88216371C0600A003E9 /* Frameworks */,
+				E550D88316371C0600A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CocoaAppleScriptApp;
+			productName = CocoaAppleScriptApp;
+			productReference = E550D88516371C0600A003E9 /* CocoaAppleScriptApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E550D8A416371C0F00A003E9 /* CommandLineTool */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D8AF16371C1000A003E9 /* Build configuration list for PBXNativeTarget "CommandLineTool" */;
+			buildPhases = (
+				E550D8A116371C0F00A003E9 /* Sources */,
+				E550D8A216371C0F00A003E9 /* Frameworks */,
+				E550D8A316371C0F00A003E9 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CommandLineTool;
+			productName = CommandLineTool;
+			productReference = E550D8A516371C0F00A003E9 /* CommandLineTool */;
+			productType = "com.apple.product-type.tool";
+		};
+		E550D8B516371C1700A003E9 /* MacRubyApplication */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D8F216371C1800A003E9 /* Build configuration list for PBXNativeTarget "MacRubyApplication" */;
+			buildPhases = (
+				E550D8B216371C1700A003E9 /* Sources */,
+				E550D8B316371C1700A003E9 /* Frameworks */,
+				E550D8B416371C1700A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E550D8DA16371C1800A003E9 /* PBXTargetDependency */,
+			);
+			name = MacRubyApplication;
+			productName = MacRubyApplication;
+			productReference = E550D8B616371C1700A003E9 /* MacRubyApplication.app */;
+			productType = "com.apple.product-type.application";
+		};
+		E550D8D716371C1800A003E9 /* MacRubyApplicationImporter */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E550D8EF16371C1800A003E9 /* Build configuration list for PBXNativeTarget "MacRubyApplicationImporter" */;
+			buildPhases = (
+				E550D8D416371C1800A003E9 /* Sources */,
+				E550D8D516371C1800A003E9 /* Frameworks */,
+				E550D8D616371C1800A003E9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MacRubyApplicationImporter;
+			productName = MacRubyApplicationImporter;
+			productReference = E550D8D816371C1800A003E9 /* MacRubyApplicationImporter.mdimporter */;
+			productType = "com.apple.product-type.bundle";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E525238316245A900012E2BA /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = CP;
+				LastUpgradeCheck = 0730;
+				ORGANIZATIONNAME = CocoaPods;
+				TargetAttributes = {
+					806F6FC217EFAF47001051EE = {
+						TestTargetID = E525238B16245A900012E2BA;
+					};
+				};
+			};
+			buildConfigurationList = E525238616245A900012E2BA /* Build configuration list for PBXProject "Cocoa Application Without productRefGroup" */;
+			compatibilityVersion = "Xcode 3.1";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E525238116245A900012E2BA;
+			productRefGroup = D5DE4A8C17D611E20001B687;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = E5FBB3461635ED35009E96B0 /* Products */;
+					ProjectRef = E5FBB3451635ED35009E96B0 /* ReferencedProject.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				E525238B16245A900012E2BA /* Cocoa Application */,
+				E52523B216245A910012E2BA /* Cocoa ApplicationTests */,
+				E52523C516245A910012E2BA /* Cocoa ApplicationImporter */,
+				E52523F316245AB20012E2BA /* iOS application */,
+				E525241E16245AB20012E2BA /* iOS applicationTests */,
+				806F6FB517EFAF46001051EE /* iOS staticLibrary */,
+				806F6FC217EFAF47001051EE /* iOS staticLibraryTests */,
+				E550D6AA16371AF600A003E9 /* Aggregate */,
+				E550D6B016371B0600A003E9 /* External */,
+				E550D6B816371B1A00A003E9 /* UnitTestingBundle */,
+				E550D6CA16371B2800A003E9 /* InAppPurchaseContent */,
+				E550D6D516371B3300A003E9 /* PlugIn */,
+				E550D6ED16371B3B00A003E9 /* KernelExtension */,
+				E550D70116371B4400A003E9 /* ImageUnitPlugIn */,
+				E550D72716371B4E00A003E9 /* IOKitDriver */,
+				E550D73B16371B5A00A003E9 /* MacRubyPrefPanel */,
+				E550D75D16371B6300A003E9 /* PreferencePanel */,
+				E550D77816371B6A00A003E9 /* QuickLook */,
+				E550D79416371B7100A003E9 /* ScreenSaver */,
+				E550D7A916371B7A00A003E9 /* SpotLightImporter */,
+				E550D7C516371B8F00A003E9 /* AutomatorAction */,
+				E550D7DD16371B9800A003E9 /* AddressBookPlugIn */,
+				E550D7F116371BA500A003E9 /* InstallerPlugIn */,
+				E550D80F16371BAF00A003E9 /* QuartzComposerPlugIn */,
+				E550D82716371BC400A003E9 /* CocoaFramework */,
+				E550D83A16371BCA00A003E9 /* Library */,
+				E550D84916371BD000A003E9 /* Bundle */,
+				E550D85916371BD600A003E9 /* XPCServic */,
+				E550D86B16371BE100A003E9 /* C/C++ Library */,
+				E550D87316371BEE00A003E9 /* STL C++ Library */,
+				E550D88416371C0600A003E9 /* CocoaAppleScriptApp */,
+				E550D8A416371C0F00A003E9 /* CommandLineTool */,
+				E550D8B516371C1700A003E9 /* MacRubyApplication */,
+				E550D8BA16371C1700A003E9 /* Deployment */,
+				E550D8D716371C1800A003E9 /* MacRubyApplicationImporter */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		E5FBB34C1635ED36009E96B0 /* ReferencedProject.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = ReferencedProject.app;
+			remoteRef = E5FBB34B1635ED36009E96B0 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E5FBB34E1635ED36009E96B0 /* ReferencedProjectTests.octest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReferencedProjectTests.octest;
+			remoteRef = E5FBB34D1635ED36009E96B0 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E5FBB3501635ED36009E96B0 /* ReferencedProjectImporter.mdimporter */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ReferencedProjectImporter.mdimporter;
+			remoteRef = E5FBB34F1635ED36009E96B0 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		806F6FC117EFAF47001051EE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FD017EFAF47001051EE /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E525238A16245A900012E2BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525239B16245A900012E2BA /* InfoPlist.strings in Resources */,
+				E52523A116245A900012E2BA /* Credits.rtf in Resources */,
+				E52523A716245A900012E2BA /* CPDocument.xib in Resources */,
+				E52523AA16245A910012E2BA /* MainMenu.xib in Resources */,
+				E52523C916245A910012E2BA /* Cocoa ApplicationImporter.mdimporter in Resources */,
+				E525243C16245AE10012E2BA /* Linked Folder in Resources */,
+				E5D46499163577B5006A4730 /* Relative_to_group in Resources */,
+				E5D4649B163577D2006A4730 /* Absolute_path in Resources */,
+				E5D4649D163577E7006A4730 /* Relative_to_project in Resources */,
+				E5D4649F163577FB006A4730 /* Relative_to_developer_direcotry in Resources */,
+				E5D464A116357816006A4730 /* Relative_to_build_products in Resources */,
+				E5D464A316357833006A4730 /* Relative_to_SDK in Resources */,
+				E5D464A616357841006A4730 /* Localized in Resources */,
+				E5D464AA16357867006A4730 /* Text_settings in Resources */,
+				E5FBB2D116357C16009E96B0 /* sample.xcconfig in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523B016245A910012E2BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E52523BE16245A910012E2BA /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523C416245A910012E2BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E52523D716245A910012E2BA /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523F216245AB20012E2BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525240116245AB20012E2BA /* InfoPlist.strings in Resources */,
+				E525240916245AB20012E2BA /* Default.png in Resources */,
+				E525240B16245AB20012E2BA /* Default@2x.png in Resources */,
+				E525240D16245AB20012E2BA /* Default-568h@2x.png in Resources */,
+				E525241016245AB20012E2BA /* MainStoryboard.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E525241C16245AB20012E2BA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525242B16245AB20012E2BA /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6B616371B1A00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6C916371B2800A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6EB16371B3B00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6FF16371B4400A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D72516371B4E00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D73916371B5A00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D75B16371B6300A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D77616371B6A00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D79216371B7100A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7A816371B7A00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7C316371B8F00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7DC16371B9800A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7F016371BA500A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D80D16371BAF00A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D82616371BC400A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D84816371BD000A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D85816371BD600A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D88316371C0600A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8B416371C1700A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E550D8DB16371C1800A003E9 /* MacRubyApplicationImporter.mdimporter in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8D616371C1800A003E9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXRezBuildPhase section */
+		E550D6EC16371B3B00A003E9 /* Rez */ = {
+			isa = PBXRezBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D70016371B4400A003E9 /* Rez */ = {
+			isa = PBXRezBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D72616371B4E00A003E9 /* Rez */ = {
+			isa = PBXRezBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D73A16371B5A00A003E9 /* Rez */ = {
+			isa = PBXRezBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D75C16371B6300A003E9 /* Rez */ = {
+			isa = PBXRezBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D77716371B6A00A003E9 /* Rez */ = {
+			isa = PBXRezBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D79316371B7100A003E9 /* Rez */ = {
+			isa = PBXRezBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXRezBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		E52523B116245A910012E2BA /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E525241D16245AB20012E2BA /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+		E525243F16245B1D0012E2BA /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "";
+		};
+		E550D6B716371B1A00A003E9 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+		E550D7C416371B8F00A003E9 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "amlint \"${BUILT_PRODUCTS_DIR}/${FULL_PRODUCT_NAME}\"";
+		};
+		E550D80E16371BAF00A003E9 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This shell script simply copies the built plug-in to \"~/Library/Graphics/Quartz Composer Plug-Ins\" and overrides any previous version at that location\n\nmkdir -p \"$USER_LIBRARY_DIR/Graphics/Quartz Composer Plug-Ins\"\nrm -rf \"$USER_LIBRARY_DIR/Graphics/Quartz Composer Plug-Ins/QuartzComposerPlugIn.plugin\"\ncp -rf \"$BUILT_PRODUCTS_DIR/QuartzComposerPlugIn.plugin\" \"$USER_LIBRARY_DIR/Graphics/Quartz Composer Plug-Ins/\"\n";
+		};
+		E550D8F9163733DF00A003E9 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "";
+		};
+		E5DCFBDC16285431002C6803 /* Custom name */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Custom name";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		806F6FB217EFAF46001051EE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FBE17EFAF46001051EE /* iOS_staticLibrary.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		806F6FBF17EFAF47001051EE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				806F6FD217EFAF47001051EE /* iOS_staticLibraryTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E525238816245A900012E2BA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525239D16245A900012E2BA /* main.m in Sources */,
+				E52523A416245A900012E2BA /* CPDocument.m in Sources */,
+				E52523AD16245A910012E2BA /* CPDocument.xcdatamodeld in Sources */,
+				E5D464AD163578AC006A4730 /* Tools_version.xcdatamodeld in Sources */,
+				E5D464B0163578C7006A4730 /* Deployment_target.xcdatamodeld in Sources */,
+				E5D464B416357954006A4730 /* Version_identifier.xcdatamodeld in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523AE16245A910012E2BA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E52523C116245A910012E2BA /* Cocoa_ApplicationTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523C216245A910012E2BA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E52523D916245A910012E2BA /* main.c in Sources */,
+				E52523DB16245A910012E2BA /* GetMetadataForFile.m in Sources */,
+				E52523DE16245A910012E2BA /* MySpotlightImporter.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E52523F016245AB20012E2BA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525240316245AB20012E2BA /* main.m in Sources */,
+				E525240716245AB20012E2BA /* CPAppDelegate.m in Sources */,
+				E525241316245AB20012E2BA /* iOS_application.xcdatamodeld in Sources */,
+				E525241616245AB20012E2BA /* CPMasterViewController.m in Sources */,
+				E525241916245AB20012E2BA /* CPDetailViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E525241A16245AB20012E2BA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E525242E16245AB20012E2BA /* iOS_applicationTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6B416371B1A00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6D216371B3300A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6E816371B3B00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D6FC16371B4400A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D72216371B4E00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D73616371B5A00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D75816371B6300A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D77316371B6A00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D78F16371B7100A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7A616371B7A00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7C116371B8F00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7DA16371B9800A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D7EE16371BA500A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D80B16371BAF00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D82316371BC400A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D83716371BCA00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D84616371BD000A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D85616371BD600A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D86816371BE100A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D87016371BEE00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D88116371C0600A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8A116371C0F00A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8B216371C1700A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E550D8D416371C1800A003E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5138059C16499F4C001D82AD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ReferencedProject;
+			targetProxy = 5138059B16499F4C001D82AD /* PBXContainerItemProxy */;
+		};
+		806F6FC917EFAF47001051EE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 806F6FB517EFAF46001051EE /* iOS staticLibrary */;
+			targetProxy = 806F6FC817EFAF47001051EE /* PBXContainerItemProxy */;
+		};
+		806F6FDC17EFB0E7001051EE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E52523F316245AB20012E2BA /* iOS application */;
+			targetProxy = 806F6FDB17EFB0E7001051EE /* PBXContainerItemProxy */;
+		};
+		E52523B816245A910012E2BA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E525238B16245A900012E2BA /* Cocoa Application */;
+			targetProxy = E52523B716245A910012E2BA /* PBXContainerItemProxy */;
+		};
+		E52523C816245A910012E2BA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E52523C516245A910012E2BA /* Cocoa ApplicationImporter */;
+			targetProxy = E52523C716245A910012E2BA /* PBXContainerItemProxy */;
+		};
+		E525242516245AB20012E2BA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E52523F316245AB20012E2BA /* iOS application */;
+			targetProxy = E525242416245AB20012E2BA /* PBXContainerItemProxy */;
+		};
+		E550D6AF16371AFC00A003E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E52523B216245A910012E2BA /* Cocoa ApplicationTests */;
+			targetProxy = E550D6AE16371AFC00A003E9 /* PBXContainerItemProxy */;
+		};
+		E550D8BC16371C1700A003E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E550D8B516371C1700A003E9 /* MacRubyApplication */;
+			targetProxy = E550D8BB16371C1700A003E9 /* PBXContainerItemProxy */;
+		};
+		E550D8DA16371C1800A003E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E550D8D716371C1800A003E9 /* MacRubyApplicationImporter */;
+			targetProxy = E550D8D916371C1800A003E9 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		806F6FCE17EFAF47001051EE /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				806F6FCF17EFAF47001051EE /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E525239916245A900012E2BA /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E525239A16245A900012E2BA /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E525239F16245A900012E2BA /* Credits.rtf */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E52523A016245A900012E2BA /* en */,
+			);
+			name = Credits.rtf;
+			sourceTree = "<group>";
+		};
+		E52523A516245A900012E2BA /* CPDocument.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E5FBB2D316357C93009E96B0 /* Base */,
+			);
+			name = CPDocument.xib;
+			sourceTree = "<group>";
+		};
+		E52523A816245A910012E2BA /* MainMenu.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E5FBB2D416357C93009E96B0 /* Base */,
+			);
+			name = MainMenu.xib;
+			sourceTree = "<group>";
+		};
+		E52523BC16245A910012E2BA /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E52523BD16245A910012E2BA /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E52523D516245A910012E2BA /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E52523D616245A910012E2BA /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E52523FF16245AB20012E2BA /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E525240016245AB20012E2BA /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E525240E16245AB20012E2BA /* MainStoryboard.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E525240F16245AB20012E2BA /* en */,
+			);
+			name = MainStoryboard.storyboard;
+			sourceTree = "<group>";
+		};
+		E525242916245AB20012E2BA /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E525242A16245AB20012E2BA /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		E5D464A816357841006A4730 /* Localized */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E5D464A716357841006A4730 /* en */,
+			);
+			name = Localized;
+			path = "Cocoa Application";
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		806F6FD317EFAF47001051EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				DSTROOT = /tmp/iOS_staticLibrary.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		806F6FD417EFAF47001051EE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				DSTROOT = /tmp/iOS_staticLibrary.dst;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		806F6FD517EFAF47001051EE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/iOS application.app/iOS application";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "iOS staticLibraryTests/iOS staticLibraryTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		806F6FD617EFAF47001051EE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/iOS application.app/iOS application";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				ENABLE_NS_ASSERTIONS = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS staticLibrary/iOS staticLibrary-Prefix.pch";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "iOS staticLibraryTests/iOS staticLibraryTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				VALIDATE_PRODUCT = YES;
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		E52523E116245A910012E2BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		E52523E216245A910012E2BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		E52523E416245A910012E2BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Cocoa ApplicationImporter/Cocoa ApplicationImporter-Prefix.pch";
+				INFOPLIST_FILE = "Cocoa ApplicationImporter/Cocoa ApplicationImporter-Info.plist";
+				INSTALL_PATH = "@executable_path/../Contents/Library/Spotlight";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = mdimporter;
+			};
+			name = Debug;
+		};
+		E52523E516245A910012E2BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Cocoa ApplicationImporter/Cocoa ApplicationImporter-Prefix.pch";
+				INFOPLIST_FILE = "Cocoa ApplicationImporter/Cocoa ApplicationImporter-Info.plist";
+				INSTALL_PATH = "@executable_path/../Contents/Library/Spotlight";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = mdimporter;
+			};
+			name = Release;
+		};
+		E52523E716245A910012E2BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "Cocoa Application/Cocoa Application.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Cocoa Application/Cocoa Application-Prefix.pch";
+				INFOPLIST_FILE = "Cocoa Application/Cocoa Application-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		E52523E816245A910012E2BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "Cocoa Application/Cocoa Application.entitlements";
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Cocoa Application/Cocoa Application-Prefix.pch";
+				INFOPLIST_FILE = "Cocoa Application/Cocoa Application-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		E52523EA16245A910012E2BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Cocoa Application.app/Contents/MacOS/Cocoa Application";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Cocoa Application/Cocoa Application-Prefix.pch";
+				INFOPLIST_FILE = "Cocoa ApplicationTests/Cocoa ApplicationTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Debug;
+		};
+		E52523EB16245A910012E2BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Cocoa Application.app/Contents/MacOS/Cocoa Application";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Cocoa Application/Cocoa Application-Prefix.pch";
+				INFOPLIST_FILE = "Cocoa ApplicationTests/Cocoa ApplicationTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Release;
+		};
+		E525242F16245AB20012E2BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS application/iOS application-Prefix.pch";
+				INFOPLIST_FILE = "iOS application/iOS application-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		E525243016245AB20012E2BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS application/iOS application-Prefix.pch";
+				INFOPLIST_FILE = "iOS application/iOS application-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		E525243116245AB20012E2BA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/iOS application.app/iOS application";
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS application/iOS application-Prefix.pch";
+				INFOPLIST_FILE = "iOS applicationTests/iOS applicationTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Debug;
+		};
+		E525243216245AB20012E2BA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/iOS application.app/iOS application";
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "iOS application/iOS application-Prefix.pch";
+				INFOPLIST_FILE = "iOS applicationTests/iOS applicationTests-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				VALIDATE_PRODUCT = YES;
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Release;
+		};
+		E550D6AC16371AF600A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E550D6AD16371AF600A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E550D6B216371B0600A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUGGING_SYMBOLS = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E550D6B316371B0600A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E550D6C716371B1A00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "UnitTestingBundle/UnitTestingBundle-Prefix.pch";
+				INFOPLIST_FILE = "UnitTestingBundle/UnitTestingBundle-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Debug;
+		};
+		E550D6C816371B1A00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = "\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"";
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "UnitTestingBundle/UnitTestingBundle-Prefix.pch";
+				INFOPLIST_FILE = "UnitTestingBundle/UnitTestingBundle-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Release;
+		};
+		E550D6D016371B2800A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = InAppPurchaseContent/ContentInfo.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/InAppPurchaseContent";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = "";
+			};
+			name = Debug;
+		};
+		E550D6D116371B2800A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = InAppPurchaseContent/ContentInfo.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/InAppPurchaseContent";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = "";
+			};
+			name = Release;
+		};
+		E550D6E616371B3300A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "PlugIn/PlugIn-Prefix.pch";
+				INFOPLIST_FILE = "PlugIn/PlugIn-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E550D6E716371B3300A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "PlugIn/PlugIn-Prefix.pch";
+				INFOPLIST_FILE = "PlugIn/PlugIn-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E550D6FA16371B3B00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "KernelExtension/KernelExtension-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				INFOPLIST_FILE = "KernelExtension/KernelExtension-Info.plist";
+				INSTALL_PATH = "$(SYSTEM_LIBRARY_DIR)/Extensions";
+				MODULE_NAME = org.cocoapods.KernelExtension;
+				MODULE_START = KernelExtension_start;
+				MODULE_STOP = KernelExtension_stop;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		E550D6FB16371B3B00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "KernelExtension/KernelExtension-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				INFOPLIST_FILE = "KernelExtension/KernelExtension-Info.plist";
+				INSTALL_PATH = "$(SYSTEM_LIBRARY_DIR)/Extensions";
+				MODULE_NAME = org.cocoapods.KernelExtension;
+				MODULE_START = KernelExtension_start;
+				MODULE_STOP = KernelExtension_stop;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		E550D72016371B4400A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ImageUnitPlugIn/ImageUnitPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "ImageUnitPlugIn/ImageUnitPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Graphics/Image Units";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = plugin;
+			};
+			name = Debug;
+		};
+		E550D72116371B4400A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ImageUnitPlugIn/ImageUnitPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "ImageUnitPlugIn/ImageUnitPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Graphics/Image Units";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = plugin;
+			};
+			name = Release;
+		};
+		E550D73416371B4E00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1.0.0d1;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "IOKitDriver/IOKitDriver-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				INFOPLIST_FILE = "IOKitDriver/IOKitDriver-Info.plist";
+				MODULE_NAME = org.cocoapods.IOKitDriver;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Debug;
+		};
+		E550D73516371B4E00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1.0.0d1;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "IOKitDriver/IOKitDriver-Prefix.pch";
+				GCC_VERSION = com.apple.compilers.llvmgcc42;
+				INFOPLIST_FILE = "IOKitDriver/IOKitDriver-Info.plist";
+				MODULE_NAME = org.cocoapods.IOKitDriver;
+				MODULE_VERSION = 1.0.0d1;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = kext;
+			};
+			name = Release;
+		};
+		E550D75616371B5A00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
+				);
+				GCC_ENABLE_OBJC_GC = required;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MacRubyPrefPanel/MacRubyPrefPanel-Prefix.pch";
+				INFOPLIST_FILE = "MacRubyPrefPanel/MacRubyPrefPanel-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/PreferencePanes";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = prefPane;
+			};
+			name = Debug;
+		};
+		E550D75716371B5A00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
+				);
+				GCC_ENABLE_OBJC_GC = required;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MacRubyPrefPanel/MacRubyPrefPanel-Prefix.pch";
+				INFOPLIST_FILE = "MacRubyPrefPanel/MacRubyPrefPanel-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/PreferencePanes";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = prefPane;
+			};
+			name = Release;
+		};
+		E550D77116371B6300A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "PreferencePanel/PreferencePanel-Prefix.pch";
+				INFOPLIST_FILE = "PreferencePanel/PreferencePanel-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/PreferencePanes";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = prefPane;
+			};
+			name = Debug;
+		};
+		E550D77216371B6300A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "PreferencePanel/PreferencePanel-Prefix.pch";
+				INFOPLIST_FILE = "PreferencePanel/PreferencePanel-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/PreferencePanes";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = prefPane;
+			};
+			name = Release;
+		};
+		E550D78D16371B6A00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "QuickLook/QuickLook-Prefix.pch";
+				INFOPLIST_FILE = "QuickLook/QuickLook-Info.plist";
+				INSTALL_PATH = /Library/QuickLook;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = qlgenerator;
+			};
+			name = Debug;
+		};
+		E550D78E16371B6A00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "QuickLook/QuickLook-Prefix.pch";
+				INFOPLIST_FILE = "QuickLook/QuickLook-Info.plist";
+				INSTALL_PATH = /Library/QuickLook;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = qlgenerator;
+			};
+			name = Release;
+		};
+		E550D7A416371B7100A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ScreenSaver/ScreenSaver-Prefix.pch";
+				INFOPLIST_FILE = "ScreenSaver/ScreenSaver-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = saver;
+			};
+			name = Debug;
+		};
+		E550D7A516371B7100A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "ScreenSaver/ScreenSaver-Prefix.pch";
+				INFOPLIST_FILE = "ScreenSaver/ScreenSaver-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Screen Savers";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = saver;
+			};
+			name = Release;
+		};
+		E550D7BF16371B7A00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SpotLightImporter/SpotLightImporter-Prefix.pch";
+				INFOPLIST_FILE = "SpotLightImporter/SpotLightImporter-Info.plist";
+				INSTALL_PATH = "@executable_path/../Contents/Library/Spotlight";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = mdimporter;
+			};
+			name = Debug;
+		};
+		E550D7C016371B7A00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "SpotLightImporter/SpotLightImporter-Prefix.pch";
+				INFOPLIST_FILE = "SpotLightImporter/SpotLightImporter-Info.plist";
+				INSTALL_PATH = "@executable_path/../Contents/Library/Spotlight";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = mdimporter;
+			};
+			name = Release;
+		};
+		E550D7D816371B9000A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AutomatorAction/AutomatorAction-Prefix.pch";
+				INFOPLIST_FILE = "AutomatorAction/AutomatorAction-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Automator";
+				OTHER_OSAFLAGS = "-x -t 0 -c 0";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = action;
+			};
+			name = Debug;
+		};
+		E550D7D916371B9000A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AutomatorAction/AutomatorAction-Prefix.pch";
+				INFOPLIST_FILE = "AutomatorAction/AutomatorAction-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Automator";
+				OTHER_OSAFLAGS = "-x -t 0 -c 0";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = action;
+			};
+			name = Release;
+		};
+		E550D7EC16371B9800A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AddressBookPlugIn/AddressBookPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "AddressBookPlugIn/AddressBookPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Developer/Palettes";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		E550D7ED16371B9800A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AddressBookPlugIn/AddressBookPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "AddressBookPlugIn/AddressBookPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Developer/Palettes";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		E550D80916371BA500A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "InstallerPlugIn/InstallerPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "InstallerPlugIn/InstallerPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Bundles";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		E550D80A16371BA500A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "InstallerPlugIn/InstallerPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "InstallerPlugIn/InstallerPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Bundles";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		E550D82116371BAF00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "QuartzComposerPlugIn/QuartzComposerPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "QuartzComposerPlugIn/QuartzComposerPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Graphics/Quartz Composer Plug-Ins";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = plugin;
+			};
+			name = Debug;
+		};
+		E550D82216371BAF00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_ENABLE_OBJC_GC = supported;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "QuartzComposerPlugIn/QuartzComposerPlugIn-Prefix.pch";
+				INFOPLIST_FILE = "QuartzComposerPlugIn/QuartzComposerPlugIn-Info.plist";
+				INSTALL_PATH = "$(HOME)/Library/Graphics/Quartz Composer Plug-Ins";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = plugin;
+			};
+			name = Release;
+		};
+		E550D83516371BC500A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CocoaFramework/CocoaFramework-Prefix.pch";
+				INFOPLIST_FILE = "CocoaFramework/CocoaFramework-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Debug;
+		};
+		E550D83616371BC500A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				FRAMEWORK_VERSION = A;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CocoaFramework/CocoaFramework-Prefix.pch";
+				INFOPLIST_FILE = "CocoaFramework/CocoaFramework-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = framework;
+			};
+			name = Release;
+		};
+		E550D84416371BCA00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Library/Library-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E550D84516371BCA00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Library/Library-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E550D85416371BD000A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Bundle/Bundle-Prefix.pch";
+				INFOPLIST_FILE = "Bundle/Bundle-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		E550D85516371BD000A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "Bundle/Bundle-Prefix.pch";
+				INFOPLIST_FILE = "Bundle/Bundle-Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		E550D86616371BD700A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "XPCServic/XPCServic-Prefix.pch";
+				INFOPLIST_FILE = "XPCServic/XPCServic-Info.plist";
+				MACH_O_TYPE = mh_execute;
+				PRODUCT_NAME = "org.cocoapods.$(TARGET_NAME:rfc1034identifier)";
+				WRAPPER_EXTENSION = xpc;
+			};
+			name = Debug;
+		};
+		E550D86716371BD700A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "XPCServic/XPCServic-Prefix.pch";
+				INFOPLIST_FILE = "XPCServic/XPCServic-Info.plist";
+				MACH_O_TYPE = mh_execute;
+				PRODUCT_NAME = "org.cocoapods.$(TARGET_NAME:rfc1034identifier)";
+				WRAPPER_EXTENSION = xpc;
+			};
+			name = Release;
+		};
+		E550D86E16371BE100A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EXECUTABLE_PREFIX = lib;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E550D86F16371BE100A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EXECUTABLE_PREFIX = lib;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E550D87F16371BEE00A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E550D88016371BEE00A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E550D89F16371C0700A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CocoaAppleScriptApp/CocoaAppleScriptApp-Prefix.pch";
+				INFOPLIST_FILE = "CocoaAppleScriptApp/CocoaAppleScriptApp-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		E550D8A016371C0700A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CocoaAppleScriptApp/CocoaAppleScriptApp-Prefix.pch";
+				INFOPLIST_FILE = "CocoaAppleScriptApp/CocoaAppleScriptApp-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		E550D8B016371C1000A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CommandLineTool/CommandLineTool-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		E550D8B116371C1000A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CommandLineTool/CommandLineTool-Prefix.pch";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		E550D8F016371C1800A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MacRubyApplicationImporter/MacRubyApplicationImporter-Prefix.pch";
+				INFOPLIST_FILE = "MacRubyApplicationImporter/MacRubyApplicationImporter-Info.plist";
+				INSTALL_PATH = "@executable_path/../Contents/Library/Spotlight";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = mdimporter;
+			};
+			name = Debug;
+		};
+		E550D8F116371C1800A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MacRubyApplicationImporter/MacRubyApplicationImporter-Prefix.pch";
+				INFOPLIST_FILE = "MacRubyApplicationImporter/MacRubyApplicationImporter-Info.plist";
+				INSTALL_PATH = "@executable_path/../Contents/Library/Spotlight";
+				LIBRARY_STYLE = BUNDLE;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = mdimporter;
+			};
+			name = Release;
+		};
+		E550D8F316371C1800A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
+				);
+				GCC_ENABLE_OBJC_GC = required;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MacRubyApplication/MacRubyApplication-Prefix.pch";
+				INFOPLIST_FILE = "MacRubyApplication/MacRubyApplication-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		E550D8F416371C1800A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Library/Frameworks\"",
+				);
+				GCC_ENABLE_OBJC_GC = required;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "MacRubyApplication/MacRubyApplication-Prefix.pch";
+				INFOPLIST_FILE = "MacRubyApplication/MacRubyApplication-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		E550D8F616371C1800A003E9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		E550D8F716371C1800A003E9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		806F6FD917EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibrary" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				806F6FD317EFAF47001051EE /* Debug */,
+				806F6FD417EFAF47001051EE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		806F6FDA17EFAF47001051EE /* Build configuration list for PBXNativeTarget "iOS staticLibraryTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				806F6FD517EFAF47001051EE /* Debug */,
+				806F6FD617EFAF47001051EE /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E525238616245A900012E2BA /* Build configuration list for PBXProject "Cocoa Application Without productRefGroup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E52523E116245A910012E2BA /* Debug */,
+				E52523E216245A910012E2BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E52523E316245A910012E2BA /* Build configuration list for PBXNativeTarget "Cocoa ApplicationImporter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E52523E416245A910012E2BA /* Debug */,
+				E52523E516245A910012E2BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E52523E616245A910012E2BA /* Build configuration list for PBXNativeTarget "Cocoa Application" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E52523E716245A910012E2BA /* Debug */,
+				E52523E816245A910012E2BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E52523E916245A910012E2BA /* Build configuration list for PBXNativeTarget "Cocoa ApplicationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E52523EA16245A910012E2BA /* Debug */,
+				E52523EB16245A910012E2BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E525243316245AB20012E2BA /* Build configuration list for PBXNativeTarget "iOS application" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E525242F16245AB20012E2BA /* Debug */,
+				E525243016245AB20012E2BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E525243416245AB20012E2BA /* Build configuration list for PBXNativeTarget "iOS applicationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E525243116245AB20012E2BA /* Debug */,
+				E525243216245AB20012E2BA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D6AB16371AF600A003E9 /* Build configuration list for PBXAggregateTarget "Aggregate" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D6AC16371AF600A003E9 /* Debug */,
+				E550D6AD16371AF600A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D6B116371B0600A003E9 /* Build configuration list for PBXLegacyTarget "External" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D6B216371B0600A003E9 /* Debug */,
+				E550D6B316371B0600A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D6C616371B1A00A003E9 /* Build configuration list for PBXNativeTarget "UnitTestingBundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D6C716371B1A00A003E9 /* Debug */,
+				E550D6C816371B1A00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D6CF16371B2800A003E9 /* Build configuration list for PBXNativeTarget "InAppPurchaseContent" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D6D016371B2800A003E9 /* Debug */,
+				E550D6D116371B2800A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D6E516371B3300A003E9 /* Build configuration list for PBXNativeTarget "PlugIn" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D6E616371B3300A003E9 /* Debug */,
+				E550D6E716371B3300A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D6F916371B3B00A003E9 /* Build configuration list for PBXNativeTarget "KernelExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D6FA16371B3B00A003E9 /* Debug */,
+				E550D6FB16371B3B00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D71F16371B4400A003E9 /* Build configuration list for PBXNativeTarget "ImageUnitPlugIn" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D72016371B4400A003E9 /* Debug */,
+				E550D72116371B4400A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D73316371B4E00A003E9 /* Build configuration list for PBXNativeTarget "IOKitDriver" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D73416371B4E00A003E9 /* Debug */,
+				E550D73516371B4E00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D75516371B5A00A003E9 /* Build configuration list for PBXNativeTarget "MacRubyPrefPanel" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D75616371B5A00A003E9 /* Debug */,
+				E550D75716371B5A00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D77016371B6300A003E9 /* Build configuration list for PBXNativeTarget "PreferencePanel" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D77116371B6300A003E9 /* Debug */,
+				E550D77216371B6300A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D78C16371B6A00A003E9 /* Build configuration list for PBXNativeTarget "QuickLook" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D78D16371B6A00A003E9 /* Debug */,
+				E550D78E16371B6A00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D7A316371B7100A003E9 /* Build configuration list for PBXNativeTarget "ScreenSaver" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D7A416371B7100A003E9 /* Debug */,
+				E550D7A516371B7100A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D7BE16371B7A00A003E9 /* Build configuration list for PBXNativeTarget "SpotLightImporter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D7BF16371B7A00A003E9 /* Debug */,
+				E550D7C016371B7A00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D7D716371B9000A003E9 /* Build configuration list for PBXNativeTarget "AutomatorAction" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D7D816371B9000A003E9 /* Debug */,
+				E550D7D916371B9000A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D7EB16371B9800A003E9 /* Build configuration list for PBXNativeTarget "AddressBookPlugIn" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D7EC16371B9800A003E9 /* Debug */,
+				E550D7ED16371B9800A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D80816371BA500A003E9 /* Build configuration list for PBXNativeTarget "InstallerPlugIn" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D80916371BA500A003E9 /* Debug */,
+				E550D80A16371BA500A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D82016371BAF00A003E9 /* Build configuration list for PBXNativeTarget "QuartzComposerPlugIn" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D82116371BAF00A003E9 /* Debug */,
+				E550D82216371BAF00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D83416371BC500A003E9 /* Build configuration list for PBXNativeTarget "CocoaFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D83516371BC500A003E9 /* Debug */,
+				E550D83616371BC500A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D84316371BCA00A003E9 /* Build configuration list for PBXNativeTarget "Library" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D84416371BCA00A003E9 /* Debug */,
+				E550D84516371BCA00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D85316371BD000A003E9 /* Build configuration list for PBXNativeTarget "Bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D85416371BD000A003E9 /* Debug */,
+				E550D85516371BD000A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D86516371BD700A003E9 /* Build configuration list for PBXNativeTarget "XPCServic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D86616371BD700A003E9 /* Debug */,
+				E550D86716371BD700A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D86D16371BE100A003E9 /* Build configuration list for PBXNativeTarget "C/C++ Library" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D86E16371BE100A003E9 /* Debug */,
+				E550D86F16371BE100A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D87E16371BEE00A003E9 /* Build configuration list for PBXNativeTarget "STL C++ Library" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D87F16371BEE00A003E9 /* Debug */,
+				E550D88016371BEE00A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D89E16371C0700A003E9 /* Build configuration list for PBXNativeTarget "CocoaAppleScriptApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D89F16371C0700A003E9 /* Debug */,
+				E550D8A016371C0700A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D8AF16371C1000A003E9 /* Build configuration list for PBXNativeTarget "CommandLineTool" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D8B016371C1000A003E9 /* Debug */,
+				E550D8B116371C1000A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D8EF16371C1800A003E9 /* Build configuration list for PBXNativeTarget "MacRubyApplicationImporter" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D8F016371C1800A003E9 /* Debug */,
+				E550D8F116371C1800A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D8F216371C1800A003E9 /* Build configuration list for PBXNativeTarget "MacRubyApplication" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D8F316371C1800A003E9 /* Debug */,
+				E550D8F416371C1800A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E550D8F516371C1800A003E9 /* Build configuration list for PBXLegacyTarget "Deployment" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E550D8F616371C1800A003E9 /* Debug */,
+				E550D8F716371C1800A003E9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		E52523AB16245A910012E2BA /* CPDocument.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				E52523AC16245A910012E2BA /* CPDocument.xcdatamodel */,
+			);
+			currentVersion = E52523AC16245A910012E2BA /* CPDocument.xcdatamodel */;
+			name = CPDocument.xcdatamodeld;
+			path = "Cocoa Application/CPDocument.xcdatamodeld";
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		E525241116245AB20012E2BA /* iOS_application.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				E525241216245AB20012E2BA /* iOS_application.xcdatamodel */,
+			);
+			currentVersion = E525241216245AB20012E2BA /* iOS_application.xcdatamodel */;
+			path = iOS_application.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		E5D464AB163578AC006A4730 /* Tools_version.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				E5D464AC163578AC006A4730 /* Tools_version.xcdatamodel */,
+			);
+			currentVersion = E5D464AC163578AC006A4730 /* Tools_version.xcdatamodel */;
+			name = Tools_version.xcdatamodeld;
+			path = "Cocoa Application/Tools_version.xcdatamodeld";
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		E5D464AE163578C7006A4730 /* Deployment_target.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				E5D464AF163578C7006A4730 /* Deployment_target.xcdatamodel */,
+			);
+			currentVersion = E5D464AF163578C7006A4730 /* Deployment_target.xcdatamodel */;
+			name = Deployment_target.xcdatamodeld;
+			path = "Cocoa Application/Deployment_target.xcdatamodeld";
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+		E5D464B216357954006A4730 /* Version_identifier.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				E5D464B316357954006A4730 /* Version_identifier.xcdatamodel */,
+			);
+			currentVersion = E5D464B316357954006A4730 /* Version_identifier.xcdatamodel */;
+			path = Version_identifier.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = E525238316245A900012E2BA /* Project object */;
+}

--- a/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Cocoa Application.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/Cocoa Application.xcscheme
+++ b/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/Cocoa Application.xcscheme
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E525238B16245A900012E2BA"
+               BuildableName = "Cocoa Application.app"
+               BlueprintName = "Cocoa Application"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E52523B216245A910012E2BA"
+               BuildableName = "Cocoa ApplicationTests.octest"
+               BlueprintName = "Cocoa ApplicationTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E525238B16245A900012E2BA"
+            BuildableName = "Cocoa Application.app"
+            BlueprintName = "Cocoa Application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "YES"
+      ignoresPersistentStateOnLaunch = "YES"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E525238B16245A900012E2BA"
+            BuildableName = "Cocoa Application.app"
+            BlueprintName = "Cocoa Application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "Some argument"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "Some Environment Variable"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "DYLD_INSERT_LIBRARIES"
+            value = "/usr/lib/libgmalloc.dylib"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "DYLD_PRINT_LIBRARIES"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "USERBREAK"
+            value = "1"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "DYLD_PRINT_APIS"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "NSDOLoggingEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "AUTO_LOG_ALL"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocGuardEdges"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "MallocScribble"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E525238B16245A900012E2BA"
+            BuildableName = "Cocoa Application.app"
+            BlueprintName = "Cocoa Application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
+++ b/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E52523F316245AB20012E2BA"
+               BuildableName = "iOS application.app"
+               BlueprintName = "iOS application"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "806F6FB517EFAF46001051EE"
+               BuildableName = "libiOS staticLibrary.a"
+               BlueprintName = "iOS staticLibrary"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "806F6FC217EFAF47001051EE"
+               BuildableName = "iOS staticLibraryTests.xctest"
+               BlueprintName = "iOS staticLibraryTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E525241E16245AB20012E2BA"
+               BuildableName = "iOS applicationTests.octest"
+               BlueprintName = "iOS applicationTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "806F6FC217EFAF47001051EE"
+               BuildableName = "iOS staticLibraryTests.xctest"
+               BlueprintName = "iOS staticLibraryTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
+++ b/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E52523F316245AB20012E2BA"
+               BuildableName = "iOS application.app"
+               BlueprintName = "iOS application"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E525241E16245AB20012E2BA"
+               BuildableName = "iOS applicationTests.octest"
+               BlueprintName = "iOS applicationTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E52523F316245AB20012E2BA"
+            BuildableName = "iOS application.app"
+            BlueprintName = "iOS application"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
+++ b/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E525241E16245AB20012E2BA"
+               BuildableName = "iOS applicationTests.octest"
+               BlueprintName = "iOS applicationTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E525241E16245AB20012E2BA"
+               BuildableName = "iOS applicationTests.octest"
+               BlueprintName = "iOS applicationTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E525241E16245AB20012E2BA"
+            BuildableName = "iOS applicationTests.octest"
+            BlueprintName = "iOS applicationTests"
+            ReferencedContainer = "container:Cocoa Application.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
+++ b/spec/fixtures/Cocoa Application With productRefGroup.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E525241E16245AB20012E2BA"
+               BuildableName = "iOS applicationTests.octest"
+               BlueprintName = "iOS applicationTests"
+               ReferencedContainer = "container:Cocoa Application.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -102,6 +102,17 @@ module ProjectSpecs
         @project.root_object.referrers.should.include?(@project)
       end
 
+      it 'does not initialize the root object products group for projects that already have a root project group' do
+        expected_product_ref_group_uuid = 'D5DE4A8C17D611E20001B687'
+        path = fixture_path('Cocoa Application With productRefGroup.xcodeproj')
+        project = Xcodeproj::Project.open(path)
+
+        product_ref_group = project.root_object.product_ref_group
+        product_ref_group.should.not.nil?
+        product_ref_group.uuid.should == expected_product_ref_group_uuid
+        product_ref_group.class.should == PBXGroup
+      end
+
       it 'initializes the root object products group also from projects that don\'t have an explicit reference' do
         path = fixture_path('Cocoa Application Without productRefGroup.xcodeproj')
         project = Xcodeproj::Project.open(path)


### PR DESCRIPTION
Buddybuild uses xcodeproj against thousands of xcode projects, and there are a few we’ve noticed issues with as a result of this commit:

36ad554b Fixes issue CocoaPods/Xcodeproj#409

The problem is that xcodeproj was actually significantly altering the structure of a project if it already has a product_ref_group defined and it wasn’t a “Products” main group.

This would resultantly lead to fatal failures when we attempt to build the project.