### PR TITLE
Don't raise an exception on newer Xcode than latest known

### DIFF
--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -221,11 +221,11 @@ module Xcodeproj
       end
 
       if archive_version.to_i > Constants::LAST_KNOWN_ARCHIVE_VERSION
-        puts "WARN: [Xcodeproj] Unknown archive version (#{archive_version.to_i})."
+        puts "WARN: [Xcodeproj] Archive version (#{archive_version.to_i}) is higher than the latest supported by xcodeproj (#{Constants::LAST_KNOWN_ARCHIVE_VERSION})."
       end
 
       if object_version.to_i > Constants::LAST_KNOWN_OBJECT_VERSION
-        puts "WARN: [Xcodeproj] Unknown object version (#{object_version.to_i})."
+        puts "WARN: [Xcodeproj] Xcode project version (#{object_version.to_i}) is higher than the latest supported by xcodeproj (#{Constants::LAST_KNOWN_OBJECT_VERSION})."
       end
 
       # Projects can have product_ref_groups that are not listed in the main_groups["Products"]

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -224,10 +224,6 @@ module Xcodeproj
         raise "[Xcodeproj] Unknown archive version (#{archive_version.to_i})."
       end
 
-      if object_version.to_i > Constants::LAST_KNOWN_OBJECT_VERSION
-        raise "[Xcodeproj] Unknown object version (#{object_version.to_i})."
-      end
-
       # Projects can have product_ref_groups that are not listed in the main_groups["Products"]
       root_object.product_ref_group ||= root_object.main_group['Products'] || root_object.main_group.new_group('Products')
     end

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -221,11 +221,11 @@ module Xcodeproj
       end
 
       if archive_version.to_i > Constants::LAST_KNOWN_ARCHIVE_VERSION
-        puts "WARN: [Xcodeproj] Archive version (#{archive_version.to_i}) is higher than the latest supported by xcodeproj (#{Constants::LAST_KNOWN_ARCHIVE_VERSION})."
+        UI.warn "[Xcodeproj] Archive version (#{archive_version.to_i}) is higher than the latest supported by xcodeproj (#{Constants::LAST_KNOWN_ARCHIVE_VERSION})."
       end
 
       if object_version.to_i > Constants::LAST_KNOWN_OBJECT_VERSION
-        puts "WARN: [Xcodeproj] Xcode project version (#{object_version.to_i}) is higher than the latest supported by xcodeproj (#{Constants::LAST_KNOWN_OBJECT_VERSION})."
+        UI.warn "[Xcodeproj] Xcode project version (#{object_version.to_i}) is higher than the latest supported by xcodeproj (#{Constants::LAST_KNOWN_OBJECT_VERSION})."
       end
 
       # Projects can have product_ref_groups that are not listed in the main_groups["Products"]

--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -221,7 +221,11 @@ module Xcodeproj
       end
 
       if archive_version.to_i > Constants::LAST_KNOWN_ARCHIVE_VERSION
-        raise "[Xcodeproj] Unknown archive version (#{archive_version.to_i})."
+        puts "WARN: [Xcodeproj] Unknown archive version (#{archive_version.to_i})."
+      end
+
+      if object_version.to_i > Constants::LAST_KNOWN_OBJECT_VERSION
+        puts "WARN: [Xcodeproj] Unknown object version (#{object_version.to_i})."
       end
 
       # Projects can have product_ref_groups that are not listed in the main_groups["Products"]


### PR DESCRIPTION
- remove exception on newer Xcode version and log only warning to inform user they are using newer xcode than the latest supported by xcodeproj - if things don't work, it will fail automatically on the right place - but chance is newer Xcode simply works so there is no reason why users should be blocked by outdated xcodeproj

Fixes issues like https://github.com/CocoaPods/Xcodeproj/issues/933 where [fix](https://github.com/CocoaPods/Xcodeproj/pull/934) is merged in but **still not released** and users are blocked for months.