### PR TITLE
Add support for location scenario reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ##### Enhancements
 
+* Allow accessing a Launch Action's Simulated Location (`LocationScenarioReference`)  
+  [freak4pc](https://github.com/freak4pc)
+  [#813](https://github.com/CocoaPods/Xcodeproj/pull/813)
+
 * Add support for group options when using the sort command
   [zanchee](https://github.com/Zanchee)
   [imachumphries](https://github.com/imachumphries)

--- a/lib/xcodeproj/scheme.rb
+++ b/lib/xcodeproj/scheme.rb
@@ -9,6 +9,7 @@ require 'xcodeproj/scheme/archive_action'
 
 require 'xcodeproj/scheme/buildable_product_runnable'
 require 'xcodeproj/scheme/buildable_reference'
+require 'xcodeproj/scheme/location_scenario_reference'
 require 'xcodeproj/scheme/execution_action'
 require 'xcodeproj/scheme/macro_expansion'
 require 'xcodeproj/scheme/remote_runnable'

--- a/lib/xcodeproj/scheme/launch_action.rb
+++ b/lib/xcodeproj/scheme/launch_action.rb
@@ -47,6 +47,21 @@ module Xcodeproj
         @xml_element.attributes['allowLocationSimulation'] = bool_to_string(flag)
       end
 
+      # @return [LocationScenarioReference]
+      #         The LocationScenarioReference to simulate a GPS location when executing the Launch Action
+      #
+      def location_scenario_reference?
+        LocationScenarioReference.new(@xml_element.elements['LocationScenarioReference'])
+      end
+
+      # @return [LocationScenarioReference]
+      #         Set the LocationScenarioReference which simulates a GPS location when executing the Launch Action
+      #
+      def location_scenario_reference=(reference)
+        @xml_element.delete_element('LocationScenarioReference')
+        @xml_element.add_element(reference.xml_element) if reference
+      end
+
       # @return [Bool]
       #         Whether this Build Action should disable detection of UI API misuse
       #         from background threads

--- a/lib/xcodeproj/scheme/location_scenario_reference.rb
+++ b/lib/xcodeproj/scheme/location_scenario_reference.rb
@@ -1,0 +1,49 @@
+module Xcodeproj
+  class XCScheme
+    # This class wraps the LocationScenarioReference node of a .xcscheme XML file
+    #
+    # A LocationScenarioReference is a reference to a simulated GPS locatio associated
+    # with a scheme's launch action
+    #
+    class LocationScenarioReference < XMLElementWrapper
+      # @param [Xcodeproj::Project::Object::AbstractTarget, REXML::Element] target_or_node
+      #        Either the Xcode target to reference,
+      #        or an existing XML 'LocationScenarioReference' node element to reference
+      #
+      def initialize(target_or_node)
+        create_xml_element_with_fallback(target_or_node, 'LocationScenarioReference') do
+          self.identifier = ''
+          self.reference_type = '0'
+        end
+      end
+
+      # @return [String]
+      #         The identifier of a built-in location scenario reference, or a path to a GPX file
+      #
+      def identifier
+        @xml_element.attributes['identifier']
+      end
+
+      # @param [String] value
+      #        Set the identifier for the location scenario reference
+      #
+      def identifier=(value)
+        @xml_element.attributes['identifier'] = value
+      end
+
+      # @return [String]
+      #         The reference type is 0 when using a custom GPX file, or 1 when using a built-in location reference
+      #
+      def reference_type
+        @xml_element.attributes['referenceType']
+      end
+
+      # @param [String] value
+      #        Set the reference type for the location scenario reference
+      #
+      def reference_type=(value)
+        @xml_element.attributes['referenceType'] = value
+      end
+    end
+  end
+end

--- a/lib/xcodeproj/scheme/location_scenario_reference.rb
+++ b/lib/xcodeproj/scheme/location_scenario_reference.rb
@@ -2,7 +2,7 @@ module Xcodeproj
   class XCScheme
     # This class wraps the LocationScenarioReference node of a .xcscheme XML file
     #
-    # A LocationScenarioReference is a reference to a simulated GPS locatio associated
+    # A LocationScenarioReference is a reference to a simulated GPS location associated
     # with a scheme's launch action
     #
     class LocationScenarioReference < XMLElementWrapper

--- a/spec/scheme/location_scenario_reference_spec.rb
+++ b/spec/scheme/location_scenario_reference_spec.rb
@@ -1,0 +1,72 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  describe XCScheme::LocationScenarioReference do
+    describe 'Created from scratch' do
+      before do
+        @ref = Xcodeproj::XCScheme::LocationScenarioReference.new(nil)
+      end
+
+      it 'Creates an initial, quite empty XML node' do
+        @ref.xml_element.name.should == 'LocationScenarioReference'
+        @ref.xml_element.attributes.count.should == 2
+        @ref.xml_element.attributes['identifier'].should == ''
+        @ref.xml_element.attributes['referenceType'].should == '0'
+      end
+    end
+
+    describe 'Built-in Created from a XML node' do
+      before do
+        node = REXML::Element.new('LocationScenarioReference')
+        attributes = {
+          'identifier' => 'London, England',
+          'referenceType' => '1',
+        }
+        node.add_attributes(attributes)
+        @ref = Xcodeproj::XCScheme::LocationScenarioReference.new(node)
+      end
+
+      it 'raise if invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::LocationScenarioReference.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
+      it '#identifier' do
+        @ref.identifier.should == @ref.xml_element.attributes['identifier']
+      end
+
+      it '#reference_type' do
+        @ref.reference_type.should == @ref.xml_element.attributes['referenceType']
+      end
+    end
+
+    describe 'Custom GPX Created from a XML node' do
+      before do
+        node = REXML::Element.new('LocationScenarioReference')
+        attributes = {
+          'identifier' => 'path/to/AmazingLocation.gpx',
+          'referenceType' => '0',
+        }
+        node.add_attributes(attributes)
+        @ref = Xcodeproj::XCScheme::LocationScenarioReference.new(node)
+      end
+
+      it 'raise if invalid XML node' do
+        node = REXML::Element.new('Foo')
+        should.raise(Informative) do
+          Xcodeproj::XCScheme::LocationScenarioReference.new(node)
+        end.message.should.match /Wrong XML tag name/
+      end
+
+      it '#identifier' do
+        @ref.identifier.should == @ref.xml_element.attributes['identifier']
+      end
+
+      it '#reference_type' do
+        @ref.reference_type.should == @ref.xml_element.attributes['referenceType']
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR parses a launch action's location scenario reference - the portion which defines the simulated GPS location of a runnable scheme

I did my best to assume what are the right tests here, but I'm not a ruby developer so if I missed anything please do let me know :) 

Thanks! 