### PR TITLE
[Gemspec] Bump atomos to `'~> 0.1.3'`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ PATH
   specs:
     xcodeproj (1.5.9)
       CFPropertyList (>= 2.3.3, < 4.0)
-      atomos (~> 0.1.2)
+      atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.2.6)
@@ -28,7 +28,7 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
-    atomos (0.1.2)
+    atomos (0.1.3)
     bacon (1.2.0)
     claide-plugins (0.9.2)
       cork

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = %w(xcodeproj)
   s.require_paths = %w(lib)
 
-  s.add_runtime_dependency 'atomos',         '~> 0.1.2'
+  s.add_runtime_dependency 'atomos',         '~> 0.1.3'
   s.add_runtime_dependency 'CFPropertyList', '>= 2.3.3', '< 4.0'
   s.add_runtime_dependency 'claide',         '>= 1.0.2', '< 2.0'
   s.add_runtime_dependency 'colored2',       '~> 3.1'


### PR DESCRIPTION
`atomos` got a new release 0.1.3, this updates its usage to that version to make sure it is used.