### PR TITLE
Future proof for different objectVersion (include objectVersion 70)

### DIFF
--- a/lib/xcodeproj/project.rb
+++ b/lib/xcodeproj/project.rb
@@ -81,10 +81,9 @@ module Xcodeproj
       unless skip_initialization
         initialize_from_scratch
         @object_version = object_version.to_s
-        unless Constants::COMPATIBILITY_VERSION_BY_OBJECT_VERSION.key?(object_version)
-          raise ArgumentError, "[Xcodeproj] Unable to find compatibility version string for object version `#{object_version}`."
+        if Constants::COMPATIBILITY_VERSION_BY_OBJECT_VERSION.key?(object_version)
+          root_object.compatibility_version = Constants::COMPATIBILITY_VERSION_BY_OBJECT_VERSION[object_version]
         end
-        root_object.compatibility_version = Constants::COMPATIBILITY_VERSION_BY_OBJECT_VERSION[object_version]
       end
     end
 


### PR DESCRIPTION
the xcodeproj format includes a version value that can help with some parsing options, however, Xcode can use different values for the same version of Xcode (e.g with Xcode 16.2, selecting project format 15.3 will give you an `objectVersion: 70`) whereas xcodeproj assumes that Xcode 15.3 is 63.

This `objectVersion` is used as a key to populate another value which is mostly for human consumption (`compatibility_version`) However, neither Xcode, nor other tools i have used rely on it for anything. 

The problem arises when an "unknown" version is presented to xcodeproj for parsing. Not always is possible to edit it in xcode prior running `pod install` or parsing the project. For example, if the project is generated with xcodegen this number is fixed and always regenerated.

This PR aims to right that wrong. Basically, consuming the value from the project, and only populating the `compatibility_version` if it's known, but doesn't stop the project from carry on working, making it more future proof.