### PR TITLE
Provides narrower regex for conflict marker detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Narrows regex for SCM conflict marker detection
+  [allenhumphreys](https://github.com/allenhumphreys)
+  [#495](https://github.com/CocoaPods/Xcodeproj/pull/495)
 
 ## 1.5.0 (2017-06-06)
 

--- a/lib/xcodeproj/plist.rb
+++ b/lib/xcodeproj/plist.rb
@@ -77,11 +77,18 @@ module Xcodeproj
 
     # @return [Bool] Checks whether there are merge conflicts in the file.
     #
-    # @param  [#to_s] path
+    # @param  [#to_s] contents
     #         The contents of the file.
     #
     def self.file_in_conflict?(contents)
-      contents.match(/^(<|=|>){7}/)
+      conflict_regex = /
+        ^<{7}(?!<) # Exactly 7 left arrows at the beginning of the line
+        [\w\W]* # Anything
+        ^={7}(?!=) # Exactly 7 equality symbols at the beginning of the line
+        [\w\W]* # Anything
+        ^>{7}(?!>) # Exactly 7 right arrows at the beginning of the line
+      /xm
+      contents.match(conflict_regex)
     end
   end
 end

--- a/spec/plist_helper_spec.rb
+++ b/spec/plist_helper_spec.rb
@@ -166,6 +166,21 @@ EOS
           Plist.write_to_path({}, '')
         end.should.raise IOError
       end
+
+      it 'raises when a merge conflict is detected' do
+        path = 'Sample Project/ProjectInMergeConflict/ProjectInMergeConflict.xcodeproj'
+        lambda do
+          Plist.read_from_path(path)
+        end.should.raise(Xcodeproj::Informative)
+      end
+
+      it 'has reasonably strict detection of conflict markers' do
+        very_similar = "\n<<<<<<<<\nwords and stuff go here\n========\nother, different words go here\n>>>>>>>>"
+        Plist.write_to_path({ 'FooterText' => very_similar }, @plist)
+        lambda do
+          Plist.read_from_path(@plist)
+        end.should.not.raise
+      end
     end
   end
 end


### PR DESCRIPTION
I recently ran into a situation when parsing the acknowledgements file within my Podfile. One of the pods (libidn v1.33) has the following in their license:

```
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
THE SOFTWARE.

===============================================

Libidn COPYING -- Explanation of licensing conditions.
Copyright (C) 2002-2015 Simon Josefsson
```

The regex currently used in `file_in_conflict` is detecting this section separator as a merge conflict, thus `Plist.read_from_path` is refusing to open the file.

I'm proposing a new regex for matching the entire conflict marker sequence which is:
1. beginning of line, followed by exactly 7 left angle brackets
2. any characters
3. beginning of line followed by exactly 7 equality symbols
4. any characters
5. beginning of line followed by exactly 7 right angle brackets 

A trivial script for testing the regex
```
#!/usr/bin/env ruby

def file_in_conflict?(contents)

    contents.match(/^<{7}(?!<)[\w\W]*^={7}(?!=)[\w\W]*^>{7}(?!>)/m)
end

conflict_example = "<<<<<<< HEAD
words and stuff go here
=======
other, different words go here
>>>>>>> 8ab358aeba3f
"

if file_in_conflict?(conflict_example)
    puts "This is in conflict" # Expect this
else
    puts "This is not in conflict"
end

non_conflict_example = "<<<<<<<<
words and stuff go here
========
other, different words go here
>>>>>>>>
"

if file_in_conflict?(non_conflict_example)
    puts "This is in conflict"
else
    puts "This is not in conflict" # Expect this
end
```