### PR TITLE
Update PBXProject known_regions attribute to include 'Base'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * Add `to_h` alias to `Config`
   [Eric Amorde](https://github.com/amorde/)
   [#710](https://github.com/CocoaPods/Xcodeproj/pull/710)
+
+* Update PBXProject known_regions attribute to include 'Base'  
+  [Liam Nichols](https://github.com/liamnichols)
+  [#9187](https://github.com/CocoaPods/CocoaPods/issues/9187)
   
 
 ##### Bug Fixes

--- a/lib/xcodeproj/project/object/root_object.rb
+++ b/lib/xcodeproj/project/object/root_object.rb
@@ -42,7 +42,7 @@ module Xcodeproj
 
         # @return [Array<String>] the list of known regions.
         #
-        attribute :known_regions, Array, ['en']
+        attribute :known_regions, Array, %w(en Base)
 
         # @return [PBXGroup] the main group of the project. The one displayed
         #         by Xcode in the Project Navigator.

--- a/spec/project/object/root_object_spec.rb
+++ b/spec/project/object/root_object_spec.rb
@@ -32,7 +32,7 @@ module ProjectSpecs
     end
 
     it 'returns the known regions' do
-      @root_object.known_regions.should == %w(en)
+      @root_object.known_regions.should == %w(en Base)
     end
 
     it 'returns the main group' do


### PR DESCRIPTION
Resolves: CocoaPods/CocoaPods/issues/9187

In Xcode 11.1, new projects are created with two known regions: "en" and "Base". A project that does not contain the "Base" region will produce the following warning with the project validator: 

<img width="269" alt="Screenshot 2019-10-09 at 13 29 32" src="https://user-images.githubusercontent.com/482871/66481437-d6222000-ea98-11e9-9ea9-4d5952f62a48.png">

As a result, pods generated using the current version of xcodeproj will produce a warning for each project since the `Base` region is not added by default. This change aims to fix that issue by updating the default value of the `known_regions` array