### PR TITLE
Fix exception set comment to match Xcode

### DIFF
--- a/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
@@ -54,7 +54,7 @@ module Xcodeproj
         attribute :platform_filters_by_relative_path, Hash
 
         def display_name
-          "Exceptions for \"#{GroupableHelper.parent(self).display_name}\" folder in \"#{build_phase.name}\" build phase"
+          "PBXFileSystemSynchronizedBuildFileExceptionSet"
         end
       end
     end


### PR DESCRIPTION
When Xcode edits the project file, it reverts this specific (though helpful) comment to `PBXFileSystemSynchronizedBuildFileExceptionSet`.

So this prevents this line from continuing to get changed/reverted as we edit project files in both Xcode and `xcodeproj`