### PR TITLE
Add `dependency_file` support for `PBXBuildRule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   [Max Langer](https://github.com/mangerlahn)
   [#853](https://github.com/CocoaPods/Xcodeproj/pull/853) 
 
+* Add `dependency_file` support for `PBXBuildRule`.
+  [Zachary Waldowski](https://github.com/zwaldowski)
+  [#862](https://github.com/CocoaPods/Xcodeproj/pull/862)
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/xcodeproj/project/object/build_rule.rb
+++ b/lib/xcodeproj/project/object/build_rule.rb
@@ -17,6 +17,13 @@ module Xcodeproj
         #
         attribute :compiler_spec, String
 
+        # @return [String] the discovered dependency file to use.
+        #
+        # @example
+        #   `$(DERIVED_FILES_DIR)/$(INPUT_FILE_NAME).d`.
+        #
+        attribute :dependency_file, String
+
         # @return [String] the type of the files that should be processed by
         #         this rule.
         #


### PR DESCRIPTION
Trivially adds the property declaration to `PBXBuildRule` to match what's available in `PBXShellScriptBuildPhase`.

This is an example of a Build Rule configuring the `dependencyFile` setting:

<img width="1209" alt="Screen Shot 2021-10-27 at 3 00 11 PM" src="https://user-images.githubusercontent.com/170812/139370317-539b85e0-ffae-4c40-8b9e-1738345b0ffc.png">

