### PR TITLE
Update rexml dependency (CVE-2024-39908)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ PATH
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.3.2)
+      rexml (>= 3.3.2, < 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ PATH
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (~> 3.3.2)
 
 GEM
   remote: https://rubygems.org/
@@ -94,7 +94,8 @@ GEM
       ffi (>= 0.5.0)
     rb-kqueue (0.2.4)
       ffi (>= 0.5.0)
-    rexml (3.2.6)
+    rexml (3.3.2)
+      strscan
     rubocop (0.47.1)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
@@ -110,6 +111,7 @@ GEM
       multi_json (~> 1.0)
       simplecov-html (~> 0.9.0)
     simplecov-html (0.9.0)
+    strscan (3.1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.4.0)

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'claide',         '>= 1.0.2', '< 2.0'
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'nanaimo',        '~> 0.3.0'
-  s.add_runtime_dependency 'rexml',          '~> 3.2.4'
+  s.add_runtime_dependency 'rexml',          '~> 3.3.2'
 
   ## Make sure you can build the gem on older versions of RubyGems too:
   s.rubygems_version = '1.6.2'

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'claide',         '>= 1.0.2', '< 2.0'
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'nanaimo',        '~> 0.3.0'
-  s.add_runtime_dependency 'rexml',          '~> 3.3.2'
+  s.add_runtime_dependency 'rexml',          '>= 3.3.2', '< 4.0'
 
   ## Make sure you can build the gem on older versions of RubyGems too:
   s.rubygems_version = '1.6.2'


### PR DESCRIPTION
There is a DoS vulnerability in REXML gem. This vulnerability has been assigned the CVE identifier [CVE-2024-39908](https://www.cve.org/CVERecord?id=CVE-2024-399086). We strongly recommend upgrading the REXML gem.

**Details**
When it parses an XML that has many specific characters such as <, 0 and %>. REXML gem may take long time.

Please update REXML gem to version 3.3.2 or later.

**Affected versions**
REXML gem 3.3.2 or prior