### PR TITLE
Verify container portal when checking target membership.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Verify container portal when checking dependency target membership.  
+  [izaakschroeder](https://github.com/izaakschroeder)
+  [#513](https://github.com/CocoaPods/Xcodeproj/issues/513)
 
 
 ## 1.5.3 (2017-10-24)

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -264,7 +264,9 @@ module Xcodeproj
         def dependency_for_target(target)
           dependencies.find do |dep|
             if dep.target_proxy.remote?
-              dep.target_proxy.remote_global_id_string == target.uuid
+              subproject_reference = project.reference_for_path(target.project.path)
+              uuid = subproject_reference.uuid if subproject_reference
+              dep.target_proxy.remote_global_id_string == target.uuid && dep.target_proxy.container_portal == uuid
             else
               dep.target == target
             end

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -447,6 +447,23 @@ module ProjectSpecs
           @target.add_dependency(dependency_target)
           @target.dependencies.count.should == 1
         end
+
+        it 'adds duplicate cross-dependencies' do
+          group = @project.new_group('SubProjects')
+          unknown_project1 = Xcodeproj::Project.new(temporary_directory + 'OtherProject1.xcodeproj')
+          unknown_project2 = Xcodeproj::Project.new(temporary_directory + 'OtherProject2.xcodeproj')
+          cross_target1 = unknown_project1.new_target(:static_library, 'SubTarget1', :ios)
+          cross_target2 = unknown_project2.new_target(:static_library, 'SubTarget2', :ios)
+          cross_target2.instance_variable_set(:@uuid, cross_target1.uuid)
+          cross_target1.uuid.should == cross_target2.uuid
+          unknown_project1.save
+          unknown_project2.save
+          group.new_file(unknown_project1.path)
+          group.new_file(unknown_project2.path)
+          @target.add_dependency(cross_target1)
+          @target.add_dependency(cross_target2)
+          @target.dependencies.count.should == 2
+        end
       end
 
       describe '#dependency_for_target' do


### PR DESCRIPTION
If you have a project that has several sub-projects and those sub-projects have been generated by copy-pasting the `.xcodeproj` file (*cough* `react-native` libs *cough*) you'll have the same target UUIDs _but_ different project UUIDs. This causes `dependency_for_target` to fail because it does not verify project membership – only target UUID. The change here allows for the case where a project may have identical target UUIDs but different project UUIDs. Esoteric case I know, but it exists :)

Fairly new to this project and not really a rubyist, so any feedback is welcome. 😄 