### PR TITLE
Update Swift packages annotations to match Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ##### Bug Fixes
 
-* None.  
+* Update Swift packages annotations to match Xcode
+  [Tommaso Madonia](https://github.com/Frugghi)
 
 
 ## 1.19.0 (2020-10-09)

--- a/lib/xcodeproj/project/object/build_file.rb
+++ b/lib/xcodeproj/project/object/build_file.rb
@@ -49,7 +49,9 @@ module Xcodeproj
         #         user.
         #
         def display_name
-          if file_ref
+          if product_ref
+            product_ref.display_name
+          elsif file_ref
             file_ref.display_name
           else
             super

--- a/lib/xcodeproj/project/object/swift_package_product_dependency.rb
+++ b/lib/xcodeproj/project/object/swift_package_product_dependency.rb
@@ -13,6 +13,16 @@ module Xcodeproj
         # @return [String] the product name of this Swift package.
         #
         attribute :product_name, String
+
+        # @!group AbstractObject Hooks
+        #--------------------------------------#
+
+        # @return [String] the name of the Swift package.
+        #
+        def display_name
+          return product_name if product_name
+          super
+        end
       end
     end
   end

--- a/lib/xcodeproj/project/object/swift_package_remote_reference.rb
+++ b/lib/xcodeproj/project/object/swift_package_remote_reference.rb
@@ -13,6 +13,20 @@ module Xcodeproj
         # @return [Hash] the version requirements for this Swift package.
         #
         attribute :requirement, Hash
+
+        # @!group AbstractObject Hooks
+        #--------------------------------------#
+
+        def ascii_plist_annotation
+          " #{isa} \"#{File.basename(display_name)}\" "
+        end
+
+        # @return [String] the name of the Swift package repository.
+        #
+        def display_name
+          return repositoryURL if repositoryURL
+          super
+        end
       end
     end
   end

--- a/spec/project/object/build_file_spec.rb
+++ b/spec/project/object/build_file_spec.rb
@@ -29,7 +29,14 @@ module ProjectSpecs
     #-------------------------------------------------------------------------#
 
     describe 'AbstractObject Hooks' do
-      it 'returns the display name of the file reference if one is available' do
+      it 'returns the display name of the Swift package if one is available' do
+        product_ref = @project.new(XCSwiftPackageProductDependency)
+        product_ref.product_name = 'SwiftPackage'
+        @build_file.product_ref = product_ref
+        @build_file.display_name.should == 'SwiftPackage'
+      end
+
+      it 'returns the display name of the file reference if one is available and Swift Package is not set' do
         file_ref = @project.new_file('Class.m')
         @build_file.file_ref = file_ref
         @build_file.display_name.should == 'Class.m'

--- a/spec/project/object/swift_package_product_dependency_spec.rb
+++ b/spec/project/object/swift_package_product_dependency_spec.rb
@@ -1,0 +1,18 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module ProjectSpecs
+  describe Xcodeproj::Project::Object::XCSwiftPackageProductDependency do
+    before do
+      @proxy = @project.new(XCSwiftPackageProductDependency)
+    end
+
+    it 'returns default display_name if product_name is not set' do
+      @proxy.display_name.should == 'SwiftPackageProductDependency'
+    end
+
+    it 'returns product_name for display_name if product_name is set' do
+      @proxy.product_name = 'NiceSwiftPackage'
+      @proxy.display_name.should == 'NiceSwiftPackage'
+    end
+  end
+end

--- a/spec/project/object/swift_package_remote_reference_spec.rb
+++ b/spec/project/object/swift_package_remote_reference_spec.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module ProjectSpecs
+  describe Xcodeproj::Project::Object::XCRemoteSwiftPackageReference do
+    before do
+      @proxy = @project.new(XCRemoteSwiftPackageReference)
+    end
+
+    it 'returns default display_name if repositoryURL is not set' do
+      @proxy.display_name.should == 'RemoteSwiftPackageReference'
+    end
+
+    it 'returns repositoryURL for display_name if repositoryURL is set' do
+      @proxy.repositoryURL = 'github.com/swift/package'
+      @proxy.display_name.should == 'github.com/swift/package'
+    end
+
+    it 'returns the ascii plist annotation with the last component of repositoryURL' do
+      @proxy.repositoryURL = 'github.com/swift/package'
+      @proxy.ascii_plist_annotation.should == ' XCRemoteSwiftPackageReference "package" '
+    end
+  end
+end


### PR DESCRIPTION
In our project we use both CocoaPods and SPM; every time we run `pod install` CocoaPods overrides the annotations of `XCSwiftPackageProductDependency` and `XCRemoteSwiftPackageReference` set by Xcode.

For example, with the "Swifter" Swift package, Xcode generates:
```plist
7DAA0CB4250A47EF003C8564 /* Swifter */ = {
    isa = XCSwiftPackageProductDependency;
    package = 7DAA0CB3250A47EF003C8564 /* XCRemoteSwiftPackageReference "swifter" */;
    productName = Swifter;
};
```
while CocoaPods changes it to:
```plist
7DAA0CB4250A47EF003C8564 /* SwiftPackageProductDependency */ = {
    isa = XCSwiftPackageProductDependency;
    package = 7DAA0CB3250A47EF003C8564 /* RemoteSwiftPackageReference */;
    productName = Swifter;
};
```

This PR matches the Xcode behavior.