### PR TITLE
Better error message when a target_dependency is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Better error message when a target_dependency is invalid.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#448](https://github.com/CocoaPods/Xcodeproj/pull/448)
 
 ##### Bug Fixes
 

--- a/lib/xcodeproj/project/object/target_dependency.rb
+++ b/lib/xcodeproj/project/object/target_dependency.rb
@@ -51,7 +51,8 @@ module Xcodeproj
         def native_target_uuid
           return target.uuid if target
           return target_proxy.remote_global_id_string if target_proxy
-          raise 'Expected target or target_proxy, from which to fetch a uuid'
+          raise "Expected target or target_proxy, from which to fetch a uuid for target '#{display_name}'." \
+            "Find and clear the PBXTargetDependency entry with uuid '#{@uuid}' in your .xcodeproj."
         end
 
         # @note This override is necessary because Xcode allows for circular

--- a/spec/project/object/target_dependency_spec.rb
+++ b/spec/project/object/target_dependency_spec.rb
@@ -86,11 +86,13 @@ module ProjectSpecs
       end
 
       it "raises if target and target_proxy aren't set" do
+        @target_dependency.name = 'TargetName'
         @target_dependency.target.nil?.should == true
         @target_dependency.target_proxy.nil?.should == true
         should.raise do
           @target_dependency.native_target_uuid
-        end.message.should.match /Expected target or target_proxy, from which to fetch a uuid/
+        end.message.should.include "Expected target or target_proxy, from which to fetch a uuid for target 'TargetName'." \
+          "Find and clear the PBXTargetDependency entry with uuid '#{@target_dependency.uuid}' in your .xcodeproj."
       end
     end
   end


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/5985