### PR TITLE
Remove empty `()` from PBXFileSystemSynchronizedRootGroup exceptions output

### DIFF
--- a/lib/xcodeproj/project/object/file_system_synchronized_root_group.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_root_group.rb
@@ -68,6 +68,21 @@ module Xcodeproj
           return path if path
           super
         end
+
+        def to_hash_as(method = :to_hash)
+          hash_as = super
+          excluded_keys_for_serialization_when_empty.each do |key|
+            if !hash_as[key].nil? && hash_as[key].empty?
+              hash_as.delete(key)
+            end
+          end
+          hash_as
+        end
+
+        # @return [Array<String>] array of keys to exclude from serialization when the value is empty
+        def excluded_keys_for_serialization_when_empty
+          %w(exceptions)
+        end
       end
     end
   end

--- a/spec/project/object/file_system_synchronized_root_group_spec.rb
+++ b/spec/project/object/file_system_synchronized_root_group_spec.rb
@@ -1,0 +1,27 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module ProjectSpecs
+  describe PBXFileSystemSynchronizedRootGroup do
+    before do
+      @project = Project.new('/path/to/Dummy.xcodeproj')
+      @root_group = @project.new(PBXFileSystemSynchronizedRootGroup)
+    end
+
+    describe '#to_hash' do
+      it "does not include exceptions in its hash if there aren't any" do
+        @root_group.to_hash['exceptions'].should.be.nil
+      end
+
+      it 'includes exceptions in its hash if it contains at least one' do
+        target = @project.new(PBXNativeTarget)
+        target.name = "TestTarget"
+
+        exception = @project.new(PBXFileSystemSynchronizedBuildFileExceptionSet)
+        exception.target = target
+        @root_group.exceptions << exception
+
+        @root_group.to_hash['exceptions'].should == [exception.uuid]
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Background

When using "Convert to Folder" on groups in projects within a CocoaPods workspace, an empty `exceptions = ();` entry is unnecessarily added to the pbxproj file.

## Why This Is a Problem

There's no need to include this empty configuration when there are no exceptions. If it were truly necessary, Xcode itself would add `exceptions = ();` when performing the Convert to Folder operation. These unnecessary entries make the project file needlessly complex and create unwanted diffs.

## Solution

The `PBXNativeTarget` class in this project already overrides the `to_hash_as` method to exclude empty collections (like packageProductDependencies) from serialization.

By extending the `PBXFileSystemSynchronizedRootGroup` class with a similar approach, we can prevent empty exceptions collections from being serialized, eliminating the unnecessary `exceptions = ();` entries in pbxproj files.