### PR TITLE
Adds the ability to specify sorting options for groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ##### Enhancements
 
-* Add support for group options when using  the sort command
+* Add support for group options when using the sort command
   [zanchee](https://github.com/Zanchee)
+  [imachumphries](https://github.com/imachumphries)
   [#807](https://github.com/CocoaPods/Xcodeproj/pull/807)
 
 * Add support for pre/post-actions in scheme actions  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Add support for group options when using  the sort command
+  [zanchee](https://github.com/Zanchee)
+  [#807](https://github.com/CocoaPods/Xcodeproj/pull/807)
+
 * Add support for pre/post-actions in scheme actions  
   [thiagohmcruz](https://github.com/thiagohmcruz)
   [#401](https://github.com/CocoaPods/CocoaPods/issues/401)

--- a/lib/xcodeproj/command/sort.rb
+++ b/lib/xcodeproj/command/sort.rb
@@ -14,7 +14,7 @@ module Xcodeproj
           ['--group-option=[above|below]', 'The position of the groups when sorting. If no option is specified, sorting will interleave groups and files.'],
         ].concat(super)
       end
-      
+
       self.arguments = [
         CLAide::Argument.new('PROJECT', false),
       ]
@@ -25,8 +25,8 @@ module Xcodeproj
         @group_option &&= @group_option.to_sym
         super
       end
-      
-      def validate
+
+      def validate!
         super
         unless [nil, :above, :below].include?(@group_option)
           help! "Unknown format `#{@group_option}`"
@@ -35,17 +35,7 @@ module Xcodeproj
       end
 
       def run
-          
-        if @group_option
-            if [:above, :below].include? @group_option
-                xcodeproj.sort(groups_position: @group_option)
-            else
-                help! "Unknown format `#{@group_option}`"
-            end
-        else
-            xcodeproj.sort
-        end
-        
+        xcodeproj.sort(:groups_position => @group_option)
         xcodeproj.save
         puts "The `#{File.basename(xcodeproj_path)}` project was sorted"
       end

--- a/lib/xcodeproj/command/sort.rb
+++ b/lib/xcodeproj/command/sort.rb
@@ -9,22 +9,43 @@ module Xcodeproj
 
       self.summary = 'Sorts the given project.'
 
+      def self.options
+        [
+          ['--group-option=[above|below]', 'The position of the groups when sorting. If no option is specified, sorting will interleave groups and files.'],
+        ].concat(super)
+      end
+      
       self.arguments = [
         CLAide::Argument.new('PROJECT', false),
       ]
 
       def initialize(argv)
         self.xcodeproj_path = argv.shift_argument
+        @group_option = argv.option('group-option')
+        @group_option &&= @group_option.to_sym
         super
       end
-
-      def validate!
+      
+      def validate
         super
+        unless [nil, :above, :below].include?(@group_option)
+          help! "Unknown format `#{@group_option}`"
+        end
         open_project!
       end
 
       def run
-        xcodeproj.sort
+          
+        if @group_option
+            if [:above, :below].include? @group_option
+                xcodeproj.sort(groups_position: @group_option)
+            else
+                help! "Unknown format `#{@group_option}`"
+            end
+        else
+            xcodeproj.sort
+        end
+        
         xcodeproj.save
         puts "The `#{File.basename(xcodeproj_path)}` project was sorted"
       end

--- a/spec/command/sort_spec.rb
+++ b/spec/command/sort_spec.rb
@@ -19,7 +19,7 @@ describe Xcodeproj::Command::Sort do
     sort = Xcodeproj::Command::Sort.new(argv)
     sort.instance_variable_get(:@group_option).should == :above
     sort.validate!.should.not.be.nil
-    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be == :above }))
+    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be == { :groups_position => :above } }))
     sort.run
   end
 
@@ -28,7 +28,7 @@ describe Xcodeproj::Command::Sort do
     sort = Xcodeproj::Command::Sort.new(argv)
     sort.instance_variable_get(:@group_option).should == :below
     sort.validate!.should.not.be.nil
-    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be == :below }))
+    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be == { :groups_position => :below } }))
     sort.run
   end
 
@@ -37,7 +37,7 @@ describe Xcodeproj::Command::Sort do
     sort = Xcodeproj::Command::Sort.new(argv)
     sort.instance_variable_get(:@group_option).should.be.nil
     sort.validate!.should.not.be.nil
-    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be.nil }))
+    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be == { :groups_position => nil } }))
     sort.run
   end
 

--- a/spec/command/sort_spec.rb
+++ b/spec/command/sort_spec.rb
@@ -1,0 +1,52 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+class MockXcodeproj
+  def initialize(sort_assertion)
+    @sort_assertion = sort_assertion
+  end
+
+  def sort(options)
+    @sort_assertion.call(options)
+  end
+
+  def save
+  end
+end
+
+describe Xcodeproj::Command::Sort do
+  it 'Can accept above group-option.' do
+    argv = CLAide::ARGV.new(['spec/fixtures/Sample Project/Cocoa Application.xcodeproj', '--group-option=above'])
+    sort = Xcodeproj::Command::Sort.new(argv)
+    sort.instance_variable_get(:@group_option).should == :above
+    sort.validate!.should.not.be.nil
+    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be == :above }))
+    sort.run
+  end
+
+  it 'Can accept below group-option.' do
+    argv = CLAide::ARGV.new(['spec/fixtures/Sample Project/Cocoa Application.xcodeproj', '--group-option=below'])
+    sort = Xcodeproj::Command::Sort.new(argv)
+    sort.instance_variable_get(:@group_option).should == :below
+    sort.validate!.should.not.be.nil
+    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be == :below }))
+    sort.run
+  end
+
+  it 'Can accept missing group-option.' do
+    argv = CLAide::ARGV.new(['spec/fixtures/Sample Project/Cocoa Application.xcodeproj'])
+    sort = Xcodeproj::Command::Sort.new(argv)
+    sort.instance_variable_get(:@group_option).should.be.nil
+    sort.validate!.should.not.be.nil
+    sort.instance_variable_set(:@xcodeproj, MockXcodeproj.new(->(options) { options.should.be.nil }))
+    sort.run
+  end
+
+  it 'raise error when unknown group-option.' do
+    argv = CLAide::ARGV.new(['spec/fixtures/Sample Project/Cocoa Application.xcodeproj', '--group-option=invalid'])
+    sort = Xcodeproj::Command::Sort.new(argv)
+    sort.instance_variable_get(:@group_option).should.be == :invalid
+    should_raise_help 'Unknown format `invalid`' do
+      sort.validate!
+    end
+  end
+end

--- a/spec/spec_helper/project_helper.rb
+++ b/spec/spec_helper/project_helper.rb
@@ -129,4 +129,15 @@ class Bacon::Context
       define_singleton_method(key) { value }
     end
   end
+
+  def should_raise_help(error_message)
+    error = nil
+    begin
+      yield
+    rescue CLAide::Help => e
+      error = e
+    end
+    error.should.not.nil?
+    error.error_message.should == error_message
+  end
 end


### PR DESCRIPTION
The `sort` command doesn't allow the user to specify how they want their project sorted. Instead, groups and files are sorted alphabetically and interleaved with each other.

Xcodeproj already supports the ability to sort with groups above or below files, but the functionality is not exposed to the cli command.

This PR simply exposes that functionality with  a new option.