### PR TITLE
Do not raise an exception on a Swift Package dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   [lemonspike](https://github.com/LemonSpike)
   [#709](https://github.com/CocoaPods/Xcodeproj/issues/709)
 
+* Do not raise an exception on a Swift Package dependency.
+  [Vincent Isambart](https://github.com/vincentisambart)
+  [#743](https://github.com/CocoaPods/Xcodeproj/issues/743)
+
 ##### Bug Fixes
 
 * Fix undefined method 'downcase' for `nil`  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
   [lemonspike](https://github.com/LemonSpike)
   [#709](https://github.com/CocoaPods/Xcodeproj/issues/709)
 
-* Do not raise an exception on a Swift Package dependency.
+* Do not raise an exception on a Swift Package dependency.  
   [Vincent Isambart](https://github.com/vincentisambart)
   [#743](https://github.com/CocoaPods/Xcodeproj/issues/743)
 

--- a/lib/xcodeproj/project/object/target_dependency.rb
+++ b/lib/xcodeproj/project/object/target_dependency.rb
@@ -34,9 +34,10 @@ module Xcodeproj
         #
         attribute :platform_filters, Array
 
-        # @return [String] the product reference for this target dependency.
+        # @return [XCSwiftPackageProductDependency] the Swift Package product
+        #         for this target dependency.
         #
-        attribute :product_ref, String
+        has_one :product_ref, XCSwiftPackageProductDependency
 
         public
 
@@ -49,20 +50,22 @@ module Xcodeproj
           return name if name
           return target.name if target
           return target_proxy.remote_info if target_proxy
+          return product_ref.product_name if product_ref
         end
 
         def ascii_plist_annotation
           " #{isa} "
         end
 
-        # @return [String] uuid of the target, if the dependency
-        #         is a native target, otherwise the uuid of the
-        #         target in the sub-project if the dependency is
-        #         a target proxy
+        # @return [String] the uuid of the target if the dependency is a native
+        #         target, the uuid of the target in the sub-project if the
+        #         dependency is a target proxy, nil if the dependency is a Swift
+        #         Package.
         #
         def native_target_uuid
           return target.uuid if target
           return target_proxy.remote_global_id_string if target_proxy
+          return nil if product_ref
           raise "Expected target or target_proxy, from which to fetch a uuid for target '#{display_name}'." \
             "Find and clear the PBXTargetDependency entry with uuid '#{@uuid}' in your .xcodeproj."
         end

--- a/spec/project/object/target_dependency_spec.rb
+++ b/spec/project/object/target_dependency_spec.rb
@@ -85,6 +85,13 @@ module ProjectSpecs
         @target_dependency.target_proxy = proxy
         @target_dependency.display_name.should == 'Pods'
       end
+
+      it 'returns the product name if needed' do
+        product_ref = @project.new(XCSwiftPackageProductDependency)
+        product_ref.product_name = 'SwiftPackage'
+        @target_dependency.product_ref = product_ref
+        @target_dependency.display_name.should == 'SwiftPackage'
+      end
     end
 
     #----------------------------------------#
@@ -111,10 +118,19 @@ module ProjectSpecs
         @target_dependency.native_target_uuid.should == @target_dependency.target.uuid
       end
 
-      it "raises if target and target_proxy aren't set" do
+      it 'returns nil for a Swift Package product' do
+        product_ref = @project.new(XCSwiftPackageProductDependency)
+        product_ref.product_name = 'SwiftPackage'
+
+        @target_dependency.product_ref = product_ref
+        @target_dependency.native_target_uuid.nil?.should == true
+      end
+
+      it "raises if target, target_proxy, and product_ref aren't set" do
         @target_dependency.name = 'TargetName'
         @target_dependency.target.nil?.should == true
         @target_dependency.target_proxy.nil?.should == true
+        @target_dependency.product_ref.nil?.should == true
         should.raise do
           @target_dependency.native_target_uuid
         end.message.should.include "Expected target or target_proxy, from which to fetch a uuid for target 'TargetName'." \


### PR DESCRIPTION
Closes #743

As described in #743, if a project has a target depending on a Swift Package product, calling `Project#host_targets_for_embedded_target` would raise a project inconsistency exception, even though the project had nothing wrong. That method is used by CocoaPods, so any project using explicit dependencies on Swift Package products would not be able to use CocoaPods.

The exception was raised by `PBXTargetDependency#native_target_uuid`. I modified that method to return `nil` if the dependency is a Swift Package project, as there is no native target to return. I also made sure `PBXTargetDependency#display_name` properly returns the product name.
