### PR TITLE
PBXReferenceProxy: Add display_name attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 
 ##### Bug Fixes
 
-* None.  
+* Reference proxy display name always returns "ReferenceProxy".
+  Behavior corrected to return the name or path of the reference.  
+  [Barak Weiss](https://github.com/barakwei)
+  [#472](https://github.com/CocoaPods/Xcodeproj/issues/472)
 
 
 ## 1.4.2 (2016-12-19)

--- a/lib/xcodeproj/project/object/reference_proxy.rb
+++ b/lib/xcodeproj/project/object/reference_proxy.rb
@@ -52,6 +52,15 @@ module Xcodeproj
         def ascii_plist_annotation
           " #{name || path && File.basename(path)} "
         end
+
+        # @return [String] A name suitable for displaying the object to the
+        #         user.
+        #
+        def display_name
+          return name if name
+          return path if path
+          super
+        end
       end
     end
   end

--- a/spec/project/object/reference_proxy_spec.rb
+++ b/spec/project/object/reference_proxy_spec.rb
@@ -9,5 +9,20 @@ module ProjectSpecs
     it 'returns whether it is a proxy' do
       @proxy.proxy?.should == true
     end
+
+    it 'returns default display_name if path or name are not set' do
+      @proxy.display_name.should == 'ReferenceProxy'
+    end
+
+    it 'returns name for display_name if name is set' do
+      @proxy.name = 'NiceProxy'
+      @proxy.path = 'Path/To/Proxy'
+      @proxy.display_name.should == 'NiceProxy'
+    end
+
+    it 'returns path for display_name if path is set and name is not set' do
+      @proxy.path = 'Path/To/Proxy'
+      @proxy.display_name.should == 'Path/To/Proxy'
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a bug that when a reference proxy doesn't have a name, it's display name doesn't fall back to "ReferenceProxy" but to the path.
This is manifested if you have a framework object in your project and it's referenced (usually by a build file) in a build phase. In this case, the display name was "ReferenceProxy" and not "XXX.framework".
Fixes #472