### PR TITLE
Properly loads both project schemes and workspaces schemes on init and prevent overriding of incorrect project path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Fix build setting variable substitution for array settings.  
   [Samuel Giddins](https://github.com/segiddins)
+* Properly loads both project schemes and workspaces schemes on init and
+  prevents overriding of incorrect project paths.  
+  [joshdholtz](https://github.com/joshdholtz)
+  [#656](https://github.com/CocoaPods/CocoaPods/pull/656)  
 
 
 ## 1.8.0 (2019-01-25)

--- a/lib/xcodeproj/workspace.rb
+++ b/lib/xcodeproj/workspace.rb
@@ -64,7 +64,7 @@ module Xcodeproj
     #
     def self.new_from_xcworkspace(path)
       from_s(File.read(File.join(path, 'contents.xcworkspacedata')),
-             File.expand_path(File.dirname(path)))
+             File.expand_path(path))
     rescue Errno::ENOENT
       new(nil)
     end
@@ -191,8 +191,14 @@ module Xcodeproj
     # @return [void]
     #
     def load_schemes(workspace_dir_path)
+      # Normalizes path to directory of workspace needed for file_reference.absolute_path
+      workspaces_dir = workspace_dir_path
+      if File.extname(workspace_dir_path) == '.xcworkspace'
+        workspaces_dir = File.expand_path('..', workspaces_dir)
+      end
+
       file_references.each do |file_reference|
-        project_full_path = file_reference.absolute_path(workspace_dir_path)
+        project_full_path = file_reference.absolute_path(workspaces_dir)
         load_schemes_from_project(project_full_path)
       end
 

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -139,7 +139,6 @@ describe Xcodeproj::Workspace do
   describe 'load schemes for all projects and the workspace from a workspace file' do
     before do
       @workspace = Xcodeproj::Workspace.new_from_xcworkspace(fixture_path('WorkspaceSchemes/WorkspaceSchemes.xcworkspace'))
-      @workspace.load_schemes(fixture_path('WorkspaceSchemes/WorkspaceSchemes.xcworkspace'))
     end
 
     it 'returns data type should be hash' do
@@ -152,6 +151,12 @@ describe Xcodeproj::Workspace do
 
     it 'contains only test data schemes' do
       @workspace.schemes.keys.sort.should == %w(WorkspaceSchemesApp WorkspaceSchemesFramework WorkspaceSchemesScheme project_in_subgroup scheme_in_subgroup_with_location)
+    end
+
+    it 'schemes hash contain path to a valid project/workspace' do
+      @workspace.schemes.values.each do |path|
+        File.exist?(path).should == true
+      end
     end
   end
 


### PR DESCRIPTION
👋 Hello from the https://github.com/fastlane team!

## Description
Our codebase had...
```rb
# Load schemes from projects in workspace
@workspace = Xcodeproj::Workspace.new_from_xcworkspace(path)
# Load schemes from workspace
@workspace.load_schemes(path)
```

### Issues experienced
`Xcodeproj::Workspace.new_from_xcworkspace(path)` would load the following schemes:
```rb
{
  "FastlaneTestTV"=>"/Users/josh/Projects/fastlane/test-ios/Test.xcodeproj",
  "Test"=>"/Users/josh/Projects/fastlane/test-ios/Test.xcodeproj",
  "Pods"=>"/Users/josh/Projects/fastlane/test-ios/Pods/Pods.xcodeproj"
}
```

However, when trying to load workspace schemes, `@workspace.load_schemes(path)` would load the following schemes:
```rb
{
  "FastlaneTestTV"=>"/Users/josh/Projects/fastlane/test-ios/Test.xcodeproj",
  "Test"=>"/Users/josh/Projects/fastlane/test-ios/Test.xcworkspace/Test.xcodeproj",
  "Pods"=>"/Users/josh/Projects/fastlane/test-ios/Test.xcworkspace/Pods/Pods.xcodeproj"
}
```

These paths for the schemes are not correct. The workspace directory was overriding the previous scheme path due to `file_reference.absolute_path` being passed the path to the workspace and not the directory containing the workspace like it needs and what the docs says - https://github.com/CocoaPods/Xcodeproj/blob/master/lib/xcodeproj/workspace/file_reference.rb#L74-L75

### Xcodeproje tests
The `xcodeproj` tests also used the same two line scheme loading like we are in _fastlane_. The tests however were only checking if the keys of the schemes hash existed and didn't actually check if the filepaths were correct.

## Solution
1. Change `new_from_xcworkspace` to pass in the workspace path (not the directory containing the workspace into `from_s`
  - This prevents needing to call `load_schemes` again because we can now get all the project schemes and all the workspace schemes just from calling `new_from_xcworkspace`
2. `load_schemes` now normalizes that path that is passed in to make sure that the path of the workspace doesn't get passed into `file_reference.absolute_path(workspaces_dir)`

### Our fastlane code 
Our fasltane code can now just be...
```rb
@workspace = Xcodeproj::Workspace.new_from_xcworkspace(path)
```

which will:
- Load all schemes from all projects
- Load all workspace schemes
- Doesn't override scheme project paths with invalid paths that's don't exist