### PR TITLE
swift_package_product_dependency: override `ascii_plist_annotation`.

### DIFF
--- a/lib/xcodeproj/project/object/swift_package_product_dependency.rb
+++ b/lib/xcodeproj/project/object/swift_package_product_dependency.rb
@@ -23,6 +23,15 @@ module Xcodeproj
           return product_name if product_name
           super
         end
+
+        # @!group AbstractObject Hooks
+        #--------------------------------------#
+        #
+        # @return [String] the asciii plist annotation of the Swift package product dependency.
+        #
+        def ascii_plist_annotation
+          " #{display_name.delete_prefix('plugin:')} "
+        end
       end
     end
   end

--- a/spec/project/object/swift_package_product_dependency_spec.rb
+++ b/spec/project/object/swift_package_product_dependency_spec.rb
@@ -14,5 +14,10 @@ module ProjectSpecs
       @proxy.product_name = 'NiceSwiftPackage'
       @proxy.display_name.should == 'NiceSwiftPackage'
     end
+
+    it 'returns the ascii plist annotation without the "plugin:" prefix in product_name' do
+      @proxy.product_name = 'plugin:NiceSwiftPackage'
+      @proxy.ascii_plist_annotation.should == ' NiceSwiftPackage '
+    end
   end
 end


### PR DESCRIPTION
We have a build plugin which is a Swift package, it's represented as a `XCSwiftPackageProductDependency` object. The display name contains a "plugin:" prefix so when it's serialized it's everywhere. The problem is that Xcode removes this prefix and uses the package name in the keys of the serialized objects and in refs to them.

Below is an example before and after the change.

before (wrong):
```
/* Begin XCSwiftPackageProductDependency section */
		19AA76E52A9F557900F1F6A1 /* plugin:SomePackageName */ = {
			isa = XCSwiftPackageProductDependency;
			productName = "plugin:SomePackageName";
		};
```
after (correct):
```
/* Begin XCSwiftPackageProductDependency section */
		19AA76E52A9F557900F1F6A1 /* SomePackageName */ = {
			isa = XCSwiftPackageProductDependency;
			productName = "plugin:SomePackageName";
		};
```