### PR TITLE
Update constants for Xcode 12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   [thiagohmcruz](https://github.com/thiagohmcruz)
   [#401](https://github.com/CocoaPods/CocoaPods/issues/401)
 
-* Bump Xcode version to suppress warnings to update build settings  
+* Bump Xcode version constants for Xcode 12.3  
   [chuganzy](https://github.com/chuganzy)
+  [amorde](https://github.com/amorde)
   [#793](https://github.com/CocoaPods/Xcodeproj/pull/793)
 
 ##### Bug Fixes

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -36,11 +36,11 @@ module Xcodeproj
 
     # @return [String] The last known Xcode version to Xcodeproj.
     #
-    LAST_UPGRADE_CHECK = '1200'
+    LAST_UPGRADE_CHECK = '1230'
 
     # @return [String] The last known Xcode version to Xcodeproj.
     #
-    LAST_SWIFT_UPGRADE_CHECK = '1200'
+    LAST_SWIFT_UPGRADE_CHECK = '1230'
 
     # @return [String] The version of `.xcscheme` files supported by Xcodeproj
     #


### PR DESCRIPTION
I checked for new build settings with `spec/fixtures/CommonBuildSettings/rebuild_from_xcode` and there were no changes.