### PR TITLE
Shallow fix for 'Uncaught exception: undefined method `isa'...'

### DIFF
--- a/lib/xcodeproj/project/object/configuration_list.rb
+++ b/lib/xcodeproj/project/object/configuration_list.rb
@@ -98,7 +98,11 @@ module Xcodeproj
         #---------------------------------------------------------------------#
 
         def ascii_plist_annotation
-          " Build configuration list for #{target.isa} \"#{target}\" "
+          if target.respond_to?(:isa)
+            " Build configuration list for #{target.isa} \"#{target}\" "
+          else
+            $stderr.puts "#{uuid} was not found, target doesn't respond to `isa`."
+          end
         end
       end
     end


### PR DESCRIPTION
As I was experimenting with Xcodeproj I found an error that others did too. In #462 @oscahie provided a quick fix for but I want to get to the bottom of this issue. (Might also relate to #470.)

Here is a minimal script and the result.
```ruby
require 'xcodeproj'

project = Xcodeproj::Project.new("test.xcodeproj")
project.initialize_from_scratch

project.save
```

```
/Users/farkasseb/.gems/gems/xcodeproj-1.4.4/lib/xcodeproj/project/object/configuration_list.rb:102:in `ascii_plist_annotation': undefined method `isa' for nil:NilClass (NoMethodError)
  from /Users/farkasseb/.gems/gems/xcodeproj-1.4.4/lib/xcodeproj/project.rb:286:in `block in to_ascii_plist'
  from /Users/farkasseb/.gems/gems/xcodeproj-1.4.4/lib/xcodeproj/project.rb:285:in `each'
  from /Users/farkasseb/.gems/gems/xcodeproj-1.4.4/lib/xcodeproj/project.rb:285:in `to_ascii_plist'
  from /Users/farkasseb/.gems/gems/xcodeproj-1.4.4/lib/xcodeproj/project.rb:353:in `block in save'
  from /Users/farkasseb/.gems/gems/xcodeproj-1.4.4/lib/xcodeproj/project.rb:353:in `open'
  from /Users/farkasseb/.gems/gems/xcodeproj-1.4.4/lib/xcodeproj/project.rb:353:in `save'
  from /Users/farkasseb/Desktop/XcodeprojTest/test.rb:6:in `<top (required)>'
  from -e:1:in `load'
  from -e:1:in `<main>'
```

This pull request only contains a shallow/quick fix. Could you please help me find the root of the problem?