### PR TITLE
Change return value of adding system framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Return file references when adding system frameworks to a target.  
+  [Keith Smiley](https://github.com/keith)
+  [#466](https://github.com/CocoaPods/Xcodeproj/pull/466)
+
 * Add more Xcode file type references by file extension.  
   [Keith Smiley](https://github.com/keith)
   [#465](https://github.com/CocoaPods/Xcodeproj/pull/465)

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -305,10 +305,11 @@ module Xcodeproj
         #         this reason the new Xcodeproj behaviour is to add the
         #         frameworks in a subgroup according to the platform.
         #
-        # @return [void]
+        # @return [Array<PBXFileReference>] An array of the newly created file
+        #         references.
         #
         def add_system_framework(names)
-          Array(names).each do |name|
+          Array(names).map do |name|
             case platform_name
             when :ios
               group = project.frameworks_group['iOS'] || project.frameworks_group.new_group('iOS')

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -445,6 +445,11 @@ module ProjectSpecs
           names = @target.frameworks_build_phase.file_display_names
           names.should == ['CoreData.framework', 'QuartzCore.framework']
         end
+
+        it 'returns the newly created file references' do
+          references = @target.add_system_frameworks(%w(CoreData QuartzCore))
+          references.map(&:display_name).should == ['CoreData.framework', 'QuartzCore.framework']
+        end
       end
 
       #----------------------------------------#


### PR DESCRIPTION
Previously it looked like this function was intending to return a file
reference of the newly created framework, but instead it was returning
the original array of strings. This change returns the array of file
references so consumers can manipulate them as needed.