### PR TITLE
Relax required REXML version

### DIFF
--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'claide',         '>= 1.0.2', '< 2.0'
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'nanaimo',        '~> 0.3.0'
-  s.add_runtime_dependency 'rexml',          '~> 3.2.4'
+  s.add_runtime_dependency 'rexml',          '~> 3.2', '>= 3.2.4'
 
   ## Make sure you can build the gem on older versions of RubyGems too:
   s.rubygems_version = '1.6.2'


### PR DESCRIPTION
fix #943

REXML doesn't use the semantic versioning. So `~> 3.2.4` doesn't match for REXML dependency. For example, 3.3.0 doesn't have backward incompatibility.