### PR TITLE
Add require for Digest

### DIFF
--- a/lib/xcodeproj/project/uuid_generator.rb
+++ b/lib/xcodeproj/project/uuid_generator.rb
@@ -76,6 +76,7 @@ module Xcodeproj
       end
 
       def uuid_for_path(path)
+        require 'Digest'
         Digest::MD5.hexdigest(path).upcase
       end
 

--- a/lib/xcodeproj/project/uuid_generator.rb
+++ b/lib/xcodeproj/project/uuid_generator.rb
@@ -76,7 +76,7 @@ module Xcodeproj
       end
 
       def uuid_for_path(path)
-        require 'Digest'
+        require 'digest'
         Digest::MD5.hexdigest(path).upcase
       end
 


### PR DESCRIPTION
Let me prefix this with "I have no idea if this is the right fix" (/gif i-have-no-idea-what-im-doing-dog)

My coworker and I started getting this error when using `predictabilize_uuids`:

```
Traceback (most recent call last):
	6: from ../../../scripts/update_twitchsdk_project.rb:15:in `<main>'
	5: from /usr/local/lib/ruby/gems/2.5.0/gems/xcodeproj-1.5.7/lib/xcodeproj/project.rb:386:in `predictabilize_uuids'
	4: from /usr/local/lib/ruby/gems/2.5.0/gems/xcodeproj-1.5.7/lib/xcodeproj/project/uuid_generator.rb:13:in `generate!'
	3: from /usr/local/lib/ruby/gems/2.5.0/gems/xcodeproj-1.5.7/lib/xcodeproj/project/uuid_generator.rb:70:in `switch_uuids'
	2: from /usr/local/lib/ruby/gems/2.5.0/gems/xcodeproj-1.5.7/lib/xcodeproj/project/uuid_generator.rb:70:in `each'
	1: from /usr/local/lib/ruby/gems/2.5.0/gems/xcodeproj-1.5.7/lib/xcodeproj/project/uuid_generator.rb:72:in `block in switch_uuids'
/usr/local/lib/ruby/gems/2.5.0/gems/xcodeproj-1.5.7/lib/xcodeproj/project/uuid_generator.rb:79:in `uuid_for_path': uninitialized constant Xcodeproj::Project::UUIDGenerator::Digest (NameError)
```

It's weird because none of this has changed in a while, and it was working before 🤔 `require`ing `Digest` seems like a straight-forward fix (confirmed running the change locally), but I'm curious if I'm missing anything.

Thanks in advance!
