### PR TITLE
Add support for the `name` attribute

### DIFF
--- a/lib/xcodeproj/project/object/file_system_synchronized_root_group.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_root_group.rb
@@ -19,9 +19,13 @@ module Xcodeproj
         #
         attribute :source_tree, String, '<group>'
 
-        # @return [String] the path to a folder in the file system.
+        # @return [String] The path to a folder in the file system.
         #
         attribute :path, String
+
+        # @return [String] The display name of the folder.
+        #
+        attribute :name, String
 
         # @return [String] Whether Xcode should use tabs for text alignment.
         #

--- a/lib/xcodeproj/project/object/helpers/groupable_helper.rb
+++ b/lib/xcodeproj/project/object/helpers/groupable_helper.rb
@@ -153,7 +153,7 @@ module Xcodeproj
                 real_path(object_parent)
               end
             when 'SOURCE_ROOT'
-              object.project.project_dir
+              object.project.project_dir + object.project.root_object.project_dir_path
             when '<absolute>'
               nil
             else

--- a/spec/project/object/helpers/groupable_helper_spec.rb
+++ b/spec/project/object/helpers/groupable_helper_spec.rb
@@ -183,8 +183,15 @@ module ProjectSpecs
         @helper.source_tree_real_path(@group).should == Pathname.new('/project_dir')
       end
 
-      it 'check project_dir_path adjustment' do
+      it 'check project_dir_path adjustment relative to main group' do
         @group.source_tree = '<group>'
+        @project.root_object.stubs(:project_dir_path).returns('../')
+        @helper.source_tree_real_path(@group).to_s.should.not.include Pathname.new('/project_dir').to_s
+        Pathname.new('/project_dir').to_s.should.include @helper.source_tree_real_path(@group).to_s
+      end
+
+      it 'check project_dir_path adjustment relative to project root' do
+        @group.source_tree = 'SOURCE_ROOT'
         @project.root_object.stubs(:project_dir_path).returns('../')
         @helper.source_tree_real_path(@group).to_s.should.not.include Pathname.new('/project_dir').to_s
         Pathname.new('/project_dir').to_s.should.include @helper.source_tree_real_path(@group).to_s


### PR DESCRIPTION
`PBXFileSystemSynchronizedRootGroup` supports a `name` attribute, which allows Xcode to display a different name than the path for a folder.

This PR adds support for this attribute (along with a tiny capitalization fix in the comments :) )

We would like for this be included in the next CocoaPods release so we can use the changes.