### PR TITLE
[#657] Form path for group references taking into account parent group.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 * Ensure a `GroupReference`'s path includes its parent `GroupReference`'s path. 
   Both `FileReference`s and `GroupReference`s only prepend the parent path if
-  the child has a type of `group`.
+  the child has a type of `group`.  
   [Kesi Maduka](https://github.com/k3zi)
   [#657](https://github.com/CocoaPods/Xcodeproj/issues/657)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   [joshdholtz](https://github.com/joshdholtz)
   [#656](https://github.com/CocoaPods/CocoaPods/pull/656)  
 
+* Ensure a `GroupReference`'s path includes its parent `GroupReference`'s path. 
+  Both `FileReference`s and `GroupReference`s only prepend the parent path if
+  the child has a type of `group`.
+  [Kesi Maduka](https://github.com/k3zi)
+  [#657](https://github.com/CocoaPods/Xcodeproj/issues/657)
 
 ## 1.8.0 (2019-01-25)
 

--- a/lib/xcodeproj/workspace/file_reference.rb
+++ b/lib/xcodeproj/workspace/file_reference.rb
@@ -1,21 +1,13 @@
+require 'xcodeproj/workspace/reference'
+
 module Xcodeproj
   class Workspace
     # Describes a file reference of a Workspace.
     #
-    class FileReference
+    class FileReference < Reference
       # @return [String] the path to the project
       #
       attr_reader :path
-
-      # @return [String] the type of reference to the project
-      #
-      # This can be of the following values:
-      # - absolute
-      # - group
-      # - container
-      # - developer (unsupported)
-      #
-      attr_reader :type
 
       # @param [#to_s] path @see path
       # @param [#to_s] type @see type
@@ -47,20 +39,10 @@ module Xcodeproj
       #
       def self.from_node(xml_node)
         type, path = xml_node.attribute('location').value.split(':', 2)
-        path = prepend_parent_path(xml_node, path)
-        new(path, type)
-      end
-
-      def self.prepend_parent_path(xml_node, path)
-        if !xml_node.parent.nil? && (xml_node.parent.name == 'Group')
-          group = GroupReference.from_node(xml_node.parent)
-          if !group.location.nil? && !group.location.empty?
-            path = '' if path.nil?
-            path = File.join(group.location, path)
-          end
+        if type == 'group'
+          path = prepend_parent_path(xml_node, path)
         end
-
-        path
+        new(path, type)
       end
 
       # @return [REXML::Element] the XML representation of the file reference.

--- a/lib/xcodeproj/workspace/group_reference.rb
+++ b/lib/xcodeproj/workspace/group_reference.rb
@@ -1,21 +1,13 @@
+require 'xcodeproj/workspace/reference'
+
 module Xcodeproj
   class Workspace
     # Describes a group reference of a Workspace.
     #
-    class GroupReference
+    class GroupReference < Reference
       # @return [String] the name of the group
       #
       attr_reader :name
-
-      # @return [String] the type of reference to the project
-      #
-      # This can be of the following values:
-      # - absolute
-      # - group
-      # - container (only supported value)
-      # - developer
-      #
-      attr_reader :type
 
       # @return [String] the location of the group on disk
       #
@@ -55,6 +47,9 @@ module Xcodeproj
         location_array = xml_node.attribute('location').value.split(':', 2)
         type = location_array.first
         location = location_array[1] || ''
+        if type == 'group'
+          location = prepend_parent_path(xml_node, location)
+        end
         name = xml_node.attribute('name').value
         new(name, type, location)
       end

--- a/lib/xcodeproj/workspace/reference.rb
+++ b/lib/xcodeproj/workspace/reference.rb
@@ -1,0 +1,40 @@
+module Xcodeproj
+  class Workspace
+    # Describes a file/group reference of a Workspace.
+    #
+    class Reference
+      # @return [String] the type of reference to the project
+      #
+      # This can be of the following values:
+      # - absolute
+      # - group
+      # - container
+      # - developer (unsupported)
+      #
+      attr_reader :type
+
+      # Returns the relative path to the parent group reference (if one exists)
+      # prepended to the passed in path.
+      #
+      # @param  [REXML::Element] xml_node
+      #         the XML representation.
+      #
+      # @param  [String] path
+      #         the path that will be prepended to.
+      #
+      # @return [String] the extended path including the parent node's path.
+      #
+      def self.prepend_parent_path(xml_node, path)
+        if !xml_node.parent.nil? && (xml_node.parent.name == 'Group')
+          group = GroupReference.from_node(xml_node.parent)
+          if !group.location.nil? && !group.location.empty?
+            path = '' if path.nil?
+            path = File.join(group.location, path)
+          end
+        end
+
+        path
+      end
+    end
+  end
+end

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group.xcodeproj/project.pbxproj
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group.xcodeproj/project.pbxproj
@@ -1,0 +1,339 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		EA9FCB8A220B4C2B003E8AE5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9FCB89220B4C2B003E8AE5 /* AppDelegate.swift */; };
+		EA9FCB8C220B4C2B003E8AE5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA9FCB8B220B4C2B003E8AE5 /* ViewController.swift */; };
+		EA9FCB8F220B4C2B003E8AE5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EA9FCB8D220B4C2B003E8AE5 /* Main.storyboard */; };
+		EA9FCB91220B4C2D003E8AE5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EA9FCB90220B4C2D003E8AE5 /* Assets.xcassets */; };
+		EA9FCB94220B4C2D003E8AE5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EA9FCB92220B4C2D003E8AE5 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		EA9FCB86220B4C2B003E8AE5 /* project_in_group_type_group.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = project_in_group_type_group.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA9FCB89220B4C2B003E8AE5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		EA9FCB8B220B4C2B003E8AE5 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		EA9FCB8E220B4C2B003E8AE5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		EA9FCB90220B4C2D003E8AE5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		EA9FCB93220B4C2D003E8AE5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		EA9FCB95220B4C2D003E8AE5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		EA9FCB83220B4C2B003E8AE5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		EA9FCB7D220B4C2B003E8AE5 = {
+			isa = PBXGroup;
+			children = (
+				EA9FCB88220B4C2B003E8AE5 /* project_in_group_type_group */,
+				EA9FCB87220B4C2B003E8AE5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		EA9FCB87220B4C2B003E8AE5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				EA9FCB86220B4C2B003E8AE5 /* project_in_group_type_group.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		EA9FCB88220B4C2B003E8AE5 /* project_in_group_type_group */ = {
+			isa = PBXGroup;
+			children = (
+				EA9FCB89220B4C2B003E8AE5 /* AppDelegate.swift */,
+				EA9FCB8B220B4C2B003E8AE5 /* ViewController.swift */,
+				EA9FCB8D220B4C2B003E8AE5 /* Main.storyboard */,
+				EA9FCB90220B4C2D003E8AE5 /* Assets.xcassets */,
+				EA9FCB92220B4C2D003E8AE5 /* LaunchScreen.storyboard */,
+				EA9FCB95220B4C2D003E8AE5 /* Info.plist */,
+			);
+			path = project_in_group_type_group;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		EA9FCB85220B4C2B003E8AE5 /* project_in_group_type_group */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA9FCB98220B4C2D003E8AE5 /* Build configuration list for PBXNativeTarget "project_in_group_type_group" */;
+			buildPhases = (
+				EA9FCB82220B4C2B003E8AE5 /* Sources */,
+				EA9FCB83220B4C2B003E8AE5 /* Frameworks */,
+				EA9FCB84220B4C2B003E8AE5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = project_in_group_type_group;
+			productName = project_in_group_type_group;
+			productReference = EA9FCB86220B4C2B003E8AE5 /* project_in_group_type_group.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		EA9FCB7E220B4C2B003E8AE5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1010;
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = CocoaPods;
+				TargetAttributes = {
+					EA9FCB85220B4C2B003E8AE5 = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = EA9FCB81220B4C2B003E8AE5 /* Build configuration list for PBXProject "project_in_group_type_group" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EA9FCB7D220B4C2B003E8AE5;
+			productRefGroup = EA9FCB87220B4C2B003E8AE5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				EA9FCB85220B4C2B003E8AE5 /* project_in_group_type_group */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EA9FCB84220B4C2B003E8AE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA9FCB94220B4C2D003E8AE5 /* LaunchScreen.storyboard in Resources */,
+				EA9FCB91220B4C2D003E8AE5 /* Assets.xcassets in Resources */,
+				EA9FCB8F220B4C2B003E8AE5 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		EA9FCB82220B4C2B003E8AE5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA9FCB8C220B4C2B003E8AE5 /* ViewController.swift in Sources */,
+				EA9FCB8A220B4C2B003E8AE5 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		EA9FCB8D220B4C2B003E8AE5 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EA9FCB8E220B4C2B003E8AE5 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		EA9FCB92220B4C2D003E8AE5 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				EA9FCB93220B4C2D003E8AE5 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		EA9FCB96220B4C2D003E8AE5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		EA9FCB97220B4C2D003E8AE5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		EA9FCB99220B4C2D003E8AE5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = project_in_group_type_group/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.project-in-group-type-group";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		EA9FCB9A220B4C2D003E8AE5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = project_in_group_type_group/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.project-in-group-type-group";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		EA9FCB81220B4C2B003E8AE5 /* Build configuration list for PBXProject "project_in_group_type_group" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA9FCB96220B4C2D003E8AE5 /* Debug */,
+				EA9FCB97220B4C2D003E8AE5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EA9FCB98220B4C2D003E8AE5 /* Build configuration list for PBXNativeTarget "project_in_group_type_group" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA9FCB99220B4C2D003E8AE5 /* Debug */,
+				EA9FCB9A220B4C2D003E8AE5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = EA9FCB7E220B4C2B003E8AE5 /* Project object */;
+}

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/AppDelegate.swift
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  project_in_group_type_group
+//
+//  Created by kezi on 2019/02/06.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Assets.xcassets/Contents.json
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Base.lproj/LaunchScreen.storyboard
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Base.lproj/Main.storyboard
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Info.plist
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/ViewController.swift
+++ b/spec/fixtures/WorkspaceSchemes/GroupLocation/GroupTypeGroupLocation/project_in_group_type_group/project_in_group_type_group/ViewController.swift
@@ -1,0 +1,20 @@
+//
+//  ViewController.swift
+//  project_in_group_type_group
+//
+//  Created by kezi on 2019/02/06.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view, typically from a nib.
+    }
+
+
+}
+

--- a/spec/fixtures/WorkspaceSchemes/WorkspaceSchemes.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/WorkspaceSchemes/WorkspaceSchemes.xcworkspace/contents.xcworkspacedata
@@ -5,6 +5,13 @@
       location = "container:GroupLocation"
       name = "Group">
       <Group
+         location = "group:GroupTypeGroupLocation"
+         name = "GroupTypeGroup">
+         <FileRef
+            location = "group:project_in_group_type_group/project_in_group_type_group.xcodeproj">
+         </FileRef>
+      </Group>
+      <Group
          location = "container:GroupLocation/Group2Location"
          name = "Group2">
          <FileRef

--- a/spec/workspace/file_reference_spec.rb
+++ b/spec/workspace/file_reference_spec.rb
@@ -60,7 +60,7 @@ module Xcodeproj
       result.to_s.should == "<FileRef location='group:&quot;&amp;&apos;&gt;&lt;.xcodeproj'/>"
     end
 
-    it 'prepends a parent Group path, if it exists, to a path' do
+    it 'prepends a parent group path, if it exists, to a path' do
       fileref_node = REXML::Element.new('FileRef')
       fileref_node.attributes['location'] = 'group:fileref_subdir/fileref'
 
@@ -70,8 +70,20 @@ module Xcodeproj
       group_node.add_element(fileref_node)
 
       fileref = Workspace::FileReference.from_node(fileref_node)
-      puts fileref.inspect
       fileref.path.to_s.should == 'dir1/dir2/fileref_subdir/fileref'
+    end
+
+    it 'does not prepend a parent group path to non-group type file references' do
+      fileref_node = REXML::Element.new('FileRef')
+      fileref_node.attributes['location'] = 'container:fileref_subdir/fileref'
+
+      group_node = REXML::Element.new('Group')
+      group_node.attributes['location'] = 'container:dir1/dir2'
+      group_node.attributes['name'] = 'The Group Name'
+      group_node.add_element(fileref_node)
+
+      fileref = Workspace::FileReference.from_node(fileref_node)
+      fileref.path.to_s.should == 'fileref_subdir/fileref'
     end
   end
 end

--- a/spec/workspace/group_reference_spec.rb
+++ b/spec/workspace/group_reference_spec.rb
@@ -43,5 +43,19 @@ module Xcodeproj
       result.class.should == REXML::Element
       result.to_s.should == "<Group location='group:' name='&quot;&amp;&apos;&gt;&lt;.xcodeproj'/>"
     end
+
+    it 'prepends a parent group path, if it exists, to a path' do
+      subgroup_node = REXML::Element.new('Group')
+      subgroup_node.attributes['location'] = 'group:groupref_subdir/groupref'
+      subgroup_node.attributes['name'] = 'Subgroup Name'
+
+      group_node = REXML::Element.new('Group')
+      group_node.attributes['location'] = 'container:dir1/dir2'
+      group_node.attributes['name'] = 'Group Name'
+      group_node.add_element(subgroup_node)
+
+      groupref = Workspace::GroupReference.from_node(subgroup_node)
+      groupref.location.to_s.should == 'dir1/dir2/groupref_subdir/groupref'
+    end
   end
 end

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -150,7 +150,10 @@ describe Xcodeproj::Workspace do
     end
 
     it 'contains only test data schemes' do
-      @workspace.schemes.keys.sort.should == %w(WorkspaceSchemesApp WorkspaceSchemesFramework WorkspaceSchemesScheme project_in_subgroup scheme_in_subgroup_with_location)
+      @workspace.schemes.keys.sort.should == %w(
+        WorkspaceSchemesApp WorkspaceSchemesFramework WorkspaceSchemesScheme
+        project_in_group_type_group project_in_subgroup scheme_in_subgroup_with_location
+      )
     end
 
     it 'schemes hash contain path to a valid project/workspace' do


### PR DESCRIPTION
Fixes #657.

File/group references that are nested in parent groups that have a type of `group` will have the parent's path prepended to their own. #633 took care of file references but not group references. Additionally there was no check for whether the type of the file reference was `group`.