### PR TITLE
Create a buildable reference to another project's target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Update default build settings for Xcode 9.3.  
   [Samuel Giddins](https://github.com/segiddins)
 
+* Allow to create a buildable reference to another project's target.  
+  [Simon Seyer](https://github.com/simonseyer)
+  [#543](https://github.com/CocoaPods/Xcodeproj/pull/543)
+
 ##### Bug Fixes
 
 * Save `.xcscheme` files with double-quoted strings, consistent with Xcode.  

--- a/lib/xcodeproj/scheme/buildable_reference.rb
+++ b/lib/xcodeproj/scheme/buildable_reference.rb
@@ -110,12 +110,13 @@ module Xcodeproj
       #                  the actual project directory name]"
       #
       def construct_referenced_container_uri(target, root_project = nil)
-        project = root_project || target.project
         target_project = target.project
-        path = if !project.root_object.project_dir_path.to_s.empty?
-                 project.path + project.root_object.project_dir_path
+        root_project ||= target_project
+        root_project_dir_path = root_project.root_object.project_dir_path
+        path = if !root_project_dir_path.to_s.empty?
+                 root_project.path + root_project_dir_path
                else
-                 project.path.dirname
+                 root_project.path.dirname
                end
         relative_path = target_project.path.relative_path_from(path).to_s
         relative_path = target_project.path.basename if relative_path == '.'

--- a/lib/xcodeproj/scheme/buildable_reference.rb
+++ b/lib/xcodeproj/scheme/buildable_reference.rb
@@ -10,10 +10,13 @@ module Xcodeproj
       #        Either the Xcode target to reference,
       #        or an existing XML 'BuildableReference' node element to reference
       #
-      def initialize(target_or_node)
+      # @param [Xcodeproj::Project] the root project to reference from
+      #                             (when nil the project of the target is used)
+      #
+      def initialize(target_or_node, root_project = nil)
         create_xml_element_with_fallback(target_or_node, 'BuildableReference') do
           @xml_element.attributes['BuildableIdentifier'] = 'primary'
-          set_reference_target(target_or_node, true) if target_or_node
+          set_reference_target(target_or_node, true, root_project) if target_or_node
         end
       end
 
@@ -49,13 +52,16 @@ module Xcodeproj
       # @param [Xcodeproj::Project::Object::AbstractTarget] target
       #        The target this BuildableReference refers to.
       #
+      # @param [Xcodeproj::Project] the root project to reference from
+      #                             (when nil the project of the target is used)
+      #
       # @param [Bool] override_buildable_name
       #        If true, buildable_name will also be updated by computing a name from the target
       #
-      def set_reference_target(target, override_buildable_name = false)
+      def set_reference_target(target, override_buildable_name = false, root_project = nil)
         @xml_element.attributes['BlueprintIdentifier'] = target.uuid
         @xml_element.attributes['BlueprintName'] = target.name
-        @xml_element.attributes['ReferencedContainer'] = construct_referenced_container_uri(target)
+        @xml_element.attributes['ReferencedContainer'] = construct_referenced_container_uri(target, root_project)
         self.buildable_name = construct_buildable_name(target) if override_buildable_name
       end
 
@@ -96,14 +102,23 @@ module Xcodeproj
 
       # @param [Xcodeproj::Project::Object::AbstractTarget] target
       #
+      # @param [Xcodeproj::Project] the root project to reference from
+      #                             (when nil the project of the target is used)
+      #
       # @return [String] A string in the format "container:[path to the project
       #                  file relative to the project_dir_path, always ending with
       #                  the actual project directory name]"
       #
-      def construct_referenced_container_uri(target)
-        project = target.project
-        relative_path = project.path.relative_path_from(project.path + project.root_object.project_dir_path).to_s
-        relative_path = project.path.basename if relative_path == '.'
+      def construct_referenced_container_uri(target, root_project = nil)
+        project = root_project || target.project
+        target_project = target.project
+        path = if !project.root_object.project_dir_path.to_s.empty?
+                 project.path + project.root_object.project_dir_path
+               else
+                 project.path.dirname
+               end
+        relative_path = target_project.path.relative_path_from(path).to_s
+        relative_path = target_project.path.basename if relative_path == '.'
         "container:#{relative_path}"
       end
     end

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -127,10 +127,13 @@ module Xcodeproj
         #        or an existing XML 'TestableReference' node element to reference,
         #        or nil to create an new, empty TestableReference
         #
-        def initialize(target_or_node = nil)
+        # @param [Xcodeproj::Project] the root project to reference from
+        #                             (when nil the project of the target is used)
+        #
+        def initialize(target_or_node = nil, root_project = nil)
           create_xml_element_with_fallback(target_or_node, 'TestableReference') do
             self.skipped = false
-            add_buildable_reference BuildableReference.new(target_or_node) unless target_or_node.nil?
+            add_buildable_reference BuildableReference.new(target_or_node, root_project) unless target_or_node.nil?
           end
         end
 

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -319,6 +319,15 @@ module ProjectSpecs
         buildable_ref.send(:construct_referenced_container_uri, target).should == 'container:../project_dir/Project.xcodeproj'
       end
 
+      it 'Constructs a reference to a different project correctly' do
+        project = Xcodeproj::Project.new('/project_dir/Project.xcodeproj')
+        another_project = Xcodeproj::Project.new('/another_project_dir/AnotherProject.xcodeproj')
+        target = another_project.new_target(:application, 'iOS application', :osx)
+        buildable_ref = Xcodeproj::XCScheme::BuildableReference.new(nil)
+
+        buildable_ref.send(:construct_referenced_container_uri, target, project).should == 'container:../another_project_dir/AnotherProject.xcodeproj'
+      end
+
       describe 'For iOS Application' do
         before do
           @scheme.add_build_target(@ios_application)


### PR DESCRIPTION
Since the buildable reference was not aware of its own project, it used the target's project to construct a buildable reference. By default, this behavior still applies. However, now it is possible to pass in a `root_project` which is used to create the reference (`root_project` -> `target.project`).