### PR TITLE
Add .inl as a recognized header file ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   [Ruenzuo](https://github.com/Ruenzuo)
   [#511](https://github.com/CocoaPods/Xcodeproj/issues/511)
 
+* Add .inl as a recognized header file ending  
+  [bes](https://github.com/bes)
+  [#7283](https://github.com/CocoaPods/CocoaPods/issues/7283)
 
 ## 1.5.3 (2017-10-24)
 

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -408,7 +408,7 @@ module Xcodeproj
 
     # @return [Array] The extensions which are associated with header files.
     #
-    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .tpp .hxx .def).freeze
+    HEADER_FILES_EXTENSIONS = %w(.h .hh .hpp .ipp .tpp .hxx .def .inl).freeze
 
     # @return [Array] The keywords Xcode use to identify a build setting can
     #                 inherit values from a previous precedence level


### PR DESCRIPTION
Adding `.inl` as header files for xcode projects as discussed in https://github.com/CocoaPods/CocoaPods/issues/7283