### PR TITLE
Allow cfpropertylist 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ PATH
   remote: .
   specs:
     xcodeproj (1.5.6)
-      CFPropertyList (~> 2.3.3)
+      CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.2)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
@@ -24,7 +24,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
+    CFPropertyList (3.0.0)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
 
   s.add_runtime_dependency 'atomos',         '~> 0.1.2'
-  s.add_runtime_dependency 'CFPropertyList', '~> 2.3.3'
+  s.add_runtime_dependency 'CFPropertyList', '>= 2.3.3', '< 4.0'
   s.add_runtime_dependency 'claide',         '>= 1.0.2', '< 2.0'
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'nanaimo',        '~> 0.2.3'


### PR DESCRIPTION
The latest version of CFPropertyList fixes a fatal crash in JRuby at the
expense of dropping support for MRI 1.8. There are no other breaking changes in
3.0. See https://github.com/fastlane/fastlane/pull/11761 for details.