### PR TITLE
Fixing the issue #531

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ##### Bug Fixes
 
-* Fixing the method recreate_user_scheme for targets other than type PBXNativeTarget.
+* Fixing the method recreate_user_scheme for targets other than type PBXNativeTarget.  
   [Yadir Hernandez](https://github.com/yadirhb)
   [#531](https://github.com/CocoaPods/CocoaPods/issues/531)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ##### Bug Fixes
 
+* Fixing the method recreate_user_scheme for targets other than type PBXNativeTarget.
+  [Yadir Hernandez](https://github.com/yadirhb)
+  [#531](https://github.com/CocoaPods/CocoaPods/issues/531)
+
 * Verify container portal when checking dependency target membership.  
   [izaakschroeder](https://github.com/izaakschroeder)
   [#513](https://github.com/CocoaPods/Xcodeproj/issues/513)

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -809,7 +809,7 @@ module Xcodeproj
       targets.each do |target|
         scheme = XCScheme.new
         scheme.add_build_target(target)
-        scheme.add_test_target(target) if target.test_target_type?
+        scheme.add_test_target(target) if target.instance_of?(Object::PBXNativeTarget) && target.test_target_type?
         yield scheme, target if block_given?
         scheme.save_as(path, target.name, false)
         xcschememanagement['SchemeUserState']["#{target.name}.xcscheme"] = {}

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -809,7 +809,7 @@ module Xcodeproj
       targets.each do |target|
         scheme = XCScheme.new
         scheme.add_build_target(target)
-        scheme.add_test_target(target) if target.instance_of?(Object::PBXNativeTarget) && target.test_target_type?
+        scheme.add_test_target(target) if target.respond_to?(:test_target_type?) && target.test_target_type?
         yield scheme, target if block_given?
         scheme.save_as(path, target.name, false)
         xcschememanagement['SchemeUserState']["#{target.name}.xcscheme"] = {}


### PR DESCRIPTION
Originally the code was assuming that every target had the method "test_target_type" but looking into the targets definition on file (xcodeproj/project/object/native_target.rb) I've notice that there are three target types:
1-PBXNativeTarget
2-PBXAggregateTarget
3-PBXLegacyTarget 

The only target type which defines the method "test_target_type" is PBXNativeTarget, that is why the change proposal adds the type verification check before actually call the referred method.