### PR TITLE
Maintain main_group annotations on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   [izaakschroeder](https://github.com/izaakschroeder)
   [#513](https://github.com/CocoaPods/Xcodeproj/issues/513)
 
+* Don't remove the main_group annotations on a save
+  [c29reid](https://github.com/c29reid)
+  [#524](https://github.com/CocoaPods/Xcodeproj/issues/524)
 
 ## 1.5.3 (2017-10-24)
 

--- a/lib/xcodeproj/project/object/group.rb
+++ b/lib/xcodeproj/project/object/group.rb
@@ -413,7 +413,7 @@ module Xcodeproj
         end
 
         def ascii_plist_annotation
-          super unless self.equal?(project.main_group)
+          super
         end
 
         # Sorts the to many attributes of the object according to the display


### PR DESCRIPTION
As described in #524 some projects have an annotation on their main_group which are being removed when the project is loaded and saved by the Xcodeproj library.

This fixes #524

I am new to this project so let me know if there's anything else I should be doing.
Thanks