### PR TITLE
Added RemoteRunnable wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,9 @@
 
 ##### Enhancements
 
-* None.  
+* Added RemoteRunnable wrapper to achieve Apple Watch compatibility  
+  [Eldorado234](https://github.com/Eldorado234)
+  [#518](https://github.com/CocoaPods/CocoaPods/issues/518)
 
 ##### Bug Fixes
 

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -8,6 +8,7 @@ require 'xcodeproj/scheme/analyze_action'
 require 'xcodeproj/scheme/archive_action'
 
 require 'xcodeproj/scheme/buildable_product_runnable'
+require 'xcodeproj/scheme/remote_runnable'
 require 'xcodeproj/scheme/buildable_reference'
 require 'xcodeproj/scheme/macro_expansion'
 

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -8,9 +8,9 @@ require 'xcodeproj/scheme/analyze_action'
 require 'xcodeproj/scheme/archive_action'
 
 require 'xcodeproj/scheme/buildable_product_runnable'
-require 'xcodeproj/scheme/remote_runnable'
 require 'xcodeproj/scheme/buildable_reference'
 require 'xcodeproj/scheme/macro_expansion'
+require 'xcodeproj/scheme/remote_runnable'
 
 module Xcodeproj
   # This class represents a Scheme document represented by a ".xcscheme" file

--- a/lib/xcodeproj/scheme/remote_runnable.rb
+++ b/lib/xcodeproj/scheme/remote_runnable.rb
@@ -1,0 +1,92 @@
+module Xcodeproj
+  class XCScheme
+    # This class wraps the RemoteRunnable node of a .xcscheme XML file
+    #
+    # A RemoteRunnable is a product that is both buildable
+    # (it contains a BuildableReference) and
+    # runnable remotely (it can be launched and debugged on a remote device, i.e. an Apple Watch)
+    #
+    class RemoteRunnable < XMLElementWrapper
+      # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
+      #        Either the Xcode target to reference,
+      #        or an existing XML 'RemoteRunnable' node element to reference
+      #        or nil to create an new, empty RemoteRunnable
+      #
+      # @param [#to_s] runnable_debugging_mode
+      #        The debugging mode (usually '2')
+      #
+      # @param [#to_s] bundle_identifier
+      #        The bundle identifier (usually 'com.apple.Carousel')
+      #
+      # @param [#to_s] remote_path
+      #        The remote path (not required, unknown usage)
+      #
+      def initialize(target_or_node = nil, runnable_debugging_mode = nil, bundle_identifier = nil, remote_path = nil)
+        create_xml_element_with_fallback(target_or_node, 'RemoteRunnable') do
+          self.buildable_reference = BuildableReference.new(target_or_node) if target_or_node
+          @xml_element.attributes['runnableDebuggingMode'] = runnable_debugging_mode.to_s if runnable_debugging_mode
+          @xml_element.attributes['BundleIdentifier'] = bundle_identifier.to_s if bundle_identifier
+          @xml_element.attributes['RemotePath'] = remote_path.to_s if remote_path
+        end
+      end
+
+      # @return [String]
+      #         The runnable debugging mode (usually '2')
+      #
+      def runnable_debugging_mode
+        @xml_element.attributes['runnableDebuggingMode']
+      end
+
+      # @param [String] value
+      #        Set the runnable debugging mode
+      #
+      def runnable_debugging_mode=(value)
+        @xml_element.attributes['runnableDebuggingMode'] = value.to_s
+      end
+
+      # @return [String]
+      #         The runnable bundle identifier (usually 'com.apple.Carousel')
+      #
+      def bundle_identifier
+        @xml_element.attributes['BundleIdentifier']
+      end
+
+      # @param [String] value
+      #        Set the runnable bundle identifier
+      #
+      def bundle_identifier=(value)
+        @xml_element.attributes['BundleIdentifier'] = value.to_s
+      end
+
+      # @return [String]
+      #         The runnable remote path (not required, unknown usage)
+      #
+      def remote_path
+        @xml_element.attributes['RemotePath']
+      end
+
+      # @param [String] value
+      #        Set the runnable remote path
+      #
+      def remote_path=(value)
+        @xml_element.attributes['RemotePath'] = value.to_s
+      end
+
+      # @return [BuildableReference]
+      #         The buildable reference this remote runnable is gonna build and run
+      #
+      def buildable_reference
+        @buildable_reference ||= BuildableReference.new @xml_element.elements['BuildableReference']
+      end
+
+      # @param [BuildableReference] ref
+      #        Set the buildable reference this remote runnable is gonna build and run
+      #
+      def buildable_reference=(ref)
+        @xml_element.delete_element('BuildableReference')
+        @xml_element.add_element(ref.xml_element)
+        @buildable_reference = ref
+      end
+    end
+  end
+end

--- a/spec/scheme/remote_runnable_spec.rb
+++ b/spec/scheme/remote_runnable_spec.rb
@@ -1,0 +1,88 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::RemoteRunnable do
+    describe 'Created from scratch' do
+      it 'Creates an initial, empty XML node' do
+        bpr = Xcodeproj::XCScheme::RemoteRunnable.new(nil)
+        bpr.xml_element.name.should == 'RemoteRunnable'
+        bpr.xml_element.attributes.count.should == 0
+        bpr.xml_element.elements.count.should == 0
+      end
+
+      it 'Creates an initial, empty XML node with runnableDebuggingMode' do
+        bpr = Xcodeproj::XCScheme::RemoteRunnable.new(nil, 2)
+        bpr.xml_element.name.should == 'RemoteRunnable'
+        bpr.xml_element.attributes.count.should == 1
+        bpr.xml_element.attributes['runnableDebuggingMode'].should == '2'
+        bpr.xml_element.elements.count.should == 0
+      end
+
+      it 'Creates an initial, empty XML node with BundleIdentifier' do
+        bpr = Xcodeproj::XCScheme::RemoteRunnable.new(nil, nil, 'com.apple.Carousel')
+        bpr.xml_element.name.should == 'RemoteRunnable'
+        bpr.xml_element.attributes.count.should == 1
+        bpr.xml_element.attributes['BundleIdentifier'].should == 'com.apple.Carousel'
+        bpr.xml_element.elements.count.should == 0
+      end
+
+      it 'Creates an initial, empty XML node with RemotePath' do
+        bpr = Xcodeproj::XCScheme::RemoteRunnable.new(nil, nil, nil, '/Test')
+        bpr.xml_element.name.should == 'RemoteRunnable'
+        bpr.xml_element.attributes.count.should == 1
+        bpr.xml_element.attributes['RemotePath'].should == '/Test'
+        bpr.xml_element.elements.count.should == 0
+      end
+    end
+
+    describe 'Created from a XML node' do
+      before do
+        node = REXML::Element.new('RemoteRunnable')
+        ref = REXML::Element.new('BuildableReference')
+        node.add_element(ref)
+        @bpr = Xcodeproj::XCScheme::RemoteRunnable.new(node)
+      end
+
+      it 'raises if invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::RemoteRunnable.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
+      it '#buildable_reference' do
+        @bpr.buildable_reference.xml_element.should == @bpr.xml_element.elements['BuildableReference']
+      end
+
+      it '#buildable_reference=' do
+        other_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+        @bpr.buildable_reference = other_ref
+        @bpr.xml_element.elements.count.should == 1
+        @bpr.xml_element.elements['BuildableReference'].should == other_ref.xml_element
+      end
+    end
+
+    describe 'Created from a target' do
+      before do
+        @project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        @target = @project.new_target(:application, 'FooApp', :ios)
+        @bpr = Xcodeproj::XCScheme::RemoteRunnable.new(@target)
+      end
+
+      it 'Uses the proper XML node' do
+        @bpr.xml_element.name.should == 'RemoteRunnable'
+      end
+
+      it '#buildable_reference' do
+        @bpr.buildable_reference.xml_element.should == @bpr.xml_element.elements['BuildableReference']
+      end
+
+      it '#buildable_name=' do
+        other_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+        @bpr.buildable_reference = other_ref
+        @bpr.xml_element.elements.count.should == 1
+        @bpr.xml_element.elements['BuildableReference'].should == other_ref.xml_element
+      end
+    end
+  end
+end


### PR DESCRIPTION
This wrapper is part of a scheme and is used to run a product on a remote device (like the Apple watch) instead of on the connected device itself (as the BuildableProductRunnable does).

I wasn't able to figure out the proper value of the `RemotePath`. Apparently, it also works without defining this attribute. I checked different open source apps and I wasn't able to find any conclusive hint about what the value of this attribute should be. 