### PR TITLE
Don’t share build settings between resources bundle configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Don’t share build settings between resources bundle configurations  
+  [jmesmith](https://github.com/jmesmith)
+  [#502](https://github.com/CocoaPods/Xcodeproj/pull/502)
 
 ## 1.5.1 (2017-07-19)
 

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -95,18 +95,16 @@ module Xcodeproj
         target.product_name = name
         target.product_type = Constants::PRODUCT_TYPE_UTI[:bundle]
 
-        build_settings = common_build_settings(nil, platform, nil, target.product_type)
-
         # Configuration List
         cl = project.new(XCConfigurationList)
         cl.default_configuration_is_visible = '0'
         cl.default_configuration_name = 'Release'
         release_conf = project.new(XCBuildConfiguration)
         release_conf.name = 'Release'
-        release_conf.build_settings = build_settings
+        release_conf.build_settings = common_build_settings(nil, platform, nil, target.product_type)
         debug_conf = project.new(XCBuildConfiguration)
         debug_conf.name = 'Debug'
-        debug_conf.build_settings = build_settings
+        debug_conf.build_settings = common_build_settings(nil, platform, nil, target.product_type)
         cl.build_configurations << release_conf
         cl.build_configurations << debug_conf
         target.build_configuration_list = cl

--- a/spec/project/project_helper_spec.rb
+++ b/spec/project/project_helper_spec.rb
@@ -99,6 +99,8 @@ module ProjectSpecs
         target.build_configuration_list.should.not.be.nil
         configurations = target.build_configuration_list.build_configurations
         configurations.map(&:name).sort.should == %w(Debug Release)
+        configurations[0].build_settings.should.not.equal? configurations[1].build_settings
+
         build_settings = configurations.first.build_settings
         build_settings['SDKROOT'].should == 'iphoneos'
         build_settings['PRODUCT_NAME'].should == '$(TARGET_NAME)'


### PR DESCRIPTION
`build_settings` are shared between debug and release build configurations in resource bundle targets. This means you can't change build settings in a resource bundle target on a per-configuration basis. This change assigns distinct `build_settings` to each build configuration.