### PR TITLE
Use modern localization identifier 'en' for the development region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Normalize xcconfig path when generating includes.  
   [bclymer](https://github.com/bclymer)
 
+* Use modern localization identifier 'en' for the development region.
+  [Steffen Matthischke](https://github.com/heeaad)
+
 ## 1.8.1 (2019-02-19)
 
 ##### Enhancements

--- a/lib/xcodeproj/project/object/root_object.rb
+++ b/lib/xcodeproj/project/object/root_object.rb
@@ -34,7 +34,7 @@ module Xcodeproj
 
         # @return [String] the development region of the project.
         #
-        attribute :development_region, String, 'English'
+        attribute :development_region, String, 'en'
 
         # @return [String] whether the project has scanned for encodings.
         #

--- a/spec/project/object/root_object_spec.rb
+++ b/spec/project/object/root_object_spec.rb
@@ -24,7 +24,7 @@ module ProjectSpecs
     end
 
     it 'returns the development region' do
-      @root_object.development_region.should == 'English'
+      @root_object.development_region.should == 'en'
     end
 
     it 'returns whether has scanned for encodings' do


### PR DESCRIPTION
Change default development_region from "English" to "en" because "English" is deprecated.

# Issue
From the Xcode 10.2 release notes:
> Xcode now more carefully distinguishes between legacy localization identifiers such as “English” and modern localization identifiers such as “en” and represents them both in both project files and the user interface. (45469882)

https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_release_notes?language=objc#3136790

This leads to deprecation warnings in Xcode 10.2:
> Migrating the English, deprecated localization to English is recommended for all projects. This will ensure localized resources are placed in “en.lproj” directories instead of deprecated “English.lproj” directories.