### PR TITLE
[BuildConfiguration] Fix expanding settings when the inherited value …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Fix expanding build settings when the current build setting is a string but
+  the inherited value is an array.  
+  [Samuel Giddins](https://github.com/segiddins)
+  [CocoaPods#7421](https://github.com/CocoaPods/CocoaPods/issues/7421)
 
 ## 1.5.6 (2018-02-04)
 

--- a/lib/xcodeproj/project/object/build_configuration.rb
+++ b/lib/xcodeproj/project/object/build_configuration.rb
@@ -113,8 +113,15 @@ module Xcodeproj
           /x
 
         def expand_build_setting(build_setting_value, config_value)
+          if build_setting_value.is_a?(Array) && config_value.is_a?(String)
+            config_value = split_build_setting_array_to_string(config_value)
+          elsif build_setting_value.is_a?(String) && config_value.is_a?(Array)
+            build_setting_value = split_build_setting_array_to_string(build_setting_value)
+          end
+
           default = build_setting_value.is_a?(String) ? '' : []
           inherited = config_value || default
+
           return build_setting_value.gsub(Regexp.union(Constants::INHERITED_KEYWORDS), inherited) if build_setting_value.is_a? String
           build_setting_value.map { |value| Constants::INHERITED_KEYWORDS.include?(value) ? inherited : value }.flatten
         end

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -72,6 +72,13 @@ module ProjectSpecs
           @target.resolved_build_setting('OTHER_LDFLAGS', true).should == { 'Release' => expected_value, 'Debug' => expected_value }
         end
 
+        it 'returns the resolved build setting array value for a given key considering inheritance between project and target settings when the target setting is a string' do
+          @project.build_configuration_list.set_setting('OTHER_LDFLAGS', %w(-framework Foundation))
+          @target.build_configuration_list.set_setting('OTHER_LDFLAGS', '${inherited} -framework CoreData')
+          expected_value = %w(-framework Foundation -framework CoreData)
+          @target.resolved_build_setting('OTHER_LDFLAGS', true).should == { 'Release' => expected_value, 'Debug' => expected_value }
+        end
+
         it 'returns the resolved build setting string value for a given key considering inherited between project, target and associated base configuration references' do
           project_xcconfig = @project.new_file(fixture_path('project.xcconfig'))
           @project.build_configuration_list.build_configurations.each { |build_config| build_config.base_configuration_reference = project_xcconfig }


### PR DESCRIPTION
…is an array but the current value is a string

Closes https://github.com/CocoaPods/CocoaPods/issues/7421.

cc @jeffreyffs