### PR TITLE
Configuring targets for running uses internal methods allowing commad line tools and apps to be launchable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add support for launchable targets from a scheme.  
+  [Derek Ostrander](https://github.com/dostrander)
+  [#614](https://github.com/CocoaPods/Xcodeproj/pull/614)
+  
 * Update last known SDKs to iOS 12, macOS 10.14, tvOS 12, and watchOS 5  
   [Minh Nguyễn](http://github.com/1ec5/)
   [#609](https://github.com/CocoaPods/Xcodeproj/pull/609)
@@ -65,7 +69,7 @@
 
 ##### Enhancements
 
-* None.  
+* None.
 
 ##### Bug Fixes
 

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -811,7 +811,7 @@ module Xcodeproj
     # folder) and optionally hides them.
     #
     # @param  [Bool] visible
-    #         Wether the schemes should be visible or hidden.
+    #         Whether the schemes should be visible or hidden.
     #
     # @return [void]
     #
@@ -826,8 +826,11 @@ module Xcodeproj
 
       targets.each do |target|
         scheme = XCScheme.new
-        scheme.add_build_target(target)
-        scheme.add_test_target(target) if target.respond_to?(:test_target_type?) && target.test_target_type?
+
+        test_target = target if target.respond_to?(:test_target_type?) && target.test_target_type?
+        launch_target = target.respond_to?(:launchable_target_type?) && target.launchable_target_type?
+        scheme.configure_with_targets(target, test_target, :launch_target => launch_target)
+
         yield scheme, target if block_given?
         scheme.save_as(path, target.name, false)
         xcschememanagement['SchemeUserState']["#{target.name}.xcscheme"] = {}

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -460,6 +460,17 @@ module Xcodeproj
           end
         end
 
+        # @return [Boolean] Whether the target is launchable.
+        #
+        def launchable_target_type?
+          case symbol_type
+          when :application, :command_line_tool
+            true
+          else
+            false
+          end
+        end
+
         # Adds source files to the target.
         #
         # @param  [Array<PBXFileReference>] file_references

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -64,13 +64,18 @@ module Xcodeproj
     # @param [Xcodeproj::Project::Object::PBXAbstractTarget] test_target
     #        The target to use for the 'Test' action
     #
-    def configure_with_targets(runnable_target, test_target)
-      build_action.add_entry BuildAction::Entry.new(runnable_target) if runnable_target
-      build_action.add_entry BuildAction::Entry.new(test_target) if test_target
-
-      test_action.add_testable TestAction::TestableReference.new(test_target) if test_target
-      launch_action.buildable_product_runnable = BuildableProductRunnable.new(runnable_target, 0) if runnable_target
-      profile_action.buildable_product_runnable = BuildableProductRunnable.new(runnable_target) if runnable_target
+    # @param [Boolean] launch_target
+    #        Determines if the runnable_target is launchable.
+    #
+    def configure_with_targets(runnable_target, test_target, launch_target: false)
+      if runnable_target
+        add_build_target(runnable_target)
+        set_launch_target(runnable_target) if launch_target
+      end
+      if test_target
+        add_build_target(test_target, false) if test_target != runnable_target
+        add_test_target(test_target)
+      end
     end
 
     public

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -780,6 +780,27 @@ module ProjectSpecs
         end
       end
 
+      describe '#launchable_target_type?' do
+        it 'returns true for command line tools and applications' do
+          @target.stubs(:symbol_type => :application)
+          @target.should.be.launchable_target_type?
+
+          @target.stubs(:symbol_type => :command_line_tool)
+          @target.should.be.launchable_target_type?
+        end
+
+        it 'returns false for non launchable types' do
+          @target.stubs(:symbol_type => :octest_bundle)
+          @target.should.not.be.launchable_target_type?
+
+          @target.stubs(:symbol_type => :unit_test_bundle)
+          @target.should.not.be.launchable_target_type?
+
+          @target.stubs(:symbol_type => :ui_test_bundle)
+          @target.should.not.be.launchable_target_type?
+        end
+      end
+
       describe '#extension_target_type?' do
         it 'returns true for extension target types' do
           @target.stubs(:symbol_type => :app_extension)

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -104,6 +104,104 @@ module ProjectSpecs
       end
     end
 
+    describe 'Configuration' do
+      it 'app target for launching' do
+        app = @project.new_target(:application, 'App', :ios)
+        scheme = Xcodeproj::XCScheme.new
+        scheme.configure_with_targets(app, nil, :launch_target => true)
+        scheme.build_action.entries.count.should == 1
+
+        entry = scheme.build_action.entries[0]
+
+        entry.build_for_running?.should == true
+        entry.build_for_testing?.should == true
+        entry.build_for_profiling?.should == true
+        entry.build_for_archiving?.should == true
+        entry.build_for_analyzing?.should == true
+        entry.buildable_references.first.buildable_name.should == 'App.app'
+
+        scheme.launch_action.buildable_product_runnable.buildable_reference.buildable_name.should == 'App.app'
+        scheme.profile_action.buildable_product_runnable.buildable_reference.buildable_name.should == 'App.app'
+        scheme.test_action.macro_expansions.count.should == 1
+      end
+
+      it 'app target not for launching' do
+        app = @project.new_target(:application, 'App', :ios)
+        scheme = Xcodeproj::XCScheme.new
+        scheme.configure_with_targets(app, nil, :launch_target => false)
+        scheme.build_action.entries.count.should == 1
+
+        entry = scheme.build_action.entries[0]
+
+        entry.build_for_running?.should == true
+        entry.build_for_testing?.should == true
+        entry.build_for_profiling?.should == true
+        entry.build_for_archiving?.should == true
+        entry.build_for_analyzing?.should == true
+        entry.buildable_references.first.buildable_name.should == 'App.app'
+
+        scheme.launch_action.buildable_product_runnable.buildable_reference.buildable_name.nil?.should == true
+        scheme.profile_action.buildable_product_runnable.buildable_reference.buildable_name.nil?.should == true
+        scheme.test_action.macro_expansions.count.should == 0
+      end
+
+      it 'app and test target for launching' do
+        app = @project.new_target(:application, 'App', :ios)
+        test = @project.new_target(:unit_test_bundle, 'Test', :ios)
+        scheme = Xcodeproj::XCScheme.new
+        scheme.configure_with_targets(app, test, :launch_target => true)
+        scheme.build_action.entries.count.should == 2
+
+        app_entry = scheme.build_action.entries[0]
+        app_entry.build_for_running?.should == true
+        app_entry.build_for_testing?.should == true
+        app_entry.build_for_profiling?.should == true
+        app_entry.build_for_archiving?.should == true
+        app_entry.build_for_analyzing?.should == true
+        app_entry.buildable_references.first.buildable_name.should == 'App.app'
+
+        test_entry = scheme.build_action.entries[1]
+        test_entry.build_for_running?.should == false
+        test_entry.build_for_testing?.should == true
+        test_entry.build_for_profiling?.should == true
+        test_entry.build_for_archiving?.should == true
+        test_entry.build_for_analyzing?.should == true
+        test_entry.buildable_references.first.buildable_name.should == 'Test.xctest'
+
+        scheme.launch_action.buildable_product_runnable.buildable_reference.buildable_name.should == 'App.app'
+        scheme.profile_action.buildable_product_runnable.buildable_reference.buildable_name.should == 'App.app'
+        scheme.test_action.macro_expansions.count.should == 1
+      end
+
+      it 'app and test target for not launching' do
+        app = @project.new_target(:application, 'App', :ios)
+        test = @project.new_target(:unit_test_bundle, 'Test', :ios)
+        scheme = Xcodeproj::XCScheme.new
+        scheme.configure_with_targets(app, test, :launch_target => false)
+        scheme.build_action.entries.count.should == 2
+
+        app_entry = scheme.build_action.entries[0]
+        app_entry.build_for_running?.should == true
+        app_entry.build_for_testing?.should == true
+        app_entry.build_for_profiling?.should == true
+        app_entry.build_for_archiving?.should == true
+        app_entry.build_for_analyzing?.should == true
+        app_entry.buildable_references.first.buildable_name.should == 'App.app'
+
+        test_entry = scheme.build_action.entries[1]
+        test_entry.build_for_running?.should == false
+        test_entry.build_for_testing?.should == true
+        test_entry.build_for_profiling?.should == true
+        test_entry.build_for_archiving?.should == true
+        test_entry.build_for_analyzing?.should == true
+        test_entry.buildable_references.first.buildable_name.should == 'Test.xctest'
+
+        scheme.launch_action.buildable_product_runnable.buildable_reference.buildable_name.nil?.should == true
+        scheme.profile_action.buildable_product_runnable.buildable_reference.buildable_name.nil?.should == true
+        scheme.test_action.macro_expansions.count.should == 0
+      end
+    end
+
     #-------------------------------------------------------------------------#
 
     describe 'Serialization' do


### PR DESCRIPTION
@segiddins @dnkoutso 