### PR TITLE
Fix small bug where product references have a trailing dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Fix small bug where product references have a trailing dot  
+  [nickgravelyn](https://github.com/nickgravelyn)
+  [#757](https://github.com/CocoaPods/Xcodeproj/pull/757)
 
 
 ## 1.16.0 (2020-04-10)

--- a/lib/xcodeproj/project/object/helpers/file_references_factory.rb
+++ b/lib/xcodeproj/project/object/helpers/file_references_factory.rb
@@ -52,7 +52,9 @@ module Xcodeproj
               prefix = 'lib'
             end
             extension = Constants::PRODUCT_UTI_EXTENSIONS[product_type]
-            ref = new_reference(group, "#{prefix}#{target_name}.#{extension}", :built_products)
+            path = "#{prefix}#{target_name}"
+            path += ".#{extension}" if extension
+            ref = new_reference(group, path, :built_products)
             ref.include_in_index = '0'
             ref.set_explicit_file_type
             ref

--- a/spec/project/object/helpers/file_references_factory_spec.rb
+++ b/spec/project/object/helpers/file_references_factory_spec.rb
@@ -281,5 +281,19 @@ module ProjectSpecs
     end
 
     #-------------------------------------------------------------------------#
+
+    describe '::new_product_ref_for_target' do
+      it 'adds extension for target types that have extensions' do
+        ref = @factory.new_product_ref_for_target(@group, 'Pods', :static_library)
+        ref.path.should == 'libPods.a'
+      end
+
+      it 'does not add trailing dot for target types that do not have extensions' do
+        ref = @factory.new_product_ref_for_target(@group, 'mytool', :command_line_tool)
+        ref.path.should == 'mytool'
+      end
+    end
+
+    #-------------------------------------------------------------------------#
   end
 end


### PR DESCRIPTION
This fixes a small bug with the `new_product_ref_for_target` helper where it didn't create the right path for command line tools because it always adds a `.` to the end, assuming an extension will be after it, but command line tools don't have extensions.

I added a pair of new tests to ensure the change is properly handled for both targets with extensions and those without.