### PR TITLE
add full_path for file_reference

### DIFF
--- a/lib/xcodeproj/project/object/file_reference.rb
+++ b/lib/xcodeproj/project/object/file_reference.rb
@@ -169,6 +169,13 @@ module Xcodeproj
           GroupableHelper.real_path(self)
         end
 
+        # @return [Pathname] the path of the file without resolving the
+        # source tree.
+        #
+        def full_path
+          GroupableHelper.full_path(self)
+        end
+
         # Sets the source tree of the reference.
         #
         # @param  [Symbol, String] source_tree

--- a/lib/xcodeproj/project/object/helpers/groupable_helper.rb
+++ b/lib/xcodeproj/project/object/helpers/groupable_helper.rb
@@ -109,6 +109,31 @@ module Xcodeproj
           # @param  [PBXGroup, PBXFileReference] object
           #         The object to analyze.
           #
+          # @return [Pathname] The path of the object without resolving the
+          #         source tree.
+          #
+          def full_path(object)
+            folder =  case object.source_tree
+                      when '<group>'
+                        parent(object).isa != 'PBXProject' ? full_path(parent(object)) : nil
+                      when 'SOURCE_ROOT'
+                        nil
+                      when '<absolute>'
+                        Pathname.new('/')
+                      else
+                        Pathname.new("${#{object.source_tree}}")
+                      end
+            folder ||= Pathname.new('')
+            if object.path
+              folder + object.path
+            else
+              folder
+            end
+          end
+
+          # @param  [PBXGroup, PBXFileReference] object
+          #         The object to analyze.
+          #
           # @return [Pathname] The absolute path of the source tree of the
           #         object.
           #

--- a/spec/project/object/file_reference_spec.rb
+++ b/spec/project/object/file_reference_spec.rb
@@ -28,6 +28,10 @@ module ProjectSpecs
       @file.real_path.should == Pathname.new('/project_dir/File.m')
     end
 
+    it 'returns the full path' do
+      @file.full_path.should == Pathname.new('File.m')
+    end
+
     it 'sets the source tree' do
       @file.source_tree = '<group>'
       @file.set_source_tree(:absolute)

--- a/spec/project/object/helpers/groupable_helper_spec.rb
+++ b/spec/project/object/helpers/groupable_helper_spec.rb
@@ -126,6 +126,46 @@ module ProjectSpecs
       end
     end
 
+    describe '::full_path' do
+      before do
+        @group = @project.new_group('Parent')
+        @file = @group.new_file('File.m')
+      end
+
+      it 'returns the full path of an object which the group path is nil' do
+        @file.set_source_tree(:group)
+        @helper.full_path(@file).should == Pathname.new('File.m')
+        @file.set_source_tree(:absolute)
+        @helper.full_path(@file).should == Pathname.new('/File.m')
+        @file.set_source_tree(:project)
+        @helper.full_path(@file).should == Pathname.new('File.m')
+        @file.set_source_tree(:developer_dir)
+        @helper.full_path(@file).should == Pathname.new('${DEVELOPER_DIR}/File.m')
+      end
+
+      it 'returns the full path of an object which the group path is not nil' do
+        @group.set_path('Parent')
+        @file.set_source_tree(:group)
+        @helper.full_path(@file).should == Pathname.new('Parent/File.m')
+        @file.set_source_tree(:absolute)
+        @helper.full_path(@file).should == Pathname.new('/File.m')
+        @file.set_source_tree(:project)
+        @helper.full_path(@file).should == Pathname.new('File.m')
+        @file.set_source_tree(:developer_dir)
+        @helper.full_path(@file).should == Pathname.new('${DEVELOPER_DIR}/File.m')
+      end
+
+      it 'returns the full path of an object which the group source tree is not <group>' do
+        @group.set_path('Parent')
+        @group.set_source_tree(:project)
+        @helper.full_path(@file).should == Pathname.new('Parent/File.m')
+        @group.set_source_tree(:absolute)
+        @helper.full_path(@file).should == Pathname.new('/Parent/File.m')
+        @group.set_source_tree(:developer_dir)
+        @helper.full_path(@file).should == Pathname.new('${DEVELOPER_DIR}/Parent/File.m')
+      end
+    end
+
     #-------------------------------------------------------------------------#
 
     describe '::source_tree_real_path' do


### PR DESCRIPTION
There is a `real_path` in `file_reference`. But sometimes, I just want to get the path from the `path` of a object and its parents without the project directory. I could get the relative path with `object.real_path.relative_path_from(project.project_dir)` when the source trees which the object and its parent groups are `<group>` and `SOURCE_ROOT`. If the source tree is a `<absolute>` path, this way will get wrong path.

So I add a method to get the full path. It will puts the `GROUP_PATH/OBJECT_PATH`.