### PR TITLE
Add `visionos` as a new platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
   [Dimitris Koutsogiorgas](https://github.com/dnkoutso)
   [#910](https://github.com/CocoaPods/Xcodeproj/pull/910)  
 
+* Add `visionOS` as a new platform.
+  [Gabriel Donadel](https://github.com/gabrieldonadel)
+  [#913](https://github.com/CocoaPods/Xcodeproj/pull/913)
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -14,6 +14,10 @@ module Xcodeproj
     #
     LAST_KNOWN_TVOS_SDK = '14.0'
 
+    # @return [String] The last known visionOS SDK (unstable).
+    #
+    LAST_KNOWN_VISIONOS_SDK = '1.0'
+
     # @return [String] The last known watchOS SDK (stable).
     #
     LAST_KNOWN_WATCHOS_SDK = '7.0'
@@ -36,11 +40,11 @@ module Xcodeproj
 
     # @return [String] The last known Xcode version to Xcodeproj.
     #
-    LAST_UPGRADE_CHECK = '1300'
+    LAST_UPGRADE_CHECK = '1500'
 
     # @return [String] The last known Xcode version to Xcodeproj.
     #
-    LAST_SWIFT_UPGRADE_CHECK = '1300'
+    LAST_SWIFT_UPGRADE_CHECK = '1500'
 
     # @return [String] The version of `.xcscheme` files supported by Xcodeproj
     #
@@ -213,6 +217,9 @@ module Xcodeproj
       }.freeze,
       [:tvos] => {
         'SDKROOT'                           => 'appletvos',
+      }.freeze,
+      [:visionos] => {
+        'SDKROOT'                           => 'xros',
       }.freeze,
       [:watchos] => {
         'SDKROOT'                           => 'watchos',

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -112,6 +112,8 @@ module Xcodeproj
             :osx
           elsif sdk.include? 'appletvos'
             :tvos
+          elsif sdk.include? 'xros'
+            :visionos
           elsif sdk.include? 'watchos'
             :watchos
           end
@@ -134,6 +136,7 @@ module Xcodeproj
           :ios => 'IPHONEOS_DEPLOYMENT_TARGET',
           :osx => 'MACOSX_DEPLOYMENT_TARGET',
           :tvos => 'TVOS_DEPLOYMENT_TARGET',
+          :visionos => 'XROS_DEPLOYMENT_TARGET',
           :watchos => 'WATCHOS_DEPLOYMENT_TARGET',
         }.freeze
 
@@ -342,6 +345,10 @@ module Xcodeproj
               group = project.frameworks_group['tvOS'] || project.frameworks_group.new_group('tvOS')
               path_sdk_name = 'AppleTVOS'
               path_sdk_version = sdk_version || Constants::LAST_KNOWN_TVOS_SDK
+            when :visionos
+              group = project.frameworks_group['visionOS'] || project.frameworks_group.new_group('visionOS')
+              path_sdk_name = 'XROS'
+              path_sdk_version = sdk_version || Constants::LAST_KNOWN_VISIONOS_SDK
             when :watchos
               group = project.frameworks_group['watchOS'] || project.frameworks_group.new_group('watchOS')
               path_sdk_name = 'WatchOS'

--- a/lib/xcodeproj/project/project_helper.rb
+++ b/lib/xcodeproj/project/project_helper.rb
@@ -284,6 +284,8 @@ module Xcodeproj
             settings['CLANG_ENABLE_OBJC_WEAK'] = 'NO' if deployment_target < '10.7'
           when :tvos
             settings['TVOS_DEPLOYMENT_TARGET'] = deployment_target
+          when :visionos
+            settings['XROS_DEPLOYMENT_TARGET'] = deployment_target
           when :watchos
             settings['WATCHOS_DEPLOYMENT_TARGET'] = deployment_target
           end

--- a/lib/xcodeproj/xcodebuild_helper.rb
+++ b/lib/xcodeproj/xcodebuild_helper.rb
@@ -27,6 +27,13 @@ module Xcodeproj
       versions_by_sdk[:tvos].sort.last
     end
 
+    # @return [String] The version of the last visionOS sdk.
+    #
+    def last_visionos_sdk
+      parse_sdks_if_needed
+      versions_by_sdk[:visionos].sort.last
+    end
+
     # @return [String] The version of the last watchOS sdk.
     #
     def last_watchos_sdk
@@ -53,6 +60,7 @@ module Xcodeproj
         @versions_by_sdk[:osx] = []
         @versions_by_sdk[:ios] = []
         @versions_by_sdk[:tvos] = []
+        @versions_by_sdk[:visionos] = []
         @versions_by_sdk[:watchos] = []
         if xcodebuild_available?
           sdks = parse_sdks_information(xcodebuild_sdks)
@@ -61,6 +69,7 @@ module Xcodeproj
             when name == 'macosx' then @versions_by_sdk[:osx] << version
             when name == 'iphoneos' then @versions_by_sdk[:ios] << version
             when name == 'appletvos' then @versions_by_sdk[:tvos] << version
+            when name == 'xros' then @versions_by_sdk[:visionos] << version
             when name == 'watchos' then @versions_by_sdk[:watchos] << version
             end
           end
@@ -82,7 +91,7 @@ module Xcodeproj
     #         is the name of the SDK and the second is the version.
     #
     def parse_sdks_information(output)
-      output.scan(/-sdk (macosx|iphoneos|watchos|appletvos)(.+\w)/)
+      output.scan(/-sdk (macosx|iphoneos|watchos|appletvos|xros)(.+\w)/)
     end
 
     # @return [String] The sdk information reported by xcodebuild.

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application and static library.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS application.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests Set Build Target For Running.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
+++ b/spec/fixtures/Sample Project/Cocoa Application.xcodeproj/xcshareddata/xcschemes/iOS applicationTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1500"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -632,7 +632,7 @@ module ProjectSpecs
           @target.build_configuration_list.set_setting('SDKROOT', 'xros')
           @target.add_system_framework('ARKit')
           file = @project['Frameworks/visionOS'].files.first
-          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_VISIONOS_SDK
+          file.path.scan(/\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_VISIONOS_SDK
         end
 
         it 'uses the last known watchOS SDK version if none is specified in the target' do

--- a/spec/project/object/native_target_spec.rb
+++ b/spec/project/object/native_target_spec.rb
@@ -307,6 +307,10 @@ module ProjectSpecs
         t4 = @project.new_target(:static_library, 'Pods', :tvos)
         t4.build_configuration_list.set_setting('SDKROOT', 'tvos9.0')
         t4.sdk_version.should == '9.0'
+
+        t5 = @project.new_target(:static_library, 'Pods', :visionos)
+        t5.build_configuration_list.set_setting('SDKROOT', 'visionos1.0')
+        t5.sdk_version.should == '1.0'
       end
 
       describe 'returns the deployment target specified in its build configuration' do
@@ -323,6 +327,11 @@ module ProjectSpecs
         it 'works for tvOS' do
           @project.build_configuration_list.set_setting('TVOS_DEPLOYMENT_TARGET', nil)
           @project.new_target(:static_library, 'Pods', :tvos, '9.0').deployment_target.should == '9.0'
+        end
+
+        it 'works for visionOS' do
+          @project.build_configuration_list.set_setting('XROS_DEPLOYMENT_TARGET', nil)
+          @project.new_target(:static_library, 'Pods', :visionos, '1.0').deployment_target.should == '1.0'
         end
 
         it 'works for watchOS' do
@@ -358,6 +367,13 @@ module ProjectSpecs
           tv_target = @project.new_target(:static_library, 'Pods', :tvos)
           tv_target.build_configurations.first.build_settings['TVOS_DEPLOYMENT_TARGET'] = nil
           tv_target.deployment_target.should == '9.0'
+        end
+
+        it 'works for visionOS' do
+          @project.build_configuration_list.set_setting('XROS_DEPLOYMENT_TARGET', '1.0')
+          vision_target = @project.new_target(:static_library, 'Pods', :visionos)
+          vision_target.build_configurations.first.build_settings['XROS_DEPLOYMENT_TARGET'] = nil
+          vision_target.deployment_target.should == '1.0'
         end
       end
 
@@ -610,6 +626,13 @@ module ProjectSpecs
           @target.add_system_framework('TVServices')
           file = @project['Frameworks/tvOS'].files.first
           file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_TVOS_SDK
+        end
+
+        it 'uses the last known visionOS SDK version if none is specified in the target' do
+          @target.build_configuration_list.set_setting('SDKROOT', 'xros')
+          @target.add_system_framework('ARKit')
+          file = @project['Frameworks/visionOS'].files.first
+          file.path.scan(/\d\d\.\d/).first.should == Xcodeproj::Constants::LAST_KNOWN_VISIONOS_SDK
         end
 
         it 'uses the last known watchOS SDK version if none is specified in the target' do

--- a/spec/project/project_helper_spec.rb
+++ b/spec/project/project_helper_spec.rb
@@ -45,6 +45,24 @@ module ProjectSpecs
         target.build_phases.map(&:isa).should == %w(PBXHeadersBuildPhase PBXSourcesBuildPhase PBXFrameworksBuildPhase)
       end
 
+      it 'creates a new visionOS target' do
+        target = @helper.new_target(@project, :static_library, 'Pods', :visionos, '1.0', @project.products_group, :objc, nil)
+        target.name.should == 'Pods'
+        target.product_type.should == 'com.apple.product-type.library.static'
+
+        target.build_configuration_list.should.not.be.nil
+        configurations = target.build_configuration_list.build_configurations
+        configurations.map(&:name).sort.should == %w(Debug Release)
+        build_settings = configurations.first.build_settings
+        build_settings['XROS_DEPLOYMENT_TARGET'].should == '1.0'
+        build_settings['SDKROOT'].should == 'xros'
+
+        @project.targets.should.include target
+        @project.products.should.include target.product_reference
+
+        target.build_phases.map(&:isa).should == %w(PBXHeadersBuildPhase PBXSourcesBuildPhase PBXFrameworksBuildPhase)
+      end
+
       it 'creates a new watchOS target' do
         target = @helper.new_target(@project, :static_library, 'Pods', :watchos, '2.0', @project.products_group, :objc, nil)
         target.name.should == 'Pods'

--- a/spec/scheme_spec.rb
+++ b/spec/scheme_spec.rb
@@ -230,7 +230,7 @@ module ProjectSpecs
         expected = <<-XML.gsub(/^ {8}/, '')
         <?xml version="1.0" encoding="UTF-8"?>
         <Scheme
-           LastUpgradeVersion = "1300"
+           LastUpgradeVersion = "1500"
            version = "1.3">
            <BuildAction
               parallelizeBuildables = "YES"

--- a/spec/xcodebuild_helper_spec.rb
+++ b/spec/xcodebuild_helper_spec.rb
@@ -17,6 +17,12 @@ tvOS SDKs:
 tvOS Simulator SDKs:
   Simulator - tvOS 9.0            -sdk appletvsimulator9.0
 
+visionOS SDKs:
+  visionOS 1.0                        -sdk xros1.0
+
+visionOS Simulator SDKs:
+  Simulator - visionOS 1.0            -sdk xrsimulator1.0
+
 watchOS SDKs:
   Watch OS 2.0                    -sdk watchos2.0
 
@@ -50,6 +56,10 @@ module Xcodeproj
         @helper.last_tvos_sdk.should == '9.0'
       end
 
+      it 'returns the last visionOS SDK' do
+        @helper.last_visionos_sdk.should == '1.0'
+      end
+
       it 'returns the last watchOS SDK' do
         @helper.last_watchos_sdk.should == '2.0'
       end
@@ -73,7 +83,7 @@ module Xcodeproj
       describe '#parse_sdks_information' do
         it 'parses the sdks information returned by xcodebuild' do
           result = @helper.send(:parse_sdks_information, SPEC_XCODEBUILD_SAMPLE_SDK_OTPUT)
-          result.should == [['macosx', '10.7'], ['macosx', '10.8'], ['iphoneos', '6.1'], ['appletvos', '9.0'], ['watchos', '2.0']]
+          result.should == [['macosx', '10.7'], ['macosx', '10.8'], ['iphoneos', '6.1'], ['appletvos', '9.0'], ['xros', '1.0'], ['watchos', '2.0']]
         end
       end
     end


### PR DESCRIPTION
This PR introduces `visionOS` as a supported platform. This lays the groundwork for supporting visionOS as a new platform in CocoaPods.


Related to https://github.com/CocoaPods/CocoaPods/issues/11961, https://github.com/CocoaPods/Core/pull/745 and https://github.com/CocoaPods/CocoaPods/pull/11965