### PR TITLE
Normalize xcconfig path when generating includes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Normalize xcconfig path when generating includes.
   [bclymer](https://github.com/bclymer)
 
+
+
 ## 1.8.1 (2019-02-19)
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,8 @@
 
 ##### Bug Fixes
 
-* Normalize xcconfig path when generating includes.
+* Normalize xcconfig path when generating includes.  
   [bclymer](https://github.com/bclymer)
-
-
 
 ## 1.8.1 (2019-02-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ##### Bug Fixes
 
-* None.  
-
+* Normalize xcconfig path when generating includes.
+  [bclymer](https://github.com/bclymer)
 
 ## 1.8.1 (2019-02-19)
 

--- a/lib/xcodeproj/config.rb
+++ b/lib/xcodeproj/config.rb
@@ -275,7 +275,7 @@ module Xcodeproj
       string.split("\n").each do |line|
         uncommented_line = strip_comment(line)
         if include = extract_include(uncommented_line)
-          @includes.push include
+          @includes.push normalized_xcconfig_path(include)
         else
           key, value = extract_key_value(uncommented_line)
           next unless key

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -207,7 +207,13 @@ Y = 123
     it 'contains file path refs to all included xcconfigs' do
       config = Xcodeproj::Config.new(fixture_path('include.xcconfig'))
       config.includes.size.should.be.equal 1
-      config.includes.first.should.be.equal 'Somefile'
+      config.includes.first.should.be.equal 'Somefile.xcconfig'
+    end
+
+    it 'contains file path refs to all included xcconfigs, even without the extension added' do
+      config = Xcodeproj::Config.new(fixture_path('config-with-include-no-extension.xcconfig'))
+      config.includes.size.should.be.equal 1
+      config.includes.first.should.be.equal 'another-config-with-include.xcconfig'
     end
 
     it 'can be created from multiline file' do

--- a/spec/fixtures/config-with-include-no-extension.xcconfig
+++ b/spec/fixtures/config-with-include-no-extension.xcconfig
@@ -1,0 +1,1 @@
+#include "another-config-with-include"


### PR DESCRIPTION
Nested `.xcconfig` files aren't processed unless they have the `.xcconfig` extension. They weren't considered a readable file here - https://github.com/CocoaPods/Xcodeproj/blob/992afb17a6998f087574ce6b2d6885c9031cb795/lib/xcodeproj/config.rb#L146. Support already existed for normalizing those file paths, it just wasn't invoked when processing the `#includes`. 

I've attached an example project where running `bundle exec pod install` will result in a failure, despite Xcode properly processing and understanding the `SWIFT_VERSION`. Note you must run `bundle install` first.

[Swift Version Test.zip](https://github.com/CocoaPods/Xcodeproj/files/2895022/Swift.Version.Test.zip)

This was found when investigating an update to CocoaPods 1.6.0. The workaround is easy obviously (just adding `.xcconfig` manually), but I still think it's worth a fix :)