### PR TITLE
Update PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet to support PBXResourcesBuildPhase

### DIFF
--- a/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
@@ -41,9 +41,9 @@ module Xcodeproj
 
       # This class represents a file system synchronized group build phase membership exception set.
       class PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet < AbstractObject
-        # @return [PBXSourcesBuildPhase, PBXCopyFilesBuildPhase] The build phase to which this exception set applies.
+        # @return [PBXSourcesBuildPhase, PBXCopyFilesBuildPhase, PBXResourcesBuildPhase] The build phase to which this exception set applies.
         #
-        has_one :build_phase, [PBXSourcesBuildPhase, PBXCopyFilesBuildPhase]
+        has_one :build_phase, [PBXSourcesBuildPhase, PBXCopyFilesBuildPhase, PBXResourcesBuildPhase]
 
         # @return [Array<String>] The list of files in the group that are excluded from the build phase.
         #
@@ -54,7 +54,8 @@ module Xcodeproj
         attribute :platform_filters_by_relative_path, Hash
 
         def display_name
-          "Exceptions for \"#{GroupableHelper.parent(self).display_name}\" folder in \"#{build_phase.name}\" build phase"
+          phase_name = build_phase.is_a?(PBXResourcesBuildPhase) ? 'Resources' : build_phase.name
+          "Exceptions for \"#{GroupableHelper.parent(self).display_name}\" folder in \"#{phase_name}\" build phase"
         end
       end
     end


### PR DESCRIPTION
When adding a bundle (such as an .mlpackage) inside an Xcode folder to a target, the "Copy Resources" phase will have an exception like this:

```
86522D262ED065A3005F54C6 /* Exceptions for "MyFolder" folder in "Copy Bundle Resources" phase from "MyApp" target */ = {
	isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
	buildPhase = 7AA69A92145AF32700190537 /* Resources */;
	membershipExceptions = (
		MyModel.mlpackage,
	);
};
```

When attempting to read this project an error would occur:

```
[Xcodeproj] Type checking error: got `PBXResourcesBuildPhase` for attribute: Attribute `buildPhase` (type: `to_one`, classes: `["PBXSourcesBuildPhase", "PBXCopyFilesBuildPhase"]`, owner class: `PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet`) - 7AA69A92145AF32700190537 <Nanaimo::Dictionary {"isa"=>"PBXResourcesBuildPhase", "buildActionMask"=>"2147483647", "runOnlyForDeploymentPostprocessing"=>"0", "files"=>[]}>
```

Note that a PBXResourcesBuildPhase doesn't have a name, so I had to adjust the `display_name` method accordingly.

See also #986.