### PR TITLE
Create command

### DIFF
--- a/lib/xcodeproj/command.rb
+++ b/lib/xcodeproj/command.rb
@@ -3,6 +3,7 @@ module Xcodeproj
   require 'claide'
 
   class Command < CLAide::Command
+    require 'xcodeproj/command/create'
     require 'xcodeproj/command/config_dump'
     require 'xcodeproj/command/target_diff'
     require 'xcodeproj/command/project_diff'

--- a/lib/xcodeproj/command/create.rb
+++ b/lib/xcodeproj/command/create.rb
@@ -1,0 +1,36 @@
+module Xcodeproj
+  class Command
+    class Create < Command
+      self.arguments = [
+        CLAide::Argument.new('PROJECT', true),
+      ]
+
+      EXTENSION = '.xcodeproj'
+
+      def initialize(argv)
+        @project_name = argv.shift_argument
+
+        add_extension_if_missing
+
+        super
+      end
+
+      def validate!
+        super
+        help! "Project file not specified" if @project_name.nil?
+        help! "Project already exists" if File.exist?(@project_name)
+      end
+
+      def run
+        project = Xcodeproj::Project.new(@project_name)
+        project.save
+      end
+
+      def add_extension_if_missing
+        return unless @project_name
+
+        @project_name += EXTENSION unless File.extname(@project_name) == EXTENSION
+      end
+    end
+  end
+end

--- a/spec/command/create_spec.rb
+++ b/spec/command/create_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+module Xcodeproj
+  class Command
+    class Create < Command
+      self.arguments = [
+        CLAide::Argument.new('PROJECT', true),
+      ]
+
+      def initialize(argv)
+        self.xcodeproj_path = argv.shift_argument
+        super
+      end
+
+      def validate!
+        super
+        help! "Project file not specified" if self.xcodeproj_path.nil?
+      end
+    end
+  end
+end
+
+
+describe Xcodeproj::Command::Create do
+  it 'errors if a project file has not been provided' do
+    argv = CLAide::ARGV.new([])
+    create = Xcodeproj::Command::Create.new(argv)
+    should_raise_help 'Project file not specified' do
+      create.validate!
+    end
+  end
+
+  it 'errors if the specified project file already exists'
+
+  it 'creates a project file'
+end

--- a/spec/command/create_spec.rb
+++ b/spec/command/create_spec.rb
@@ -1,25 +1,6 @@
 require File.expand_path('../../spec_helper', __FILE__)
 
-module Xcodeproj
-  class Command
-    class Create < Command
-      self.arguments = [
-        CLAide::Argument.new('PROJECT', true),
-      ]
-
-      def initialize(argv)
-        self.xcodeproj_path = argv.shift_argument
-        super
-      end
-
-      def validate!
-        super
-        help! "Project file not specified" if self.xcodeproj_path.nil?
-      end
-    end
-  end
-end
-
+require 'fileutils'
 
 describe Xcodeproj::Command::Create do
   it 'errors if a project file has not been provided' do
@@ -30,7 +11,39 @@ describe Xcodeproj::Command::Create do
     end
   end
 
-  it 'errors if the specified project file already exists'
+  it 'errors if the specified project already exists' do
+    project_dir = 'FooBar.xcodeproj'
+    FileUtils.mkdir(project_dir)
 
-  it 'creates a project file'
+    argv = CLAide::ARGV.new([project_dir])
+    create = Xcodeproj::Command::Create.new(argv)
+    should_raise_help 'Project already exists' do
+      create.validate!
+    end
+  ensure
+    FileUtils.rm_r(project_dir)
+  end
+
+  it 'creates a project file' do
+    project_dir = 'FooBar.xcodeproj'
+    argv = CLAide::ARGV.new([project_dir])
+    create = Xcodeproj::Command::Create.new(argv)
+    create.run
+
+    File.exist?(project_dir).should.be.true
+  ensure
+    FileUtils.rm_r(project_dir)
+  end
+
+  it 'adds the suffix if one is not provided' do
+    project_name = 'FooBar'
+    project_dir = 'FooBar.xcodeproj'
+    argv = CLAide::ARGV.new([project_name])
+    create = Xcodeproj::Command::Create.new(argv)
+    create.run
+
+    File.exist?(project_dir).should.be.true
+  ensure
+    FileUtils.rm_r(project_dir)
+  end
 end


### PR DESCRIPTION
We want to add to the command set of `xcodeproj` so that we can manipulate Xcode projects on non-Mac platforms. The first command is `xcodeproj create PROJECT`.