### PR TITLE
Add `code_coverage_targets` getter/setters to TestAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   [Ben Yohay](https://github.com/byohay)
   [#861](https://github.com/CocoaPods/Xcodeproj/pull/861)
 
-* Add `code_coverage_targets` support for `TestAction`.
+* Add `code_coverage_targets` support for `TestAction`.  
   [Joey Dong](https://github.com/joeydong)
   [#874](https://github.com/CocoaPods/Xcodeproj/pull/874)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
   [Ben Yohay](https://github.com/byohay)
   [#861](https://github.com/CocoaPods/Xcodeproj/pull/861)
 
+* Add `code_coverage_targets` support for `TestAction`.
+  [Joey Dong](https://github.com/joeydong)
+  [#874](https://github.com/CocoaPods/Xcodeproj/pull/874)
+
 ##### Bug Fixes
 
 * Fix undefined method 'downcase' for `nil`  

--- a/lib/xcodeproj/scheme/test_action.rb
+++ b/lib/xcodeproj/scheme/test_action.rb
@@ -151,6 +151,44 @@ module Xcodeproj
         arguments
       end
 
+      # @return [Array<BuildableReference>]
+      #         The list of BuildableReference (code coverage targets) associated with this Test Action
+      #
+      def code_coverage_targets
+        return [] unless @xml_element.elements['CodeCoverageTargets']
+
+        @xml_element.elements['CodeCoverageTargets'].get_elements('BuildableReference').map do |node|
+          BuildableReference.new(node)
+        end
+      end
+
+      # @param [Array<BuildableReference>] buildable_references
+      #         Sets the list of BuildableReference (code coverage targets) associated with this Test Action
+      #
+      def code_coverage_targets=(buildable_references)
+        @xml_element.attributes['onlyGenerateCoverageForSpecifiedTargets'] = bool_to_string(true)
+
+        @xml_element.delete_element('CodeCoverageTargets')
+        coverage_targets_element = @xml_element.add_element('CodeCoverageTargets')
+        buildable_references.each do |reference|
+          coverage_targets_element.add_element(reference.xml_element)
+        end
+
+        code_coverage_targets
+      end
+
+      # @param [BuildableReference] buildable_reference
+      #        Add a BuildableReference (code coverage target) to this Test Action
+      #
+      def add_code_coverage_target(buildable_reference)
+        @xml_element.attributes['onlyGenerateCoverageForSpecifiedTargets'] = bool_to_string(true)
+
+        coverage_targets_element = @xml_element.elements['CodeCoverageTargets'] || @xml_element.add_element('CodeCoverageTargets')
+        coverage_targets_element.add_element(buildable_reference.xml_element)
+
+        code_coverage_targets
+      end
+
       #-------------------------------------------------------------------------#
 
       class TestableReference < XMLElementWrapper

--- a/spec/scheme/test_action_spec.rb
+++ b/spec/scheme/test_action_spec.rb
@@ -231,6 +231,59 @@ module Xcodeproj
           xml_out.should == "<EnvironmentVariables>\n<EnvironmentVariable key='a' value='1' isEnabled='YES'/>\n</EnvironmentVariables>"
         end
       end
+
+      it '#code_coverage_targets' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+        @sut.xml_element.add_element('CodeCoverageTargets')
+
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        buildable_ref1 = XCScheme::BuildableReference.new(target1)
+        @sut.xml_element.elements['CodeCoverageTargets'].add_element(buildable_ref1.xml_element)
+
+        target2 = project.new_target(:application, 'FooApp', :ios)
+        buildable_ref2 = XCScheme::BuildableReference.new(target2)
+        @sut.xml_element.elements['CodeCoverageTargets'].add_element(buildable_ref2.xml_element)
+
+        @sut.code_coverage_targets.count.should == 2
+        @sut.code_coverage_targets.all? { |t| t.class.should == XCScheme::BuildableReference }
+        @sut.code_coverage_targets[0].xml_element.should == buildable_ref1.xml_element
+        @sut.code_coverage_targets[1].xml_element.should == buildable_ref2.xml_element
+      end
+
+      it '#code_coverage_targets=' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        buildable_ref1 = XCScheme::BuildableReference.new(target1)
+
+        target2 = project.new_target(:application, 'FooApp', :ios)
+        buildable_ref2 = XCScheme::BuildableReference.new(target2)
+
+        @sut.code_coverage_targets = [buildable_ref1, buildable_ref2]
+
+        @sut.xml_element.attributes['onlyGenerateCoverageForSpecifiedTargets'].should == 'YES'
+        @sut.code_coverage_targets.count.should == 2
+        @sut.code_coverage_targets.all? { |t| t.class.should == XCScheme::BuildableReference }
+        @sut.code_coverage_targets[0].xml_element.should == buildable_ref1.xml_element
+        @sut.code_coverage_targets[1].xml_element.should == buildable_ref2.xml_element
+      end
+
+      it '#add_code_coverage_target' do
+        project = Xcodeproj::Project.new('/foo/bar/baz.xcodeproj')
+
+        target1 = project.new_target(:application, 'FooApp', :ios)
+        buildable_ref1 = XCScheme::BuildableReference.new(target1)
+        @sut.add_code_coverage_target(buildable_ref1)
+
+        target2 = project.new_target(:application, 'FooApp', :ios)
+        buildable_ref2 = XCScheme::BuildableReference.new(target2)
+        @sut.add_code_coverage_target(buildable_ref2)
+
+        @sut.xml_element.attributes['onlyGenerateCoverageForSpecifiedTargets'].should == 'YES'
+        @sut.xml_element.elements['CodeCoverageTargets'].count.should == 2
+        @sut.xml_element.elements['CodeCoverageTargets/BuildableReference[1]'].should == buildable_ref1.xml_element
+        @sut.xml_element.elements['CodeCoverageTargets/BuildableReference[2]'].should == buildable_ref2.xml_element
+      end
     end
 
     describe XCScheme::TestAction::TestableReference do


### PR DESCRIPTION
Add `code_coverage_targets` getter/setters to TestAction to enable support for setting "Gather coverage for **some** targets" preference as opposed to all or none:

<img width="326" alt="Screen Shot 2022-03-14 at 3 33 52 PM" src="https://user-images.githubusercontent.com/434294/158271917-3a0d8d54-e50c-4ba8-84bf-219cc9252998.png">

