### PR TITLE
Use relative_path for local Swift packages

### DIFF
--- a/lib/xcodeproj/project/object/swift_package_local_reference.rb
+++ b/lib/xcodeproj/project/object/swift_package_local_reference.rb
@@ -21,7 +21,7 @@ module Xcodeproj
         # @return [String] the path of the local Swift package reference.
         #
         def display_name
-          return path if path
+          return relative_path if relative_path
           super
         end
       end

--- a/lib/xcodeproj/project/object/swift_package_local_reference.rb
+++ b/lib/xcodeproj/project/object/swift_package_local_reference.rb
@@ -6,9 +6,10 @@ module Xcodeproj
       class XCLocalSwiftPackageReference < AbstractObject
         # @!group Attributes
 
-        # @return [String] the repository url this Swift package was installed from.
+        # @return [String] the repository path where the package is located relative
+        # to the Xcode project.
         #
-        attribute :path, String
+        attribute :relative_path, String
 
         # @!group AbstractObject Hooks
         #--------------------------------------#

--- a/lib/xcodeproj/project/object/swift_package_local_reference.rb
+++ b/lib/xcodeproj/project/object/swift_package_local_reference.rb
@@ -7,7 +7,7 @@ module Xcodeproj
         # @!group Attributes
 
         # @return [String] the repository path where the package is located relative
-        # to the Xcode project.
+        #                  to the Xcode project.
         #
         attribute :relative_path, String
 

--- a/lib/xcodeproj/project/object/swift_package_local_reference.rb
+++ b/lib/xcodeproj/project/object/swift_package_local_reference.rb
@@ -6,6 +6,10 @@ module Xcodeproj
       class XCLocalSwiftPackageReference < AbstractObject
         # @!group Attributes
 
+        # @return [String] the repository url this Swift package was installed from.
+        #
+        attribute :path, String
+
         # @return [String] the repository path where the package is located relative
         #                  to the Xcode project.
         #

--- a/spec/project/object/swift_package_local_reference_spec.rb
+++ b/spec/project/object/swift_package_local_reference_spec.rb
@@ -11,12 +11,12 @@ module ProjectSpecs
     end
 
     it 'returns path for display_name if path is set' do
-      @proxy.path = '../path'
+      @proxy.relative_path = '../path'
       @proxy.display_name.should == '../path'
     end
 
     it 'returns the ascii plist annotation with the last component of path' do
-      @proxy.path = '../path'
+      @proxy.relative_path = '../path'
       @proxy.ascii_plist_annotation.should == ' XCLocalSwiftPackageReference "path" '
     end
   end


### PR DESCRIPTION
PR #911 added support for local packages but did not add support for the `relativePath` property inside of the local package definition. Here's a sample from my pbxproj file:

```
/* Begin XCLocalSwiftPackageReference section */
		93ED17092AAED02600B3DB25 /* XCLocalSwiftPackageReference "../../Packages/SharedResources" */ = {
			isa = XCLocalSwiftPackageReference;
			relativePath = ../../Packages/SharedResources;
		};
```
When I try to use the new local package model I got the following error: `[!] Xcodeproj doesn't know about the following attributes {"relativePath"=>"../../Packages/SharedResources"} for the 'XCLocalSwiftPackageReference' isa.` and I believe that was because the class was looking for `path` (which doesn't exist) and not `relativePath` which does.

This PR fixes that problem for local packages.