### PR TITLE
Add missing file extensions for target types

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -137,6 +137,9 @@ module Xcodeproj
       :bundle           => 'bundle',
       :octest_bundle    => 'octest',
       :unit_test_bundle => 'xctest',
+      :app_extension    => 'appex',
+      :watch2_extension => 'appex',
+      :watch2_app       => 'app',
     }.freeze
 
     # @return [Hash] The common build settings grouped by platform, and build


### PR DESCRIPTION
Currently if xcodeproj doesn't have an entry in this hash for a specific
target type, it generates a target like `Foo.` where it is missing the
extension. This change adds the extensions for a few more target types.