### PR TITLE
Added "inherited" to SWIFT_ACTIVE_COMPILATION_CONDITIONS in Swift debug.

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -200,7 +200,7 @@ module Xcodeproj
       }.freeze,
       [:debug, :swift] => {
         'SWIFT_OPTIMIZATION_LEVEL'            => '-Onone',
-        'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => 'DEBUG',
+        'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => ['$(inherited)', 'DEBUG'],
       }.freeze,
       [:release, :swift] => {
         'SWIFT_OPTIMIZATION_LEVEL'          => '-Owholemodule',


### PR DESCRIPTION
By adding `$(inherited)`, this should no longer override all `SWIFT_ACTIVE_COMPILATION_CONDITIONS` when building in Swift debug. 
This fixes #478.