### PR TITLE
Adding missing parameter on the PBXAggregatedTarget

### DIFF
--- a/lib/xcodeproj/project/object/native_target.rb
+++ b/lib/xcodeproj/project/object/native_target.rb
@@ -729,6 +729,11 @@ module Xcodeproj
         #         target.
         #
         has_many :build_phases, [PBXCopyFilesBuildPhase, PBXShellScriptBuildPhase]
+
+        # @return [ObjectList<XCSwiftPackageProductDependency>] the Swift package products necessary to
+        #         build this target.
+        #
+        has_many :package_product_dependencies, XCSwiftPackageProductDependency
       end
 
       #-----------------------------------------------------------------------#


### PR DESCRIPTION
Solves #892 .

For projects that have SPM support xcodeproj complains about unknown attribute `packageProductDependencies` for the `PBXAggregatedTarget`. 

This attribute was already supported in the `PBXNativeTarget`. This PR simply copies that support

```
[!] Xcodeproj doesn't know about the following attributes {"packageProductDependencies" => []} for the 'PBXAggregateTarget' isa.
If this attribute was generated by Xcode please file an issue: https://github.com/CocoaPods/Xcodeproj/issues/new
```