### PR TITLE
Add compatibility version 70 for Xcode 26.0

### DIFF
--- a/lib/xcodeproj/constants.rb
+++ b/lib/xcodeproj/constants.rb
@@ -132,6 +132,7 @@ module Xcodeproj
     # @return [Hash] The compatibility version string for different object versions.
     #
     COMPATIBILITY_VERSION_BY_OBJECT_VERSION = {
+      70 => 'Xcode 26.0',
       77 => 'Xcode 16.0', # with project compatibility set to Xcode 16.0
       71 => 'Xcode 16.2',
       70 => 'Xcode 16.0',


### PR DESCRIPTION
Fix ArgumentError - [Xcodeproj] Unable to find compatibility version string for object version `70` error