### PR TITLE
Update rexml dependency to >= 3.3.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ PATH
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.4.0)
-      rexml (>= 3.3.6, < 4.0)
+      rexml (>= 3.3.9, < 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/xcodeproj.gemspec
+++ b/xcodeproj.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'claide',         '>= 1.0.2', '< 2.0'
   s.add_runtime_dependency 'colored2',       '~> 3.1'
   s.add_runtime_dependency 'nanaimo',        '~> 0.4.0'
-  s.add_runtime_dependency 'rexml',          '>= 3.3.6', '< 4.0'
+  s.add_runtime_dependency 'rexml',          '>= 3.3.9', '< 4.0'
 
   ## Make sure you can build the gem on older versions of RubyGems too:
   s.rubygems_version = '1.6.2'


### PR DESCRIPTION
Bump the minimum required version of the rexml gem from 3.3.6 to 3.3.9 in both the gemspec and Gemfile.lock to ensure compatibility and address potential issues with older versions.