### PR TITLE
Associated changelog entry to the correct version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@
 * Fix regression resulting in projects existing product ref groups being altered  
   [Rashin Arab](https://github.com/rasharab)
   [#429](https://github.com/CocoaPods/Xcodeproj/pull/429)
-
+  
+* Fixed handling of xcdatamodeld packages in subfolders.  
+  [Simon Seyer](https://github.com/Eldorado234)
+  [#427](https://github.com/CocoaPods/Xcodeproj/pull/427)
 
 ## 1.3.2 (2016-10-10)
 
@@ -24,10 +27,6 @@
 * Cover more cases of the Dir.chdir breakages.  
   [Danielle Tomlinson](https://github.com/dantoml)
   [#421](https://github.com/CocoaPods/Xcodeproj/pull/421)
-
-* Fixed handling of xcdatamodeld packages in subfolders.  
-  [Simon Seyer](https://github.com/Eldorado234)
-  [#427](https://github.com/CocoaPods/Xcodeproj/pull/427)
 
 ## 1.3.1 (2016-09-10)
 


### PR DESCRIPTION
Probably when merging the PR the changelog entry got associated with `1.3.2` in the changelog even though it is not released so far.