### PR TITLE
Prevent duplicate project references from being added to the generated workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ##### Bug Fixes
 
+* Prevent duplicate project references from being added to the generated workspace.  
+  [Sean Reinhardt](https://github.com/seanreinhardtapps)
+  [#8481](https://github.com/CocoaPods/CocoaPods/issues/8481)
+  
 * Fix small bug where product references have a trailing dot  
   [nickgravelyn](https://github.com/nickgravelyn)
   [#757](https://github.com/CocoaPods/Xcodeproj/pull/757)

--- a/lib/xcodeproj/workspace.rb
+++ b/lib/xcodeproj/workspace.rb
@@ -107,8 +107,9 @@ module Xcodeproj
       else
         raise ArgumentError, "Input to the << operator must be a file path or FileReference, got #{path_or_reference.inspect}"
       end
-
-      @document.root.add_element(project_file_reference.to_node)
+      unless file_references.any? { |ref| project_file_reference.eql? ref }
+        @document.root.add_element(project_file_reference.to_node)
+      end
       load_schemes_from_project File.expand_path(projpath || project_file_reference.path)
     end
 

--- a/lib/xcodeproj/workspace/file_reference.rb
+++ b/lib/xcodeproj/workspace/file_reference.rb
@@ -13,7 +13,7 @@ module Xcodeproj
       # @param [#to_s] type @see type
       #
       def initialize(path, type = 'group')
-        @path = path.to_s
+        @path = Pathname.new(path.to_s).cleanpath.to_s
         @type = type.to_s
       end
 

--- a/spec/workspace/file_reference_spec.rb
+++ b/spec/workspace/file_reference_spec.rb
@@ -30,6 +30,12 @@ module Xcodeproj
       result.should == @file
     end
 
+    it 'cleans messy file paths' do
+      Workspace::FileReference.new('project.xcodeproj').path.should == 'project.xcodeproj'
+      Workspace::FileReference.new('Directory1/directory_2/project.xcodeproj').path.should == 'Directory1/directory_2/project.xcodeproj'
+      Workspace::FileReference.new('D1/D2/../../D3/../Directory/project.xcodeproj').path.should == 'Directory/project.xcodeproj'
+    end
+
     it 'returns the absolute path for group types' do
       result = @file.absolute_path('/path/to/')
       result.should == '/path/to/project.xcodeproj'

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -3,9 +3,9 @@ require File.expand_path('../spec_helper', __FILE__)
 describe Xcodeproj::Workspace do
   describe 'from new' do
     before do
-      pods_project_file_reference = Xcodeproj::Workspace::FileReference.new('Pods/Pods.xcodeproj')
-      project_file_reference = Xcodeproj::Workspace::FileReference.new('App.xcodeproj')
-      @workspace = Xcodeproj::Workspace.new(pods_project_file_reference, project_file_reference)
+      @pods_project_file_reference = Xcodeproj::Workspace::FileReference.new('Pods/Pods.xcodeproj')
+      @project_file_reference = Xcodeproj::Workspace::FileReference.new('App.xcodeproj')
+      @workspace = Xcodeproj::Workspace.new(@pods_project_file_reference, @project_file_reference)
     end
 
     it 'contains the initial projects' do
@@ -15,7 +15,22 @@ describe Xcodeproj::Workspace do
 
     it 'accepts new projects' do
       @workspace << 'Framework.xcodeproj'
-      @workspace.file_references.should.include Xcodeproj::Workspace::FileReference.new('Framework.xcodeproj')
+      proj_ref = Xcodeproj::Workspace::FileReference.new('Framework.xcodeproj')
+      @workspace.file_references.should == [@pods_project_file_reference, @project_file_reference, proj_ref]
+    end
+
+    it 'should skip duplicate projects' do
+      @workspace << 'Framework.xcodeproj'
+      @workspace << 'Framework.xcodeproj'
+      proj_ref = Xcodeproj::Workspace::FileReference.new('Framework.xcodeproj')
+      @workspace.file_references.should == [@pods_project_file_reference, @project_file_reference, proj_ref]
+    end
+
+    it 'should skip duplicate projects with messy paths' do
+      @workspace << 'OtherDirectory/../Directory/Framework.xcodeproj'
+      @workspace << 'Directory/Framework.xcodeproj'
+      proj_ref = Xcodeproj::Workspace::FileReference.new('Directory/Framework.xcodeproj')
+      @workspace.file_references.should == [@pods_project_file_reference, @project_file_reference, proj_ref]
     end
 
     it 'accepts new groups' do


### PR DESCRIPTION
closes CocoaPods/CocoaPods#8481