### PR TITLE
Fix for builds broken by Xcode 16

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -132,6 +132,7 @@ module Xcodeproj
     # @return [Hash] The compatibility version string for different object versions.
     #
     COMPATIBILITY_VERSION_BY_OBJECT_VERSION = {
+      70 => 'Xcode 16.0',
       63 => 'Xcode 15.3',
       60 => 'Xcode 15.0',
       56 => 'Xcode 14.0',

--- a/lib/xcodeproj/project/object/group.rb
+++ b/lib/xcodeproj/project/object/group.rb
@@ -501,6 +501,11 @@ module Xcodeproj
       end
 
       #-----------------------------------------------------------------------#
+
+      # A new group type introduced by Xcode 16
+      #
+      class PBXFileSystemSynchronizedRootGroup < PBXGroup
+      end
     end
   end
 end

--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -461,6 +461,11 @@ module Xcodeproj
         #
         has_many :build_phases, AbstractBuildPhase
 
+        # @return [ObjectList<PBXFileSystemSynchronizedRootGroup>] the synchronized 
+        #         folder groups used by this target.
+        #
+        has_many :fileSystemSynchronizedGroups, PBXFileSystemSynchronizedRootGroup
+
         public
 
         # @!group Helpers


### PR DESCRIPTION
I hope this format for the PR is okay, never contributed here before. I ran into this when our intern grouped the 3 files he was working on and broke builds. I rolled back the grouping in our project, but I wanted CocoaPods to be able to support it going forward.

Changes:
- Add object version 70 to version map
- Add support for new folder group type (PBXFileSystemSynchronizedRootGroup), currently an empty implementation to resolve error

Related Issues:
- https://github.com/CocoaPods/Xcodeproj/issues/950
- https://github.com/CocoaPods/Xcodeproj/issues/951
- https://github.com/CocoaPods/Xcodeproj/issues/963
- https://github.com/CocoaPods/Xcodeproj/issues/965
- https://github.com/CocoaPods/Xcodeproj/issues/966
- https://github.com/CocoaPods/Xcodeproj/issues/967
- https://github.com/CocoaPods/Xcodeproj/issues/968
- https://github.com/CocoaPods/Xcodeproj/issues/969
- https://github.com/CocoaPods/Xcodeproj/issues/974

