### PR TITLE
Add test reference to xcscheme if target is of type test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add test reference to xcscheme if target is of type test  
+  [Dimitris Koutsogiorga](https://github.com/dnkoutso)
+  [#485](https://github.com/CocoaPods/Xcodeproj/pull/485)
+
 * Make build settings parsing optionally take into account any associated xcconfig files.  
   [Renzo Crisóstomo](https://github.com/ruenzuo)
   [#180](https://github.com/CocoaPods/Xcodeproj/pull/180)

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -809,6 +809,7 @@ module Xcodeproj
       targets.each do |target|
         scheme = XCScheme.new
         scheme.add_build_target(target)
+        scheme.add_test_target(target) if target.symbol_type == :ui_test_bundle || target.symbol_type == :unit_test_bundle
         scheme.save_as(path, target.name, false)
         xcschememanagement['SchemeUserState']["#{target.name}.xcscheme"] = {}
         xcschememanagement['SchemeUserState']["#{target.name}.xcscheme"]['isShown'] = visible

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -622,6 +622,32 @@ module ProjectSpecs
           plist = Plist.read_from_path(manifest.to_s)
           plist['SchemeUserState']['Xcode.xcscheme']['isShown'].should == false
         end
+
+        it 'adds test target to scheme for ui test bundle' do
+          sut = Xcodeproj::Project.new(SpecHelper.temporary_directory + 'Pods.xcodeproj')
+          sut.new_target(:application, 'Xcode', :ios)
+          sut.new_target(:ui_test_bundle, 'XcodeTests', :ios)
+          sut.recreate_user_schemes(false)
+          schemes_dir = sut.path + "xcuserdata/#{ENV['USER']}.xcuserdatad/xcschemes"
+          schemes_dir.children.map { |f| f.basename.to_s }.sort.should == ['Xcode.xcscheme', 'XcodeTests.xcscheme', 'xcschememanagement.plist']
+          test_scheme = @scheme = Xcodeproj::XCScheme.new(schemes_dir + 'XcodeTests.xcscheme')
+          test_scheme.test_action.testables.count.should == 1
+          test_scheme.test_action.testables.first.buildable_references.count.should == 1
+          test_scheme.test_action.testables.first.buildable_references.first.target_name.should == 'XcodeTests'
+        end
+
+        it 'adds test target to scheme for unit test bundle' do
+          sut = Xcodeproj::Project.new(SpecHelper.temporary_directory + 'Pods.xcodeproj')
+          sut.new_target(:application, 'Xcode', :ios)
+          sut.new_target(:unit_test_bundle, 'XcodeTests', :ios)
+          sut.recreate_user_schemes(false)
+          schemes_dir = sut.path + "xcuserdata/#{ENV['USER']}.xcuserdatad/xcschemes"
+          schemes_dir.children.map { |f| f.basename.to_s }.sort.should == ['Xcode.xcscheme', 'XcodeTests.xcscheme', 'xcschememanagement.plist']
+          test_scheme = @scheme = Xcodeproj::XCScheme.new(schemes_dir + 'XcodeTests.xcscheme')
+          test_scheme.test_action.testables.count.should == 1
+          test_scheme.test_action.testables.first.buildable_references.count.should == 1
+          test_scheme.test_action.testables.first.buildable_references.first.target_name.should == 'XcodeTests'
+        end
       end
     end
 


### PR DESCRIPTION
This came up from working on https://github.com/CocoaPods/Core/pull/369.

The xcscheme generated does not allow pressing CMD+U because the target is not added as a test reference.