### PR TITLE
Add support for setting/getting main thread checker related flags for launch and test actions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add support for disableMainThreadChecker and stopOnEveryMainThreadCheckerIssue flags
   [Jacek Suliga](https://github.com/jmkk)
+  [#619](https://github.com/CocoaPods/Xcodeproj/pull/619)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ##### Enhancements
 
-* None.  
+* Add support for disableMainThreadChecker and stopOnEveryMainThreadCheckerIssue flags
+  [Jacek Suliga](https://github.com/jmkk)
 
 ##### Bug Fixes
 

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -47,6 +47,40 @@ module Xcodeproj
         @xml_element.attributes['allowLocationSimulation'] = bool_to_string(flag)
       end
 
+      # @return [Bool]
+      #         Whether this Build Action should disable detection of UI API misuse
+      #         from background threads
+      #
+      def disable_main_thread_checker?
+        string_to_bool(@xml_element.attributes['disableMainThreadChecker'])
+      end
+
+      # @param [Bool] flag
+      #        Set whether this Build Action should disable detection of UI API misuse
+      #        from background threads
+      #
+      def disable_main_thread_checker=(flag)
+        @xml_element.attributes['disableMainThreadChecker'] = bool_to_string(flag)
+      end
+
+      # @return [Bool]
+      #         Whether UI API misuse from background threads detection should pause execution.
+      #         This flag is ignored when the thread checker disabled
+      #         ([disable_main_thread_checker] flag).
+      #
+      def stop_on_every_main_thread_checker_issue?
+        string_to_bool(@xml_element.attributes['stopOnEveryMainThreadCheckerIssue'])
+      end
+
+      # @param [Bool] flag
+      #         Set whether UI API misuse from background threads detection should pause execution.
+      #         This flag is ignored when the thread checker disabled
+      #         ([disable_main_thread_checker] flag).
+      #
+      def stop_on_every_main_thread_checker_issue=(flag)
+        @xml_element.attributes['stopOnEveryMainThreadCheckerIssue'] = bool_to_string(flag)
+      end
+
       # @return [String]
       #         The launch automatically substyle
       #

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -36,6 +36,22 @@ module Xcodeproj
       end
 
       # @return [Bool]
+      #         Whether this Test Action should disable detection of UI API misuse
+      #         from background threads
+      #
+      def disable_main_thread_checker?
+        string_to_bool(@xml_element.attributes['disableMainThreadChecker'])
+      end
+
+      # @param [Bool] flag
+      #        Set whether this Test Action should disable detection of UI API misuse
+      #        from background threads
+      #
+      def disable_main_thread_checker=(flag)
+        @xml_element.attributes['disableMainThreadChecker'] = bool_to_string(flag)
+      end
+
+      # @return [Bool]
       #         Whether Clang Code Coverage is enabled ('Gather coverage data' turned ON)
       #
       def code_coverage_enabled?

--- a/spec/fixtures/SharedSchemes/SharedSchemes.xcodeproj/xcshareddata/xcschemes/SharedSchemes.xcscheme
+++ b/spec/fixtures/SharedSchemes/SharedSchemes.xcodeproj/xcshareddata/xcschemes/SharedSchemes.xcscheme
@@ -26,6 +26,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      disableMainThreadChecker = "YES"
       buildConfiguration = "Debug">
       <Testables>
       </Testables>
@@ -56,6 +57,8 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
+      disableMainThreadChecker = "YES"
+      stopOnEveryMainThreadCheckerIssue = "YES"
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/spec/scheme/launch_action_spec.rb
+++ b/spec/scheme/launch_action_spec.rb
@@ -16,6 +16,8 @@ module Xcodeproj
 
       action.xml_element.attributes['buildConfiguration'].should == 'Debug'
       action.xml_element.attributes['allowLocationSimulation'].should == 'YES'
+      action.xml_element.attributes['disableMainThreadChecker'].nil?
+      action.xml_element.attributes['stopOnEveryMainThreadCheckerIssue'].nil?
     end
 
     it 'raises if created with an invalid XML node' do

--- a/spec/scheme/test_action_spec.rb
+++ b/spec/scheme/test_action_spec.rb
@@ -10,6 +10,7 @@ module Xcodeproj
       test_action.xml_element.attributes['selectedLauncherIdentifier'].should == 'Xcode.DebuggerFoundation.Launcher.LLDB'
       test_action.xml_element.attributes['shouldUseLaunchSchemeArgsEnv'].should == 'YES'
       test_action.xml_element.attributes['buildConfiguration'].should == 'Debug'
+      test_action.xml_element.attributes['disableMainThreadChecker'].nil?
     end
 
     it 'raises if created with an invalid XML node' do
@@ -28,6 +29,7 @@ module Xcodeproj
       extend SpecHelper::XCScheme
       specs_for_bool_attr(:should_use_launch_scheme_args_env => 'shouldUseLaunchSchemeArgsEnv')
       specs_for_bool_attr(:code_coverage_enabled => 'codeCoverageEnabled')
+      specs_for_bool_attr(:disable_main_thread_checker => 'disableMainThreadChecker')
 
       it '#testables' do
         project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -44,6 +44,7 @@ module ProjectSpecs
       it 'Properly map the scheme\'s TestAction' do
         @scheme.test_action.should_use_launch_scheme_args_env?.should == true
         @scheme.test_action.build_configuration.should == 'Debug'
+        @scheme.test_action.disable_main_thread_checker?.should == true
 
         @scheme.test_action.testables.count.should == 0
         @scheme.test_action.macro_expansions.count.should == 1
@@ -65,6 +66,8 @@ module ProjectSpecs
       it 'Properly map the scheme\'s LaunchAction' do
         @scheme.launch_action.allow_location_simulation?.should == true
         @scheme.launch_action.build_configuration.should == 'Debug'
+        @scheme.launch_action.disable_main_thread_checker?.should == true
+        @scheme.launch_action.stop_on_every_main_thread_checker_issue?.should == true
 
         bpr = @scheme.launch_action.buildable_product_runnable
         bpr.class.should == Xcodeproj::XCScheme::BuildableProductRunnable


### PR DESCRIPTION
Adding `disableMainThreadChecker` (for Launch and Profile Actions) and `stopOnEveryMainThreadCheckerIssue` (for Launch Action)

<img width="789" alt="xcode-10-testaction-mainthreadchecker" src="https://user-images.githubusercontent.com/3430965/47611364-ec1e0880-da20-11e8-9085-14ab062e7cf0.png">
<img width="720" alt="xcode-10-buildaction-mainthreadchecker" src="https://user-images.githubusercontent.com/3430965/47611365-ec1e0880-da20-11e8-9487-0e35480a5b7f.png">
