### PR TITLE
Fix evaluation of `SOURCE_ROOT`

### DIFF
--- a/lib/xcodeproj/project/object/file_system_synchronized_root_group.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_root_group.rb
@@ -19,9 +19,13 @@ module Xcodeproj
         #
         attribute :source_tree, String, '<group>'
 
-        # @return [String] the path to a folder in the file system.
+        # @return [String] The path to a folder in the file system.
         #
         attribute :path, String
+
+        # @return [String] The display name of the folder.
+        #
+        attribute :name, String
 
         # @return [String] Whether Xcode should use tabs for text alignment.
         #

--- a/lib/xcodeproj/project/object/helpers/groupable_helper.rb
+++ b/lib/xcodeproj/project/object/helpers/groupable_helper.rb
@@ -153,7 +153,7 @@ module Xcodeproj
                 real_path(object_parent)
               end
             when 'SOURCE_ROOT'
-              object.project.project_dir
+              object.project.project_dir + object.project.root_object.project_dir_path
             when '<absolute>'
               nil
             else


### PR DESCRIPTION
The value of the `SOURCE_ROOT` variable was evaluated incorrectly by CocoaPods.

In Xcode, it is the path to the root of the repository (e.g. `~/Developer/shapr3d`) but in the CocoaPods implementation, it was expanded to the path to the project, which, in the case of `KernelProject.xcodeproj` was `~/Developer/shapr3d/build/cmake`.

This mismatch caused CocoaPods to not find the `.xcconfig` file of targets generated by CMake (e.g. `SPLibBinginsTests`).

> [!TIP]
> See https://github.com/CocoaPods/CocoaPods/issues/6268 for more info. Specifically [this](https://github.com/CocoaPods/CocoaPods/issues/6268#issuecomment-443689964) comment.