### PR TITLE
Support assetTagsByRelativePath on PBXFileSystemSynchronizedBuildFileExceptionSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   [Eric Amorde](https://github.com/amorde)
   [#1041](https://github.com/CocoaPods/Xcodeproj/pull/1041)
 
+* Add support for `assetTagsByRelativePath` field on `PBXFileSystemSynchronizedBuildFileExceptionSet`.  
+  [Frederik Seiffert](https://github.com/triplef)
+  [#1035](https://github.com/CocoaPods/Xcodeproj/pull/1035)
+
+
 ##### Bug Fixes
 
 * None.  

--- a/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
+++ b/lib/xcodeproj/project/object/file_system_synchronized_exception_set.rb
@@ -26,6 +26,10 @@ module Xcodeproj
         #
         attribute :additional_compiler_flags_by_relative_path, Hash
 
+        # @return [Hash] The files with on demand resource tags.
+        #
+        attribute :asset_tags_by_relative_path, Hash
+
         # @return [Hash] The files with specific attributes.
         #
         attribute :attributes_by_relative_path, Hash

--- a/spec/project/object/file_system_synchronized_exception_set_spec.rb
+++ b/spec/project/object/file_system_synchronized_exception_set_spec.rb
@@ -1,0 +1,39 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+module ProjectSpecs
+  describe PBXFileSystemSynchronizedBuildFileExceptionSet do
+    before do
+      @exception_set = @project.new(PBXFileSystemSynchronizedBuildFileExceptionSet)
+    end
+
+    it 'supports serializing asset tags by relative path' do
+      @exception_set.asset_tags_by_relative_path = {
+        'Demo Content.localized' => ['featured-videos'],
+      }
+
+      @exception_set.to_hash['assetTagsByRelativePath'].should == {
+        'Demo Content.localized' => ['featured-videos'],
+      }
+    end
+
+    it 'supports deserializing asset tags by relative path from plist data' do
+      uuid = 'F00BA4F00BA4F00BA4F00BA4'
+      exception_set = PBXFileSystemSynchronizedBuildFileExceptionSet.new(@project, uuid)
+      objects_by_uuid_plist = {
+        uuid => {
+          'isa' => 'PBXFileSystemSynchronizedBuildFileExceptionSet',
+          'assetTagsByRelativePath' => {
+            'Demo Content.localized' => ['featured-videos'],
+          },
+        },
+      }
+
+      UI.expects(:warn).never
+      exception_set.configure_with_plist(objects_by_uuid_plist)
+
+      exception_set.asset_tags_by_relative_path.should == {
+        'Demo Content.localized' => ['featured-videos'],
+      }
+    end
+  end
+end


### PR DESCRIPTION
Add support for `assetTagsByRelativePath` on `PBXFileSystemSynchronizedBuildFileExceptionSet` objects, which is used by folder-synchronized projects for On-Demand-Resources (ODR) tags using Xcode 26.

Fixes the following warning:

```
[!] Xcodeproj doesn't know about the following attributes {"assetTagsByRelativePath" => {"Folder/my-resource" => ["my-resource"]}} for the 'PBXFileSystemSynchronizedBuildFileExceptionSet' isa.
```