### PR TITLE
[Scheme] Serialize `BuildableReference` attributes in schemes in the same order as Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 * Properly loads both project schemes and workspaces schemes on init and
   prevents overriding of incorrect project paths.  
   [joshdholtz](https://github.com/joshdholtz)
-  [#656](https://github.com/CocoaPods/CocoaPods/pull/656)  
+  [#656](https://github.com/CocoaPods/CocoaPods/pull/656)
+
+* Serialize `BuildableReference` attributes in schemes in the same order as Xcode.  
+  [Samuel Giddins](https://github.com/segiddins)
 
 
 ## 1.8.0 (2019-01-25)

--- a/lib/xcodeproj/scheme/buildable_reference.rb
+++ b/lib/xcodeproj/scheme/buildable_reference.rb
@@ -59,10 +59,12 @@ module Xcodeproj
       #        If true, buildable_name will also be updated by computing a name from the target
       #
       def set_reference_target(target, override_buildable_name = false, root_project = nil)
+        # note, the order of assignment here is important, it determines the order of serialization in the xml
+        # this matches the order that Xcode generates
         @xml_element.attributes['BlueprintIdentifier'] = target.uuid
+        self.buildable_name = construct_buildable_name(target) if override_buildable_name
         @xml_element.attributes['BlueprintName'] = target.name
         @xml_element.attributes['ReferencedContainer'] = construct_referenced_container_uri(target, root_project)
-        self.buildable_name = construct_buildable_name(target) if override_buildable_name
       end
 
       # @return [String]

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -241,9 +241,9 @@ module ProjectSpecs
                  <BuildableReference
                     BuildableIdentifier = "primary"
                     BlueprintIdentifier = "8AF293B530B5A8B3208262BD"
+                    BuildableName = "iOS application.app"
                     BlueprintName = "iOS application"
-                    ReferencedContainer = "container:Cocoa Application.xcodeproj"
-                    BuildableName = "iOS application.app">
+                    ReferencedContainer = "container:Cocoa Application.xcodeproj">
                  </BuildableReference>
               </MacroExpansion>
            </TestAction>
@@ -264,9 +264,9 @@ module ProjectSpecs
                  <BuildableReference
                     BuildableIdentifier = "primary"
                     BlueprintIdentifier = "8AF293B530B5A8B3208262BD"
+                    BuildableName = "iOS application.app"
                     BlueprintName = "iOS application"
-                    ReferencedContainer = "container:Cocoa Application.xcodeproj"
-                    BuildableName = "iOS application.app">
+                    ReferencedContainer = "container:Cocoa Application.xcodeproj">
                  </BuildableReference>
               </BuildableProductRunnable>
            </LaunchAction>
@@ -280,9 +280,9 @@ module ProjectSpecs
                  <BuildableReference
                     BuildableIdentifier = "primary"
                     BlueprintIdentifier = "8AF293B530B5A8B3208262BD"
+                    BuildableName = "iOS application.app"
                     BlueprintName = "iOS application"
-                    ReferencedContainer = "container:Cocoa Application.xcodeproj"
-                    BuildableName = "iOS application.app">
+                    ReferencedContainer = "container:Cocoa Application.xcodeproj">
                  </BuildableReference>
               </BuildableProductRunnable>
            </ProfileAction>


### PR DESCRIPTION
This will help minimize diffs