### PR TITLE
add .rbenv-gemsets to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.bundle
 *.o
 *.rbc
+.rbenv-gemsets
 .rbenv-version
 ext/xcodeproj/.RUBYARCHDIR.time
 ext/xcodeproj/extconf.h


### PR DESCRIPTION
[rbenv-gemset](https://github.com/jf/rbenv-gemset) is helpful for developing gems while also using the stable version.