### PR TITLE
Fixup UUIDGenerator initializer for backwards compatibility.

### DIFF
--- a/lib/xcodeproj/project/uuid_generator.rb
+++ b/lib/xcodeproj/project/uuid_generator.rb
@@ -4,7 +4,7 @@ module Xcodeproj
       require 'digest'
 
       def initialize(projects)
-        @projects = projects
+        @projects = Array(projects)
         @paths_by_object = {}
       end
 


### PR DESCRIPTION
Now that `UUIDGenerator` takes in a list of projects, this change supports just passing in a single project for backwards compatibility.