### PR TITLE
Update PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet to correctly support build_phase attribute pointing to PBXCopyFilesBuildPhase

### DIFF
--- a/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
@@ -41,9 +41,9 @@ module Xcodeproj
 
       # This class represents a file system synchronized group build phase membership exception set.
       class PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet < AbstractObject
-        # @return [PBXSourcesBuildPhase] The build phase to which this exception set applies.
+        # @return [PBXSourcesBuildPhase, PBXCopyFilesBuildPhase] The build phase to which this exception set applies.
         #
-        has_one :build_phase, PBXSourcesBuildPhase
+        has_one :build_phase, [PBXSourcesBuildPhase, PBXCopyFilesBuildPhase]
 
         # @return [Array<String>] The list of files in the group that are excluded from the build phase.
         #


### PR DESCRIPTION
Follow up to https://github.com/CocoaPods/Xcodeproj/pull/985

If adding a target such as a static library with `Objective-C` language selected, the `Copy Files` build phase will have an exception set for the public headers.

Example:

```
/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
	0782A2F32CCD962C007072F5 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {
		isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
		buildPhase = 0782A2EB2CCD962C007072F5 /* CopyFiles */;
		membershipExceptions = (
			Objc_iOS_StaticLibrary.h,
		);
	};
/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
```

When attempting to read this project an error would occur:

```
[Xcodeproj] Type checking error: got `PBXCopyFilesBuildPhase` for attribute: Attribute `buildPhase` (type: `to_one`, classes: `["PBXSourcesBuildPhase"]`, owner class: `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet`)
```