### PR TITLE
Fixup UUID generation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add support to generating deterministic UUIDs for a list of projects.  
+  [Sebastian Shanus](https://github.com/sebastianv1)
+  [#627](https://github.com/CocoaPods/Xcodeproj/pull/627) 
+
 * Add support for tbd libraries  
   [raptorxcz](https://github.com/raptorxcz)
   [#379](https://github.com/CocoaPods/Xcodeproj/issues/379)

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -388,7 +388,24 @@ module Xcodeproj
     # @return [void]
     #
     def predictabilize_uuids
-      UUIDGenerator.new(self).generate!
+      UUIDGenerator.new([self]).generate!
+    end
+
+    # Replaces all the UUIDs in the list of provided projects with deterministic MD5 checksums.
+    #
+    # @param  [Array<Project>] projects
+    #
+    # @note The current sorting of the project is taken into account when
+    #       generating the new UUIDs.
+    #
+    # @note This method should only be used for entirely machine-generated
+    #       projects, as true UUIDs are useful for tracking changes in the
+    #       project.
+    #
+    # @return [void]
+    #
+    def self.predictabilize_uuids(projects)
+      UUIDGenerator.new(projects).generate!
     end
 
     public

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -480,20 +480,36 @@ module ProjectSpecs
           project
         end
 
-        it 'have the same UUIDS' do
-          create_project[0].uuids.sort.should == create_project[1].uuids.sort
+        it 'not have the same UUIDS' do
+          create_project[0].uuids.sort.should != create_project[1].uuids.sort
         end
 
-        it 'always has the same root object UUID, even for different paths' do
+        it 'have the same UUIDS' do
+          create_project[0].uuids.sort.should == create_project[0].uuids.sort
+        end
+
+        it 'always has the same root object UUID, for the same path' do
           project = Xcodeproj::Project.new('path1.xcodeproj')
           project.add_build_configuration('Config', :debug)
           project.predictabilize_uuids
-          project.root_object.uuid.should == 'D41D8CD98F00B204E9800998ECF8427E'
+          project.root_object.uuid.should == 'BB3CBEC84BD00C24CC882BA09F25FC35'
+
+          project = Xcodeproj::Project.new('path1.xcodeproj')
+          project.add_build_configuration('Config', :release)
+          project.predictabilize_uuids
+          project.root_object.uuid.should == 'BB3CBEC84BD00C24CC882BA09F25FC35'
+        end
+
+        it 'has different root object UUID, for different paths' do
+          project = Xcodeproj::Project.new('path1.xcodeproj')
+          project.add_build_configuration('Config', :debug)
+          project.predictabilize_uuids
+          project.root_object.uuid.should == 'BB3CBEC84BD00C24CC882BA09F25FC35'
 
           project = Xcodeproj::Project.new('path2.xcodeproj')
           project.add_build_configuration('Config', :release)
           project.predictabilize_uuids
-          project.root_object.uuid.should == 'D41D8CD98F00B204E9800998ECF8427E'
+          project.root_object.uuid.should == '58C5CB80A8C53842A0F017EE22887DF0'
         end
 
         Pathname.glob("#{fixture_path}/**/*.xcodeproj").each do |path|


### PR DESCRIPTION
Support the ability to pass in a list of projects that can be used to generate deterministic UUIDs, and also initially pass into UUID generation the project basename such that we have unique UUIDs across all projects.