### PR TITLE
Set root object compatibility version depending on object version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ##### Bug Fixes
 
+* Set root object compatibility version depending on object version.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso) & [Doug Mead](https://github.com/dmead28)
+  [#668](https://github.com/CocoaPods/Xcodeproj/pull/668)
+
 * Normalize xcconfig path when generating includes.  
   [bclymer](https://github.com/bclymer)
 

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -11,9 +11,11 @@ module Xcodeproj
     LAST_KNOWN_OSX_SDK = '10.14'
 
     # @return [String] The last known tvOS SDK (stable).
+    #
     LAST_KNOWN_TVOS_SDK = '12.0'
 
     # @return [String] The last known watchOS SDK (stable).
+    #
     LAST_KNOWN_WATCHOS_SDK = '5.0'
 
     # @return [String] The last known archive version to Xcodeproj.
@@ -25,6 +27,7 @@ module Xcodeproj
     LAST_KNOWN_SWIFT_VERSION = '4.0'
 
     # @return [String] The default object version for Xcodeproj.
+    #
     DEFAULT_OBJECT_VERSION = 46
 
     # @return [String] The last known object version to Xcodeproj.
@@ -118,6 +121,17 @@ module Xcodeproj
       'xctest'       => 'wrapper.cfbundle',
       'xib'          => 'file.xib',
       'zip'          => 'archive.zip',
+    }.freeze
+
+    # @return [Hash] The compatibility version string for different object versions.
+    #
+    COMPATIBILITY_VERSION_BY_OBJECT_VERSION = {
+      51 => 'Xcode 10.0',
+      50 => 'Xcode 9.3',
+      48 => 'Xcode 8.0',
+      47 => 'Xcode 6.3',
+      46 => 'Xcode 3.2',
+      45 => 'Xcode 3.1',
     }.freeze
 
     # @return [Hash] The uniform type identifier of various product types.

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -80,6 +80,10 @@ module Xcodeproj
       unless skip_initialization
         initialize_from_scratch
         @object_version = object_version.to_s
+        unless Constants::COMPATIBILITY_VERSION_BY_OBJECT_VERSION.key?(object_version)
+          raise ArgumentError, "[Xcodeproj] Unable to find compatibility version string for object version `#{object_version}`."
+        end
+        root_object.compatibility_version = Constants::COMPATIBILITY_VERSION_BY_OBJECT_VERSION[object_version]
       end
     end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -49,6 +49,22 @@ module ProjectSpecs
         @project.root_object.main_group.class.should == PBXGroup
       end
 
+      it 'initializes the root object compatibility version' do
+        @project.root_object.compatibility_version.should == 'Xcode 3.2'
+      end
+
+      it 'initializes the root object compatibility version on different object version' do
+        project = Xcodeproj::Project.new('foo.xcodeproj', false, 50)
+        project.root_object.compatibility_version.should == 'Xcode 9.3'
+      end
+
+      it 'raises when a compatibiliy version string cannot be found for an unknown object version' do
+        e = should.raise ArgumentError do
+          Xcodeproj::Project.new('foo.xcodeproj', false, 999)
+        end
+        e.message.should == '[Xcodeproj] Unable to find compatibility version string for object version `999`.'
+      end
+
       it 'initializes the root object products group' do
         product_ref_group = @project.root_object.product_ref_group
         product_ref_group.class.should == PBXGroup


### PR DESCRIPTION
This is out of sync with the `objectVersion` we set for the generated projects by Xcodeproj and ensures they remain in sync.