### PR TITLE
[Command] Ensure `--no-ansi` disables output of escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   [Ruenzuo](https://github.com/Ruenzuo)
   [#510](https://github.com/CocoaPods/Xcodeproj/issues/510)
 
+* Ensure `--no-ansi` disables output of escape sequences.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [#540](https://github.com/CocoaPods/Xcodeproj/issues/540)
+
 
 ## 1.5.4 (2017-12-16)
 

--- a/lib/xcodeproj/command.rb
+++ b/lib/xcodeproj/command.rb
@@ -18,6 +18,7 @@ module Xcodeproj
     def initialize(argv)
       super
       unless self.ansi_output?
+        Colored2.disable!
         String.send(:define_method, :colorize) { |string, _| string }
       end
     end


### PR DESCRIPTION
Closes #540.