### PR TITLE
Xcode 10 support for input file list and output file list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Xcode 10 support for input file list and output file list  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#7835](https://github.com/CocoaPods/CocoaPods/issues/7835)
 
 
 ## 1.5.9 (2018-05-15)

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -29,7 +29,7 @@ module Xcodeproj
 
     # @return [String] The last known object version to Xcodeproj.
     #
-    LAST_KNOWN_OBJECT_VERSION = 50
+    LAST_KNOWN_OBJECT_VERSION = 51
 
     # @return [String] The last known object version to Xcodeproj.
     #

--- a/lib/xcodeproj/project/object/build_phase.rb
+++ b/lib/xcodeproj/project/object/build_phase.rb
@@ -250,12 +250,26 @@ module Xcodeproj
         #
         attribute :input_paths, Array, []
 
+        # @return [Array<String>] an array of input file list paths of the script.
+        #
+        # @example
+        #   "$(SRCROOT)/newInputFile.xcfilelist"
+        #
+        attribute :input_file_list_paths, Array, []
+
         # @return [Array<String>] an array of output paths of the script.
         #
         # @example
         #   "$(DERIVED_FILE_DIR)/myfile"
         #
         attribute :output_paths, Array, []
+
+        # @return [Array<String>] an array of output file list paths of the script.
+        #
+        # @example
+        #   "$(SRCROOT)/newOutputFile.xcfilelist"
+        #
+        attribute :output_file_list_paths, Array, []
 
         # @return [String] the path to the script interpreter.
         #

--- a/spec/project/object/build_phase_spec.rb
+++ b/spec/project/object/build_phase_spec.rb
@@ -159,7 +159,9 @@ module ProjectSpecs
     it 'has empty defaults for the other attributes' do
       @build_phase.files.should == []
       @build_phase.input_paths.should == []
+      @build_phase.input_file_list_paths.should == []
       @build_phase.output_paths.should == []
+      @build_phase.output_file_list_paths.should == []
       @build_phase.shell_script.should == ''
     end
 


### PR DESCRIPTION
closes https://github.com/CocoaPods/CocoaPods/issues/7835

@segiddins how was `build_settings_array_settings_by_object_version.rb` generated for version 50? Was it manual? Looking to see if we can generate it for version 51.