### PR TITLE
Update remote Swift packages annotations to match Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ##### Bug Fixes
 
-* None.  
+* Update remote Swift packages annotations to match Xcode
+   [alexandre-pod](https://github.com/alexandre-pod)
+   [#921](https://github.com/CocoaPods/Xcodeproj/pull/921)
 
 
 ## 1.23.0 (2023-09-22)

--- a/lib/xcodeproj/project/object/swift_package_remote_reference.rb
+++ b/lib/xcodeproj/project/object/swift_package_remote_reference.rb
@@ -18,7 +18,7 @@ module Xcodeproj
         #--------------------------------------#
 
         def ascii_plist_annotation
-          " #{isa} \"#{File.basename(display_name)}\" "
+          " #{isa} \"#{File.basename(display_name,".git")}\" "
         end
 
         # @return [String] the name of the remote Swift package reference.

--- a/spec/project/object/swift_package_remote_reference_spec.rb
+++ b/spec/project/object/swift_package_remote_reference_spec.rb
@@ -19,5 +19,10 @@ module ProjectSpecs
       @proxy.repositoryURL = 'github.com/swift/package'
       @proxy.ascii_plist_annotation.should == ' XCRemoteSwiftPackageReference "package" '
     end
+
+    it 'returns the ascii plist annotation without the .git extension of repositoryURL' do
+      @proxy.repositoryURL = 'github.com/swift/package.git'
+      @proxy.ascii_plist_annotation.should == ' XCRemoteSwiftPackageReference "package" '
+    end
   end
 end


### PR DESCRIPTION
I am using two tools that use `Xcodeproj` to manipulate Xcode files ([ccios](https://github.com/faberNovel/ccios) and [Kintsugi](https://github.com/Lightricks/Kintsugi/)). But on projects using Swift packages the `Xcodeproj` updates  is not matching what Xcode 14 and 15 generates, it has additional ".git" in packages annotations. 

For example, with a clean project with a single Swift package dependency, when I just read and save the Xcode project using this code (`Xcodeproj::Project.open('./SimpleApp.xcodeproj').save('./SimpleApp.xcodeproj')`), this happens in git:

<img width="810" alt="diff of the .xcodeproj file showing the Xcodeproj adding .git extension in annotations" src="https://github.com/CocoaPods/Xcodeproj/assets/24512899/3c39470f-c845-49eb-93e7-db03e9a0ba53">


This PR make `Xcodeproj` match the Xcode behavior
