### PR TITLE
Add `command_line_arguments` to `TestAction`

### DIFF
--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -101,6 +101,24 @@ module Xcodeproj
         env_vars
       end
 
+      # @todo handle 'AdditionalOptions' tag
+
+      # @return [CommandLineArguments]
+      #         Returns the CommandLineArguments that will be passed at app launch
+      #
+      def command_line_arguments
+        CommandLineArguments.new(@xml_element.elements[XCScheme::COMMAND_LINE_ARGS_NODE])
+      end
+
+      # @return [CommandLineArguments] arguments
+      #         Sets the CommandLineArguments that will be passed at app launch
+      #
+      def command_line_arguments=(arguments)
+        @xml_element.delete_element(XCScheme::COMMAND_LINE_ARGS_NODE)
+        @xml_element.add_element(arguments.xml_element) if arguments
+        arguments
+      end
+
       #-------------------------------------------------------------------------#
 
       class TestableReference < XMLElementWrapper


### PR DESCRIPTION
The documentation for `CommandLineArguments` says
> It can either appear on a LaunchAction or TestAction scheme group.

yet, it wasn't included on `TestAction`. This just adds the same code that is defined in `LaunchAction`.