### PR TITLE
CI for ruby 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
+  - 2.6.0
 
 before_install:
   # There is a bug in travis. When using system ruby, bundler is not


### PR DESCRIPTION
Ruby 2.6.0 was released in December 2018 (https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/) and will be the system ruby for macOS 10.15 that will be unveiled for WWDC19 in 2-3 weeks.