### PR TITLE
Introduce working CI/CD through GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -1,44 +1,4 @@
 name: Lint
-
-jobs:
-  lint:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: [2.6]
-        os: [ubuntu-20.04]
-
-    name: Lint
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Set build image var
-        run: echo "ImageVersion=$ImageVersion"  >> $GITHUB_ENV
-
-      - name: Checkout git
-        uses: actions/checkout@v1
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems@v1-${{ matrix.os }}-${{ env.ImageVersion }}-Ruby${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
-          restore-keys: |
-            gems@v1-${{ matrix.os }}-${{ env.ImageVersion }}-Ruby${{ matrix.ruby }}-
-      - name: Run bundle install
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3 --without debugging documentation
-
-      - name: Run Tests
-        run: bundle exec rake spec:all
-        env:
-          COCOAPODS_CI_TASKS: LINT
-
-
 on:
   push:
     branches:
@@ -49,3 +9,30 @@ on:
       - master
       - "*-stable"
 
+jobs:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.6]
+        os: [ubuntu-24.04]
+
+    name: Lint
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set build image var
+        run: echo "ImageVersion=$ImageVersion"  >> $GITHUB_ENV
+
+      - name: Checkout git
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run Tests
+        run: bundle exec rake spec:all
+        env:
+          COCOAPODS_CI_TASKS: LINT

--- a/.github/workflows/Lint.yml
+++ b/.github/workflows/Lint.yml
@@ -20,14 +20,9 @@ jobs:
     name: Lint
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Set build image var
-        run: echo "ImageVersion=$ImageVersion"  >> $GITHUB_ENV
+      - uses: actions/checkout@v6
 
-      - name: Checkout git
-        uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
         os: [ubuntu-24.04]
         include:
           - os: macos-14

--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -14,30 +14,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
         os: [ubuntu-24.04]
         include:
           - os: macos-14
             ruby: '2.6'
+          - os: macos-26
+            ruby: '3.2'
 
     name: ${{ matrix.os }} / Ruby ${{ matrix.ruby }}
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set build image var
-        run: echo "ImageVersion=$ImageVersion"  >> $GITHUB_ENV
+      - uses: actions/checkout@v6
 
-      - name: Checkout git
-        uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-
-      - name: Update git submodules
-        run: git submodule update --init
 
       - name: Run Tests
         run: bundle exec rake spec:all

--- a/.github/workflows/Specs.yml
+++ b/.github/workflows/Specs.yml
@@ -1,53 +1,4 @@
 name: Specs
-
-jobs:
-  specs:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ['2.7', '3.0']
-        os: [ubuntu-20.04]
-        include:
-          - os: macos-12
-            ruby: system
-
-    name: ${{ matrix.os }} / Ruby ${{ matrix.ruby }}
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Set build image var
-        run: echo "ImageVersion=$ImageVersion"  >> $GITHUB_ENV
-
-      - name: Checkout git
-        uses: actions/checkout@v1
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        if: ${{ matrix.ruby != 'system' }}
-        with:
-          ruby-version: ${{ matrix.ruby }}
-
-      - name: Update git submodules
-        run: git submodule update --init
-
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems@v1-${{ matrix.os }}-${{ env.ImageVersion }}-Ruby${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
-          restore-keys: |
-            gems@v1-${{ matrix.os }}-${{ env.ImageVersion }}-Ruby${{ matrix.ruby }}-
-
-      - name: Run bundle install
-        run: |
-          gem install bundler -v "~> 1.17"
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3 --without debugging documentation
-
-      - name: Run Tests
-        run: bundle exec rake spec:all
-        env:
-          COCOAPODS_CI_TASKS: SPEC
-
 on:
   push:
     branches:
@@ -58,3 +9,37 @@ on:
       - master
       - "*-stable"
 
+jobs:
+  specs:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.7', '3.0']
+        os: [ubuntu-24.04]
+        include:
+          - os: macos-14
+            ruby: '2.6'
+
+    name: ${{ matrix.os }} / Ruby ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Set build image var
+        run: echo "ImageVersion=$ImageVersion"  >> $GITHUB_ENV
+
+      - name: Checkout git
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Update git submodules
+        run: git submodule update --init
+
+      - name: Run Tests
+        run: bundle exec rake spec:all
+        env:
+          COCOAPODS_CI_TASKS: SPEC

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ xcuserdata
 rakelib/doccoverage/
 coverage/
 .coveralls.yml
+.idea


### PR DESCRIPTION
## Problem
CI/CD has decayed for 2 reasons. The images are no longer supported (ubuntu-20) and the actions used (checkout-v1) are no longer supported. This means they instant fail.

## Solution
1. We introduce configuration with Dependabot to manage GitHub Actions which means each time an action releases a new major release (1-2 a year) - a PR will be delivered.
2. We rework the pipelines entirely. In 2026 `setup-ruby` is far more powerful with caching built in and more. We leverage that in order to reduce the code needed for manual gem cache creation. This turns CI pipelines into about 6 lines of code.
3. We expand testing from minimal Ruby version to as high as we can go (3.3). 3.4/4.0 require changes due to the standard gem removal.
4. We expand the Mac testing on both Mac 14 and 26 in order to get a CI run with the newer restrictive Xcode 26.

## Meta
Until my PR is approved for CI to run - you'll have no proof it works. So here is my fork and a [test PR](https://github.com/iBotPeaches/Xcodeproj/pull/1) for proof. You can see failures for Ruby 3.4 & 4.0 [here](https://github.com/iBotPeaches/Xcodeproj/actions/runs/22542732257) which I can do a follow-up PR for post merge.