### PR TITLE
Bump Xcode version to suppress warnings to update build settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   [thiagohmcruz](https://github.com/thiagohmcruz)
   [#401](https://github.com/CocoaPods/CocoaPods/issues/401)
 
+* Bump Xcode version to suppress warnings to update build settings  
+  [chuganzy](https://github.com/chuganzy)
+  [#793](https://github.com/CocoaPods/Xcodeproj/pull/793)
+
 ##### Bug Fixes
 
 * Update Swift packages annotations to match Xcode

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -34,13 +34,13 @@ module Xcodeproj
     #
     LAST_KNOWN_OBJECT_VERSION = 54
 
-    # @return [String] The last known object version to Xcodeproj.
+    # @return [String] The last known Xcode version to Xcodeproj.
     #
-    LAST_UPGRADE_CHECK = '1100'
+    LAST_UPGRADE_CHECK = '1200'
 
-    # @return [String] The last known object version to Xcodeproj.
+    # @return [String] The last known Xcode version to Xcodeproj.
     #
-    LAST_SWIFT_UPGRADE_CHECK = '1100'
+    LAST_SWIFT_UPGRADE_CHECK = '1200'
 
     # @return [String] The version of `.xcscheme` files supported by Xcodeproj
     #

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -229,7 +229,7 @@ module ProjectSpecs
         expected = <<-XML.gsub(/^ {8}/, '')
         <?xml version="1.0" encoding="UTF-8"?>
         <Scheme
-           LastUpgradeVersion = "1100"
+           LastUpgradeVersion = "1200"
            version = "1.3">
            <BuildAction
               parallelizeBuildables = "YES"


### PR DESCRIPTION
To suppress these warnings on Xcode 12:

<img width="518" alt="Screen Shot 2020-10-09 at 12 30 23 PM" src="https://user-images.githubusercontent.com/2619092/95624132-37bdf700-0a2b-11eb-90a3-5204a3d54d32.png">
