### PR TITLE
Add `expected_signature` support for `PBXFileReference`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ##### Enhancements
 
-* Add `expected_signature support` for `PBXFileReference`
+* Add `expected_signature support` for `PBXFileReference`.  
   [hieu9102002](https://github.com/hieu9102002)
   [#924](https://github.com/CocoaPods/Xcodeproj/pull/924)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ##### Enhancements
 
-* None.  
+* Add expected_signature support for PBXFileReference
+  [hieu9102002](https://github.com/hieu9102002)
+  [#924](https://github.com/CocoaPods/Xcodeproj/pull/924)
 
 ##### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ##### Enhancements
 
-* Add expected_signature support for PBXFileReference
+* Add `expected_signature support` for `PBXFileReference`
   [hieu9102002](https://github.com/hieu9102002)
   [#924](https://github.com/CocoaPods/Xcodeproj/pull/924)
 

--- a/lib/xcodeproj/project/object/file_reference.rb
+++ b/lib/xcodeproj/project/object/file_reference.rb
@@ -106,7 +106,7 @@ module Xcodeproj
         #   `0`
         #
         attribute :line_ending, String
-        
+
         # @return [String] a string that specifies the signature of an external
         #         framework.
         #

--- a/lib/xcodeproj/project/object/file_reference.rb
+++ b/lib/xcodeproj/project/object/file_reference.rb
@@ -106,6 +106,14 @@ module Xcodeproj
         #   `0`
         #
         attribute :line_ending, String
+        
+        # @return [String] a string that specifies the signature of an external
+        #         framework.
+        #
+        # @example
+        #   `AppleDeveloperProgram:TEAM0ID1:Team name`
+        #
+        attribute :expected_signature, String
 
         # @return [String] Comments associated with this file.
         #


### PR DESCRIPTION
Trivially adds Expected signature support to PBX File Reference. This option is apparently only available to `xcframeworks` references.

Documentation: https://developer.apple.com/documentation/Xcode/verifying-the-origin-of-your-xcframeworks

Mentioned in #906 with a real example.