### PR TITLE
Add support for `productRef` attribute for `PBXTargetDependency`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 ##### Bug Fixes
 
+* Add support for `productRef` attribute for `PBXTargetDependency`.  
+  [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
+  [#715](https://github.com/CocoaPods/Xcodeproj/issues/715)
+
 * Add support for `runOncePerArchitecture` attribute for `PBXBuildRule`.  
   [Alon Karasik](https://github.com/alon-k/)
   [#712](https://github.com/CocoaPods/Xcodeproj/pull/712)

--- a/lib/xcodeproj/project/object/target_dependency.rb
+++ b/lib/xcodeproj/project/object/target_dependency.rb
@@ -30,6 +30,10 @@ module Xcodeproj
         #
         attribute :platform_filter, String
 
+        # @return [String] the product reference for this target dependency.
+        #
+        attribute :product_ref, String
+
         public
 
         # @!group AbstractObject Hooks


### PR DESCRIPTION
closes https://github.com/CocoaPods/Xcodeproj/issues/715