### PR TITLE
Add an unambiguous sort order to build phase files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ##### Enhancements
 
-* None.  
+* Add an unambiguous sort order to build phase files.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#839](https://github.com/CocoaPods/Xcodeproj/pull/839)
+
+* Add fallback to sort group by full path.  
+  [Igor Makarov](https://github.com/igor-makarov)
+  [#835](https://github.com/CocoaPods/Xcodeproj/pull/835)
 
 ##### Bug Fixes
 

--- a/lib/xcodeproj/project/object/build_phase.rb
+++ b/lib/xcodeproj/project/object/build_phase.rb
@@ -145,6 +145,27 @@ module Xcodeproj
         def ascii_plist_annotation
           " #{display_name} "
         end
+
+        # Sorts the build files of the phase according to the display
+        # name or the path.
+        #
+        # @param  [Hash] _options
+        #         Not used.
+        #
+        # @return [void]
+        #
+        def sort(_options = nil)
+          files.sort! do |x, y|
+            result = File.basename(x.display_name.downcase, '.*') <=> File.basename(y.display_name.downcase, '.*')
+            if result.zero?
+              result = File.extname(x.display_name.downcase) <=> File.extname(y.display_name.downcase)
+              if result.zero? && x.file_ref.respond_to?(:full_path) && y.file_ref.respond_to?(:full_path)
+                result = x.file_ref.full_path.to_s.downcase <=> y.file_ref.full_path.to_s.downcase
+              end
+            end
+            result
+          end
+        end
       end
 
       #-----------------------------------------------------------------------#

--- a/spec/project/object/build_phase_spec.rb
+++ b/spec/project/object/build_phase_spec.rb
@@ -26,6 +26,72 @@ module ProjectSpecs
 
     #----------------------------------------#
 
+    describe '#sort' do
+      it 'sorts file references by name' do
+        files = %w(b a d c)
+        files.each do |filename|
+          file = @project.new_file(filename)
+          @build_phase.add_file_reference(file)
+        end
+        @build_phase.sort
+        @build_phase.files_references.map(&:path).should == %w(a b c d)
+      end
+
+      it 'sorts file references by full name if ambiguous' do
+        files = %w(f.b f.a f.d f.c)
+        files.each do |filename|
+          file = @project.new_file(filename)
+          @build_phase.add_file_reference(file)
+        end
+        @build_phase.sort
+        @build_phase.files_references.map(&:path).should == %w(f.a f.b f.c f.d)
+      end
+
+      it 'sorts file references by file paths if ambiguous' do
+        files = %w(
+          zh-Hant.lproj/InfoPlist.strings
+          he.lproj/InfoPlist.strings
+          ar.lproj/InfoPlist.strings
+          en.lproj/InfoPlist.strings
+          el.lproj/InfoPlist.strings
+        )
+
+        files.each do |filename|
+          file = @project.new_file(filename)
+          @build_phase.add_file_reference(file)
+        end
+        @build_phase.sort
+        @build_phase.files_references.map(&:path).should == %w(
+          ar.lproj/InfoPlist.strings
+          el.lproj/InfoPlist.strings
+          en.lproj/InfoPlist.strings
+          he.lproj/InfoPlist.strings
+          zh-Hant.lproj/InfoPlist.strings
+        )
+      end
+
+      it 'sorts file references by full file paths' do
+        groups = %w(b a d c)
+
+        parent_group = @project.new_group('parent', 'parent')
+
+        groups.each do |group_name|
+          group = parent_group.new_group(group_name, group_name)
+          file = group.new_file('file.json')
+          @build_phase.add_file_reference(file)
+        end
+        @build_phase.sort
+        @build_phase.files_references.map(&:full_path).map(&:to_s).should == %w(
+          parent/a/file.json
+          parent/b/file.json
+          parent/c/file.json
+          parent/d/file.json
+        )
+      end
+    end
+
+    #----------------------------------------#
+
     it "returns the files it's associated with through its build files" do
       file = @project.new_file('some/file')
       @build_phase.add_file_reference(file)


### PR DESCRIPTION
This PR resolves an issue where build files of the same build phase sharing the same filename were being treated as equal by the sort algorithm. This resulted in an unstable sort order.

The PR introduces a defined sort order for build files that aims to remove almost all ambiguity:
* Sort by display base name, lowercased
* If ambiguous, sort by display name, lowercased
* If ambiguous, sort by full path, lowercased

To be clear - before the PR, the build files were being sorted by the default sort impl in `AbstractObject`.