### PR TITLE
Add support for runOncePerArchitecture attribute for PBXBuildRule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Add support for `runOncePerArchitecture` attribute for `PBXBuildRule`.  
+  [Alon Karasik](https://github.com/alon-k/)
+  [#712](https://github.com/CocoaPods/Xcodeproj/pull/712)
 
 
 ## 1.12.0 (2019-08-02)

--- a/lib/xcodeproj/project/object/build_rule.rb
+++ b/lib/xcodeproj/project/object/build_rule.rb
@@ -56,6 +56,13 @@ module Xcodeproj
         #
         attribute :output_files_compiler_flags, Array
 
+        # @return [String] whether the rule should be run once per architecture.
+        #
+        # @example
+        #   `0`.
+        #
+        attribute :run_once_per_architecture, String
+
         # @return [String] the content of the script to use for the build rule.
         #
         # @note   This attribute is present if the #{#compiler_spec} is


### PR DESCRIPTION
closes https://github.com/CocoaPods/Xcodeproj/issues/713

This attribute was added with Xcode 11 and whoever updated the gem
to include Xcode 11 updates missed it.