### PR TITLE
fix: Support optional includes

### DIFF
--- a/lib/xcodeproj/config.rb
+++ b/lib/xcodeproj/config.rb
@@ -341,7 +341,7 @@ module Xcodeproj
     # @return [Nil] if no include was found in the line.
     #
     def extract_include(line)
-      regexp = /#include\s*"(.+)"/
+      regexp = /#include\??\s*"(.+)"/
       match = line.match(regexp)
       match[1] if match
     end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -229,6 +229,12 @@ Y = 123
       config.includes.first.should.be.equal 'Somefile.xcconfig'
     end
 
+    it 'contains file path refs to optional included xcconfigs' do
+      config = Xcodeproj::Config.new(fixture_path('optional-include.xcconfig'))
+      config.includes.size.should.be.equal 1
+      config.includes.first.should.be.equal 'Optional.xcconfig'
+    end
+
     it 'contains file path refs to all included xcconfigs, even without the extension added' do
       config = Xcodeproj::Config.new(fixture_path('config-with-include-no-extension.xcconfig'))
       config.includes.size.should.be.equal 1

--- a/spec/fixtures/optional-include.xcconfig
+++ b/spec/fixtures/optional-include.xcconfig
@@ -1,0 +1,1 @@
+#include? "Optional.xcconfig"


### PR DESCRIPTION
This PR adds support for the optional include syntax `#include?`. Xcode will include these files if they exist and ignore the entries otherwise.

Due to how the library currently handles includes, it's only the syntax that needs to be supported as it already considers all includes optional.