### PR TITLE
Remove build files when underlying `file_ref` is removed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   [Zachary Waldowski](https://github.com/zwaldowski)
   [#862](https://github.com/CocoaPods/Xcodeproj/pull/862)
 
+* Remove build files when underlying file_ref is removed.  
+  [Ben Yohay](https://github.com/byohay)
+  [#861](https://github.com/CocoaPods/Xcodeproj/pull/861)
+
 ##### Bug Fixes
 
 * Fix undefined method 'downcase' for `nil`  

--- a/lib/xcodeproj/project/object/file_reference.rb
+++ b/lib/xcodeproj/project/object/file_reference.rb
@@ -313,8 +313,7 @@ module Xcodeproj
         end
 
         # In addition to removing the file reference, this will also remove any
-        # items related to this reference in case it represents an external
-        # Xcode project.
+        # items related to this reference.
         #
         # @see AbstractObject#remove_from_project
         #
@@ -327,6 +326,8 @@ module Xcodeproj
             project_reference[:product_group].remove_from_project
             project.root_object.project_references.delete(project_reference)
           end
+
+          build_files.each(&:remove_from_project)
           super
         end
 

--- a/lib/xcodeproj/project/object/group.rb
+++ b/lib/xcodeproj/project/object/group.rb
@@ -448,6 +448,25 @@ module Xcodeproj
             result
           end
         end
+
+        # @return [Array<PBXBuildFile>] the build files associated with the
+        #         current reference proxy.
+        #
+        def build_files
+          referrers.grep(PBXBuildFile)
+        end
+
+        # In addition to removing the reference proxy, this will also remove any
+        # items related to this reference.
+        #
+        # @see AbstractObject#remove_from_project
+        #
+        # @return [void]
+        #
+        def remove_from_project
+          build_files.each(&:remove_from_project)
+          super
+        end
       end
 
       #-----------------------------------------------------------------------#

--- a/lib/xcodeproj/project/object/reference_proxy.rb
+++ b/lib/xcodeproj/project/object/reference_proxy.rb
@@ -61,6 +61,25 @@ module Xcodeproj
           return path if path
           super
         end
+
+        # @return [Array<PBXBuildFile>] the build files associated with the
+        #         current reference proxy.
+        #
+        def build_files
+          referrers.grep(PBXBuildFile)
+        end
+
+        # In addition to removing the reference proxy, this will also remove any
+        # items related to this reference.
+        #
+        # @see AbstractObject#remove_from_project
+        #
+        # @return [void]
+        #
+        def remove_from_project
+          build_files.each(&:remove_from_project)
+          super
+        end
       end
     end
   end

--- a/spec/project/object/file_reference_spec.rb
+++ b/spec/project/object/file_reference_spec.rb
@@ -75,6 +75,14 @@ module ProjectSpecs
       @file.comments.should == 'This file was automatically generated.'
     end
 
+    it 'removes the build files when removing the file reference' do
+      @target = @project.new_target(:static_library, 'Pods', :ios)
+      @target.build_phases[0].add_file_reference(@file)
+
+      @file.remove_from_project
+      @target.build_phases[0].files.should.be.empty
+    end
+
     describe 'concerning proxies' do
       it 'returns that it is not a proxy' do
         @file.should.not.be.a.proxy

--- a/spec/project/object/group_spec.rb
+++ b/spec/project/object/group_spec.rb
@@ -352,6 +352,15 @@ module ProjectSpecs
       end
     end
 
+    it 'removes the build files when removing the group' do
+      @target = @project.new_target(:static_library, 'Pods', :ios)
+      build_file = @project.new(Xcodeproj::Project::PBXBuildFile)
+      build_file.file_ref = @group
+      @target.build_phases[0].files << build_file
+
+      @group.remove_from_project
+      @target.build_phases[0].files.should.be.empty
+    end
     #-------------------------------------------------------------------------#
   end
 end

--- a/spec/project/object/reference_proxy_spec.rb
+++ b/spec/project/object/reference_proxy_spec.rb
@@ -24,5 +24,13 @@ module ProjectSpecs
       @proxy.path = 'Path/To/Proxy'
       @proxy.display_name.should == 'Path/To/Proxy'
     end
+
+    it 'removes the build files when removing the reference proxy' do
+      @target = @project.new_target(:static_library, 'Pods', :ios)
+      @target.build_phases[0].add_file_reference(@proxy)
+
+      @proxy.remove_from_project
+      @target.build_phases[0].files.should.be.empty
+    end
   end
 end


### PR DESCRIPTION
A build file doesn't have any meaning without its underlying file
reference, as it can't be built.
In this commit, when a file reference is removed, in addition to the
previous file reference removal logic, the build files that refer to
the file references are removed as well.
Furthermore, the same is done for other types of objects that can be referenced by a build file: `PBXReferenceProxy`, `PBXGroup`.