### PR TITLE
Add framework fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ use to generate project diffs, target diffs, output all configurations and show 
 
 For more information consult `xcodeproj --help`.
 
+## Building/Installing Locally
+
+To build locally run `gem build xcodeproj.gemspec`. You can then install the gem locally replacing
+`*` with your specific gem's version `gem install xcodeproj-*.gem`
+
 ## Collaborate
 
 All Xcodeproj development happens on [GitHub][xcodeproj]. Contributing patches
@@ -80,7 +85,6 @@ is really easy and gratifying.
 
 Follow [@CocoaPods][twitter] to get up to date information about what's
 going on in the CocoaPods world.
-
 
 ## LICENSE
 

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -2,22 +2,6 @@ module Xcodeproj
   # This modules groups all the constants known to Xcodeproj.
   #
   module Constants
-    # @return [String] The last known iOS SDK (stable).
-    #
-    LAST_KNOWN_IOS_SDK = '12.2'
-
-    # @return [String] The last known OS X SDK (stable).
-    #
-    LAST_KNOWN_OSX_SDK = '10.14'
-
-    # @return [String] The last known tvOS SDK (stable).
-    #
-    LAST_KNOWN_TVOS_SDK = '12.2'
-
-    # @return [String] The last known watchOS SDK (stable).
-    #
-    LAST_KNOWN_WATCHOS_SDK = '5.2'
-
     # @return [String] The last known archive version to Xcodeproj.
     #
     LAST_KNOWN_ARCHIVE_VERSION = 1

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -316,6 +316,11 @@ module Xcodeproj
         # @param  [Array<String>, String] names
         #         The name or the list of the names of the framework.
         #
+        # @param  [String] sdk
+        #         Optional version of the sdk you are adding the SDK for. If
+        #         left empty the path will not include the SDK version as
+        #         newer version of xcode use a symbolic link.
+        #
         # @note   Xcode behaviour is following: if the target has the same SDK
         #         of the project it adds the reference relative to the SDK root
         #         otherwise the reference is added relative to the Developer
@@ -327,27 +332,27 @@ module Xcodeproj
         # @return [Array<PBXFileReference>] An array of the newly created file
         #         references.
         #
-        def add_system_framework(names)
+        def add_system_framework(names, sdk = "")
           Array(names).map do |name|
             case platform_name
             when :ios
               group = project.frameworks_group['iOS'] || project.frameworks_group.new_group('iOS')
               path_sdk_name = 'iPhoneOS'
-              path_sdk_version = sdk_version || Constants::LAST_KNOWN_IOS_SDK
             when :osx
               group = project.frameworks_group['OS X'] || project.frameworks_group.new_group('OS X')
               path_sdk_name = 'MacOSX'
-              path_sdk_version = sdk_version || Constants::LAST_KNOWN_OSX_SDK
             when :tvos
               group = project.frameworks_group['tvOS'] || project.frameworks_group.new_group('tvOS')
               path_sdk_name = 'AppleTVOS'
-              path_sdk_version = sdk_version || Constants::LAST_KNOWN_TVOS_SDK
             when :watchos
               group = project.frameworks_group['watchOS'] || project.frameworks_group.new_group('watchOS')
               path_sdk_name = 'WatchOS'
-              path_sdk_version = sdk_version || Constants::LAST_KNOWN_WATCHOS_SDK
             else
               raise 'Unknown platform for target'
+            end
+
+            if (sdk != "") 
+              path_sdk_version = sdk
             end
 
             path = "Platforms/#{path_sdk_name}.platform/Developer/SDKs/#{path_sdk_name}#{path_sdk_version}.sdk/System/Library/Frameworks/#{name}.framework"

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -57,12 +57,6 @@ module Xcodeproj
         # Build phases
         build_phases_for_target_type(type).each { |phase| target.build_phases << project.new(phase) }
 
-        # Frameworks
-        unless type == :static_library
-          framework_name = (platform == :osx) ? 'Cocoa' : 'Foundation'
-          target.add_system_framework(framework_name)
-        end
-
         target
       end
 

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -602,21 +602,18 @@ module ProjectSpecs
           @target.build_configuration_list.set_setting('SDKROOT', 'iphoneos')
           @target.add_system_framework('QuartzCore')
           file = @project['Frameworks/iOS'].files.first
-          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_IOS_SDK
         end
 
         it 'uses the last known tvOS SDK version if none is specified in the target' do
           @target.build_configuration_list.set_setting('SDKROOT', 'appletvos')
           @target.add_system_framework('TVServices')
           file = @project['Frameworks/tvOS'].files.first
-          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_TVOS_SDK
         end
 
         it 'uses the last known watchOS SDK version if none is specified in the target' do
           @target.build_configuration_list.set_setting('SDKROOT', 'watchos')
           @target.add_system_framework('WatchConnectivity')
           file = @project['Frameworks/watchOS'].files.first
-          file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_WATCHOS_SDK
         end
 
         it "doesn't duplicate references to a frameworks if one already exists" do


### PR DESCRIPTION
Fixes #769

This is a WIP PR for issues around adding system frameworks. I would like some insight as to what version of XCode this applies to. Regardless I can confirm this works for anyone using 11 & 12. 

**Issue**
When adding a framework, it is not made obvious that in order to have it point to the right SDK folder you must set the SDKROOT. This also comes with more issues. At least in XCode 11+ the frameworks live in a unspecified SDK version folder (ex: `AppleTVOS.sdk`) with versioned symbolically linked folders (ex: `AppleTVOS14.0`) pointing to the unspecified SDK folder. Therefore, the use of `LAST_KNOWN_TVOS_SDK` causes issues and links to an unknown path. Not to mention that the idea of these values being maintained is an issue of itself. 

You can however set the SDK root and have the frameworks get added with the correct path as commented in #769. However, when adding a target it adds either Cocoa or Foundation automatically if not a static library, which can be unintended. 

I am not sure of the best approach/solution to this problem, but this at least gives some insight into the issue. What I am most concerned about here is the breaking of support for older XCode versions. Should anyone be using 11+ you can at least take these changes and with the additional info in the `README.md` on building and installing locally, you should be able to get this working.