### PR TITLE
Fix crash when saving project.

### DIFF
--- a/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
@@ -54,7 +54,12 @@ module Xcodeproj
         attribute :platform_filters_by_relative_path, Hash
 
         def display_name
-          "Exceptions for \"#{GroupableHelper.parent(self).display_name}\" folder in \"#{build_phase.name}\" build phase"
+          build_phase_identifier = if build_phase.respond_to?(:name) && build_phase.name
+            build_phase.name
+          else
+            build_phase.uuid
+          end
+          "Exceptions for \"#{GroupableHelper.parent(self).display_name}\" folder in \"#{build_phase_identifier}\" build phase"
         end
       end
     end


### PR DESCRIPTION
Fixes a crash that happens when a project is saved, under the following conditions:
- That project had an build phase exception set
- That build phase exception set is the child of a build phase that does not have a name.

For example, the "Compile Sources" build phase does not have a name, and could lead to this crash if there's an exception set attached to it.

At some point during the saving of a project, The `display_name` method of the `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet` tries to use the `name` of the build phase, causing the crash.

To fix this, I added a fallback behavior, if the build phase does not have a name, the UUID is used instead.

Example stacktrace of the issue this is solving:
```
MethodError: [!] undefined method `name' for <PBXSourcesBuildPhase UUID=`8BED7DD31C39112F0001C6F1`>:Xcodeproj::Project::Object::PBXSourcesBuildPhase
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/xcodeproj-1.27.0/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb:57:in `display_name'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/xcodeproj-1.27.0/lib/xcodeproj/project/object.rb:417:in `ascii_plist_annotation'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/xcodeproj-1.27.0/lib/xcodeproj/project.rb:297:in `block in to_ascii_plist'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/xcodeproj-1.27.0/lib/xcodeproj/project.rb:296:in `each'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/xcodeproj-1.27.0/lib/xcodeproj/project.rb:296:in `to_ascii_plist'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/xcodeproj-1.27.0/lib/xcodeproj/project.rb:365:in `block in save'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/atomos-0.1.3/lib/atomos.rb:21:in `block in atomic_write'
/Users/jenkins/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tempfile.rb:291:in `open'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/atomos-0.1.3/lib/atomos.rb:17:in `atomic_write'
/Users/jenkins/.jenkins/workspace/Facetune 2 Pipelines/Repo/vendor/bundle/ruby/2.7.0/gems/xcodeproj-1.27.0/lib/xcodeproj/project.rb:364:in `save'
```