### PR TITLE
Add `platform_filters` support for `PBXTargetDependency`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add `platform_filters` support for `PBXTargetDependency`.  
+  [Max Langer](https://github.com/mangerlahn)
+  [#853](https://github.com/CocoaPods/Xcodeproj/pull/853) 
 
 ##### Bug Fixes
 

--- a/lib/xcodeproj/project/object/target_dependency.rb
+++ b/lib/xcodeproj/project/object/target_dependency.rb
@@ -29,6 +29,10 @@ module Xcodeproj
         # @return [String] the platform filter for this target dependency.
         #
         attribute :platform_filter, String
+        
+        # @return [Array<String>] the platform filters for this target dependency.
+        #
+        attribute :platform_filters, Array
 
         # @return [String] the product reference for this target dependency.
         #

--- a/lib/xcodeproj/project/object/target_dependency.rb
+++ b/lib/xcodeproj/project/object/target_dependency.rb
@@ -29,7 +29,7 @@ module Xcodeproj
         # @return [String] the platform filter for this target dependency.
         #
         attribute :platform_filter, String
-        
+
         # @return [Array<String>] the platform filters for this target dependency.
         #
         attribute :platform_filters, Array


### PR DESCRIPTION
Hi again, 

thank you for quickly implementing `platform_filters` support. While this fixes my usage, I still get a warning when running `xcodeproj`:

`[!] Xcodeproj doesn't know about the following attributes {"platformFilters"=>["macos"]} for the 'PBXTargetDependency' isa`

I attempted to fix this myself, feel free to take a look.