### PR TITLE
Add fallback to sort group by full path

### DIFF
--- a/lib/xcodeproj/project/object/group.rb
+++ b/lib/xcodeproj/project/object/group.rb
@@ -440,10 +440,12 @@ module Xcodeproj
 
             result = File.basename(x.display_name.downcase, '.*') <=> File.basename(y.display_name.downcase, '.*')
             if result.zero?
-              File.extname(x.display_name.downcase) <=> File.extname(y.display_name.downcase)
-            else
-              result
+              result = File.extname(x.display_name.downcase) <=> File.extname(y.display_name.downcase)
+              if result.zero?
+                result = x.path.downcase <=> y.path.downcase
+              end
             end
+            result
           end
         end
       end


### PR DESCRIPTION
This PR resolves an issue where having several items that have the same `basename` and `extname` would be sorted in an unstable manner.

Example:
```
PBXVariantGroup
|
+- en.lproj/InfoPlist.strings
+- he.lproj/InfoPlist.strings
+- it.lproj/InfoPlist.strings
+- zh-Hant.lproj/InfoPlist.strings
```

Because essentially all of these files have the same `basename` and `extname`, the sort becomes non-deterministic.

Adding a fallback by full path, eg.g `en.lproj/InfoPlist.strings` resolves this.