### PR TITLE
target_dependency: Fix crash if `target_proxy` is `nil`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* target_dependency: Fix crash if target_proxy is nil.  
+  [Ben Yohay](https://github.com/byohay)
+  [#915](https://github.com/CocoaPods/Xcodeproj/pull/915)
 
 
 ## 1.22.0 (2022-06-22)

--- a/lib/xcodeproj/project/object/target_dependency.rb
+++ b/lib/xcodeproj/project/object/target_dependency.rb
@@ -80,7 +80,7 @@ module Xcodeproj
           hash = {}
           hash['displayName'] = display_name
           hash['isa'] = isa
-          hash['targetProxy'] = target_proxy.to_tree_hash
+          hash['targetProxy'] = target_proxy.to_tree_hash if target_proxy
           hash
         end
 

--- a/spec/project/object/target_dependency_spec.rb
+++ b/spec/project/object/target_dependency_spec.rb
@@ -66,6 +66,17 @@ module ProjectSpecs
       }
     end
 
+    it 'tree hash for target dependency without target proxy' do
+      target = @project.new_target(:static, 'Pods', :ios)
+      @target_dependency.target = target
+      target.dependencies << @target_dependency
+
+      @target_dependency.to_tree_hash.should == {
+        'displayName' => 'Pods',
+        'isa' => 'PBXTargetDependency',
+      }
+    end
+
     #----------------------------------------#
 
     describe '#display_name' do


### PR DESCRIPTION
If `target_proxy` is `nil`, calling `to_tree_hash` on it will raise an
exception: undefined method `to_tree_hash' for nil:NilClass
(NoMethodError).