### PR TITLE
[Plist] Correct auto-load for CFPropertyList

### DIFF
--- a/lib/xcodeproj/plist.rb
+++ b/lib/xcodeproj/plist.rb
@@ -1,5 +1,5 @@
 autoload :Nanaimo, 'nanaimo'
-autoload :CFPropertyList, 'cfpropertylist'
+autoload :CFPropertyList, 'CFPropertyList'
 
 module Xcodeproj
   # Provides support for loading and serializing property list files.


### PR DESCRIPTION
The file is actually capitalized, so this will now work on case-sensitive file systems